### PR TITLE
Add Django Debug Toolbar to default dev config.

### DIFF
--- a/settings/dev.py
+++ b/settings/dev.py
@@ -5,10 +5,14 @@ Dev-specific Django settings.
 # Inherit from base settings
 from .base import *
 
-MIDDLEWARE_CLASSES += (
-    'django_pdb.middleware.PdbMiddleware',  # Needed to enable shell-on-crash behavior
-)
-
 INSTALLED_APPS += (
     'django_pdb',            # Allows post-mortem debugging on exceptions
+    'debug_toolbar',
 )
+
+MIDDLEWARE_CLASSES += (
+    'django_pdb.middleware.PdbMiddleware',  # Needed to enable shell-on-crash behavior
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+)
+
+INTERNAL_IPS = ('127.0.0.1',)


### PR DESCRIPTION
Just enabling this. It might not actually do everything we need it to, since it doesn't fire on async JS calls. But it's nice to have around anyway. @stephensanchez , @wedaly 
