### PR TITLE
Added setup.py to make packages installable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ install:
 script:
   - "python manage.py test"
   - "python manage.py harvest"
+  - "python setup.py install"

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,3 @@
+Stephen Sanchez <steve@edx.org>
+Joe Blaylock <jrbl@stanford.edu>
+Will Daly <will@edx.org>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include requirements/base.txt
+include LICENSE
+include AUTHORS
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+PACKAGES = ['common_grading', 'peer_grading']
+
+REQUIREMENTS = [
+    line.strip() for line in
+    open("requirements/base.txt").readlines()
+]
+
+setup(
+    name='edx-tim',
+    version='0.0.1',
+    author='edX',
+    url='http://github.com/edx/edx-tim',
+    description='edx-tim',
+    license='AGPL',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU Affero General Public License v3',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+    ],
+    packages=PACKAGES,
+    install_requires=REQUIREMENTS,
+)


### PR DESCRIPTION
- Created `setup.py` script, which installs packages in this repo.
  - To install locally, use `python setup.py install`.
  - To install using pip, you can specify the GitHub URL in the requirements file.  See [the edx-platform requirements](https://github.com/edx/edx-platform/blob/master/requirements/edx/github.txt) for an example.
- Created an `AUTHORS` file and included it in the installation.
- Added the installation script to the Travis test scripts, to verify that the install process succeeds.

Once packages are installed, you can import them as follows:

```
    >>> import common_grading
    >>> common_grading
    <module 'common_grading' from '/Users/will/.virtualenvs/tim/lib/python2.7/site-packages/edx_tim-0.0.1-py2.7.egg/common_grading/__init__.pyc'>
    >>> import peer_grading
    >>> peer_grading
    <module 'peer_grading' from '/Users/will/.virtualenvs/tim/lib/python2.7/site-packages/edx_tim-0.0.1-py2.7.egg/peer_grading/__init__.pyc'>
```
