### PR TITLE
Adjust types and limits for common_grading/models.py

### DIFF
--- a/common_grading/models.py
+++ b/common_grading/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 
-MAX_LENGTH = 1028
-ESSAY_BODY_MAX_LENGTH = 8192
+MAX_LENGTH = 255
+ESSAY_BODY_MAX_LENGTH = 10000
 GRADING_TYPES = (
     ('PE', 'Peer Assessment'),
 )
@@ -11,7 +11,7 @@ class Submission(models.Model):
     student_id = models.CharField(max_length=MAX_LENGTH, db_index=True)
     location_id = models.CharField(max_length=MAX_LENGTH, default="")
     course_id = models.CharField(max_length=MAX_LENGTH, default="")
-    essay_body = models.CharField(max_length=ESSAY_BODY_MAX_LENGTH, default="")
+    essay_body = models.TextField(max_length=ESSAY_BODY_MAX_LENGTH, default="")
     preferred_grading = models.CharField(max_length=2, choices=GRADING_TYPES)
     submitted_date = models.DateTimeField()
 
@@ -28,5 +28,5 @@ class Scoring(models.Model):
 
 
 class Feedback(models.Model):
-    text = models.CharField(max_length=MAX_LENGTH, default="")
+    text = models.TextField(max_length=MAX_LENGTH, default="")
     score = models.ForeignKey(Scoring)


### PR DESCRIPTION
- Reduced MAX_LENGTH to 255 for varchar fields because that's the
  largest size with which we're guaranteed to be able to make an
  index on InnoDB with UTF-8 encoded text.
- Increased ESSAY_BODY_MAX_LENGTH to 10000 in response to limits
  discussion thread.
- Changed a couple of fields to text from varchar, just in case
  we ever decide to increase the size limits on them in the future.
