### PR TITLE
Update workbench and XBlock versions to grab workbench HTML fix.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # edX Internal Requirements
-git+https://github.com/edx/XBlock.git@d38ea051#egg=XBlock
-git+https://github.com/ormsbee/xblock-sdk.git@3c092c27#egg=xblock-sdk
+git+https://github.com/edx/XBlock.git@923978c5#egg=XBlock
+git+https://github.com/ormsbee/xblock-sdk.git@295678ff#egg=xblock-sdk
 
 # Third Party Requirements
 django==1.4.8


### PR DESCRIPTION
@talbs, @stephensanchez: You need to pip install again for these to work. Doing this should work:

`pip install -r requirements/base.txt --upgrade`

The last flag to force it to reload since the declared versions didn't really change even if the git hash did.
