### PR TITLE
Accept numeric xblock trace values

### DIFF
--- a/apps/openassessment/xblock/openassessmentblock.py
+++ b/apps/openassessment/xblock/openassessmentblock.py
@@ -242,7 +242,7 @@ class OpenAssessmentBlock(
         Useful for logging, debugging, and uniqueification.
 
         """
-        return self.scope_ids.usage_id, self.scope_ids.user_id
+        return unicode(self.scope_ids.usage_id), unicode(self.scope_ids.user_id)
 
     def get_student_item_dict(self):
         """Create a student_item_dict from our surrounding context.

--- a/apps/openassessment/xblock/test/test_openassessment.py
+++ b/apps/openassessment/xblock/test/test_openassessment.py
@@ -100,6 +100,14 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         student_view = xblock.student_view({})
         self.assertIsNotNone(student_view)
 
+    @scenario('data/basic_scenario.xml', user_id=2)
+    def test_numeric_scope_ids(self, xblock):
+        # Even if we're passed a numeric user ID, we should store it as a string
+        # because that's what our models expect.
+        student_item = xblock.get_student_item_dict()
+        self.assertEqual(student_item['student_id'], '2')
+        self.assertIsInstance(student_item['item_id'], unicode)
+
 
 class TestDates(XBlockHandlerTestCase):
 


### PR DESCRIPTION
Self-assessment was failing in the LMS on the check between student_id:
(a) the student item model was storing it as a charfield
(b) the XBlock was storing it as an integer
This would cause the comparison to fail, resulting in a server-side error.

Since we're storing the student and item IDs as strings in the student item model, it makes sense to convert them as soon as we retrieve them from the XBlock scope ids.
