### PR TITLE
Remove django-rest-framework

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,4 +2,3 @@
 
 # Third Party Requirements
 django==1.4.8
-djangorestframework==2.3.5

--- a/settings/base.py
+++ b/settings/base.py
@@ -120,15 +120,9 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.admin',
     'django.contrib.admindocs',
-    'rest_framework',
     'peer_grading',
     'common_grading'
 )
-
-REST_FRAMEWORK = {
-    'DEFAULT_PERMISSIONS_CLASSES': ('rest_framework.permissions.IsAdminUser',),
-    'PAGINATE_BY': 10
-}
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to


### PR DESCRIPTION
We're not aiming to have an REST API in the MVP. Can re-add when we get around to implementing it.
