### PR TITLE
Log submission errors

### DIFF
--- a/apps/openassessment/xblock/submission_mixin.py
+++ b/apps/openassessment/xblock/submission_mixin.py
@@ -1,8 +1,12 @@
+import logging
 from xblock.core import XBlock
 from django.utils.translation import ugettext as _
 from submissions import api
 from openassessment.assessment import peer_api
 from openassessment.workflow import api as workflow_api
+
+
+logger = logging.getLogger(__name__)
 
 
 class SubmissionMixin(object):
@@ -60,6 +64,7 @@ class SubmissionMixin(object):
                 status_tag = 'EBADFORM'
                 status_text = unicode(err.field_errors)
             except (api.SubmissionError, workflow_api.AssessmentWorkflowError):
+                logger.exception("Error occurred while submitting.")
                 status_tag = 'EUNKNOWN'
             else:
                 status = True


### PR DESCRIPTION
It took me longer than necessary to figure out that I hadn't run syncdb and was getting a database error.  It's possible this will lead to duplicate exceptions in the logs if the APIs are themselves logging exceptions, but I figure over-reporting is less harmful than under-reporting.  Thoughts?
