### PR TITLE
TIM-125: Students completing scoring see results

### DIFF
--- a/apps/openassessment/peer/api.py
+++ b/apps/openassessment/peer/api.py
@@ -140,7 +140,7 @@ def create_evaluation(
 
         # Check if the submission is finished and its Author has graded enough.
         student_item = submission.student_item
-        _check_if_finished_and_create_score(
+        _score_if_finished(
             student_item,
             submission,
             required_evaluations_for_student,
@@ -159,7 +159,7 @@ def create_evaluation(
             student_item=scorer_item
         ).order_by("-attempt_number")
 
-        _check_if_finished_and_create_score(
+        _score_if_finished(
             scorer_item,
             scorer_submissions[0],
             required_evaluations_for_student,
@@ -177,11 +177,11 @@ def create_evaluation(
         raise PeerEvaluationInternalError(error_message)
 
 
-def _check_if_finished_and_create_score(student_item,
-                                        submission,
-                                        required_evaluations_for_student,
-                                        required_evaluations_for_submission):
-    """Basic function for checking if a student is finished with peer workflow.
+def _score_if_finished(student_item,
+                       submission,
+                       required_evaluations_for_student,
+                       required_evaluations_for_submission):
+    """Calculate final grade iff peer evaluation flow is satisfied.
 
     Checks if the student is finished with the peer evaluation workflow. If the
     student already has a final grade calculated, there is no need to proceed.

--- a/apps/openassessment/xblock/static/js/src/oa_submission.js
+++ b/apps/openassessment/xblock/static/js/src/oa_submission.js
@@ -8,9 +8,9 @@ function OpenAssessmentBlock(runtime, element) {
     /* Sample Debug Console: http://localhost:8000/submissions/Joe_Bloggs/TestCourse/u_3 */
 
     function displayStatus(result) {
-        status = result[0]
-        error_msg = result[2]
-        if (status) {
+        status = result[0];
+        error_msg = result[2];
+        if (status === 'true') {
             $('.openassessment_response_status_block', element).html(success_msg.concat(click_msg)); 
         } else {
             $('.openassessment_response_status_block', element).html(failure_msg.concat(error_msg).concat(click_msg));

--- a/apps/openassessment/xblock/test/test_openassessment.py
+++ b/apps/openassessment/xblock/test/test_openassessment.py
@@ -77,13 +77,31 @@ class TestOpenAssessment(TestCase):
         return request
 
     def test_submit_submission(self):
-        """XBlock accepts response, returns true on success."""
+        """XBlock accepts response, returns true on success"""
+        # This one should pass because we haven't submitted before
         resp = self.runtime.handle(
             self.assessment, 'submit',
             self.make_request(self.default_json_submission)
         )
         result = json.loads(resp.body)
         self.assertTrue(result[0])
+
+    def test_submission_multisubmit_failure(self):
+        """XBlock returns true on first, false on second submission"""
+        # We don't care about return value of first one
+        resp = self.runtime.handle(
+            self.assessment, 'submit',
+            self.make_request(self.default_json_submission)
+        )
+        # This one should fail becaus we're not allowed to submit multiple times
+        resp = self.runtime.handle(
+            self.assessment, 'submit',
+            self.make_request(self.default_json_submission)
+        )
+        result = json.loads(resp.body)
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], "ENOMULTI")
+        self.assertEqual(result[2], self.assessment.submit_errors["ENOMULTI"])
 
     @patch.object(api, 'create_submission')
     def test_submission_general_failure(self, mock_submit):


### PR DESCRIPTION
- When a score becomes available for a student (i.e., when they have
  completed the minimum number of peer assessments and have received
  enough assessments to their submission), it is shown to the student.
- XXX: As an interim fix to not having thought through all the cases
  around multiple existing submissions, this commit disallows making
  multiple submissions.
- Refactoring of XBlock view to devolve functionality into smaller
  pieces - this is interim work until there's a better workflow layer
  (or perhaps it can be the prep for that.)
- TODO: since overgrading should be baked in, we should still show them
  their assessment page.
