### PR TITLE
Fixing peer assessment for required grading of 1

### DIFF
--- a/apps/openassessment/assessment/peer_api.py
+++ b/apps/openassessment/assessment/peer_api.py
@@ -646,7 +646,7 @@ def _get_submission_for_review(workflow, graded_by, over_grading=False):
         "1"
 
     """
-    order = " having count(1) < %s order by pw.created_at, pw.id "
+    order = " having count(pwi.id) < %s order by pw.created_at, pw.id "
     timeout = (datetime.utcnow().replace(tzinfo=UTC) - TIME_LIMIT).strftime("%Y-%m-%d %H:%M:%S")
     sub = _get_next_submission(
         order,
@@ -710,7 +710,7 @@ def _get_next_submission(order, workflow, *args):
     and pw.submission_uuid<>'cdd6cf7a-2787-43ec-8d31-62fdb14d4e09'
     and pw.submission_uuid<>'ebc7d4e1-1577-4443-ab58-2caad9a10837'
     and (pwi.scorer_id_id is NULL or pwi.assessment<>-1 or pwi.started_at > '2014-03-04 20:09:04')
-    group by pw.submission_uuid having count(1) < 3
+    group by pw.submission_uuid having count(pwi.id) < 3
     order by pw.created_at, pw.id
     limit 1;
 

--- a/apps/openassessment/assessment/test/test_peer.py
+++ b/apps/openassessment/assessment/test/test_peer.py
@@ -114,7 +114,7 @@ class TestPeerApi(TestCase):
     def test_create_assessment(self):
         self._create_student_and_submission("Tim", "Tim's answer")
         bob_sub, bob = self._create_student_and_submission("Bob", "Bob's answer")
-        sub = peer_api.get_submission_to_assess(bob, 3)
+        sub = peer_api.get_submission_to_assess(bob, 1)
         assessment = peer_api.create_assessment(
             sub["uuid"],
             bob["student_id"],

--- a/apps/openassessment/xblock/static/xml/poverty_rubric_example.xml
+++ b/apps/openassessment/xblock/static/xml/poverty_rubric_example.xml
@@ -107,8 +107,8 @@
         <assessment name="peer-assessment"
                     start="2014-12-20T19:00-7:00"
                     due="2014-12-21T22:22-7:00"
-                    must_grade="5"
-                    must_be_graded_by="3" />
+                    must_grade="1"
+                    must_be_graded_by="1" />
         <assessment name="self-assessment" />
     </assessments>
 </openassessment>


### PR DESCRIPTION
Fixing a defect where the SQL query for getting a submission for peer assessment fails when the required number of assessments is set to 1. Updated a simple test to validate this as well.

Note: reverted the change on the rubric xml; that should have shown up, but still here for some reason. 
