### PR TITLE
UI tweaks to save response

### DIFF
--- a/apps/openassessment/xblock/openassessmentblock.py
+++ b/apps/openassessment/xblock/openassessmentblock.py
@@ -10,7 +10,7 @@ from django.template.loader import get_template
 from webob import Response
 
 from xblock.core import XBlock
-from xblock.fields import List, Scope, String
+from xblock.fields import List, Scope, String, Boolean
 from xblock.fragment import Fragment
 from openassessment.xblock.grade_mixin import GradeMixin
 
@@ -203,6 +203,12 @@ class OpenAssessmentBlock(
         default=None,
         scope=Scope.user_state,
         help="The student's submission that others will be assessing."
+    )
+
+    has_saved = Boolean(
+        default=False,
+        scope=Scope.user_state,
+        help="Indicates whether the user has saved a response"
     )
 
     saved_response = String(

--- a/apps/openassessment/xblock/static/js/src/oa_base.js
+++ b/apps/openassessment/xblock/static/js/src/oa_base.js
@@ -177,9 +177,10 @@ OpenAssessment.BaseUI.prototype = {
         // Retrieve the student's response from the DOM
         var submission = $('#submission__answer__value', this.element).val();
         var ui = this;
+        $('#response__save_status', this.element).html('Saving...');
         this.server.save(submission).done(function() {
             // Update the "saved" icon
-            $('#response__save_status', this.element).replaceWith("Saved");
+            $('#response__save_status', this.element).html("Saved but not submitted");
         }).fail(function(errMsg) {
             // TODO: display to the user
             console.log(errMsg);

--- a/apps/openassessment/xblock/submission_mixin.py
+++ b/apps/openassessment/xblock/submission_mixin.py
@@ -87,6 +87,7 @@ class SubmissionMixin(object):
         if 'submission' in data:
             try:
                 self.saved_response = unicode(data['submission'])
+                self.has_saved = True
             except:
                 return {'success': False, 'msg': _(u"Could not save response submission")}
             else:
@@ -144,6 +145,16 @@ class SubmissionMixin(object):
             pass
         return submissions[0] if submissions else None
 
+    @property
+    def save_status(self):
+        """
+        Return a string indicating whether the response has been saved.
+
+        Returns:
+            unicode
+        """
+        return _(u'Saved but not submitted') if self.has_saved else _(u'Not saved')
+
     @XBlock.handler
     def render_submission(self, data, suffix=''):
         """Renders the Submission HTML section of the XBlock
@@ -178,7 +189,7 @@ class SubmissionMixin(object):
             "student_score": student_score,
             "step_status": step_status,
             "saved_response": self.saved_response,
-            "save_status": _('Saved but not submitted') if len(self.saved_response) > 0 else _("Not saved"),
+            "save_status": self.save_status
         }
 
         path = "openassessmentblock/response/oa_response.html"

--- a/apps/openassessment/xblock/test/test_save_response.py
+++ b/apps/openassessment/xblock/test/test_save_response.py
@@ -14,6 +14,7 @@ class SaveResponseTest(XBlockHandlerTestCase):
     def test_default_saved_response_blank(self, xblock):
         resp = self.request(xblock, 'render_submission', json.dumps({}))
         self.assertIn('<textarea id="submission__answer__value" placeholder=""></textarea>', resp)
+        self.assertIn('<div id="response__save_status">Not saved</div>', resp)
 
     @ddt.file_data('data/save_responses.json')
     @scenario('data/save_scenario.xml', user_id="Perleman")
@@ -31,6 +32,7 @@ class SaveResponseTest(XBlockHandlerTestCase):
             submitted=submission_text
         )
         self.assertIn(expected_html, resp.decode('utf-8'))
+        self.assertIn('<div id="response__save_status">Saved but not submitted</div>', resp)
 
     @scenario('data/save_scenario.xml', user_id="Valchek")
     def test_overwrite_saved_response(self, xblock):


### PR DESCRIPTION
Make "saving" text consistent between client and server code.
Fix a bug in which saving a blank response would continue to show "Not saved"
Insert the saving status into the div instead of replacing it.
Display a "saving..." message while waiting for a response from the server.
