### PR TITLE
Update to XBlock version that installs workbench packages.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # edX Internal Requirements
--e git+https://github.com/edx/XBlock.git@8eb2c4a02b#egg=XBlock
+git+https://github.com/edx/XBlock.git@1d228943#egg=XBlock
 
 # Third Party Requirements
 django==1.4.8

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,3 @@
-# Grab everything in test (which pulls everything in base)
 -r test.txt
 
 # Debug tools

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def is_requirement(line):
     line = line.strip()
 
     # Skip blank lines, comments, and editable installs
-    return not (line == ''  or line.startswith('#') or line.startswith('-e'))
+    return not (line == ''  or line.startswith('#') or line.startswith('-e') or line.startswith('git+'))
 
 
 REQUIREMENTS = [


### PR DESCRIPTION
Let's see if this unbreaks Travis. Note that if you've got a local XBlocks install, you'll want to `pip uninstall xblock` first. I actually had to do it twice, but that may just have been as a result of my mucking around locally with invoking setup.py in different ways. In any case, after pip tells you xblock is no longer installed, run `pip install -r base.txt`
