### PR TITLE
Send errors to the DOM

### DIFF
--- a/apps/openassessment/xblock/static/js/src/oa_base.js
+++ b/apps/openassessment/xblock/static/js/src/oa_base.js
@@ -92,8 +92,7 @@ OpenAssessment.BaseUI.prototype = {
                 );
             }
         ).fail(function(errMsg) {
-            // TODO: display to the user
-            console.log(errMsg);
+            ui.showError('load', errMsg);
         });
     },
 
@@ -134,8 +133,7 @@ OpenAssessment.BaseUI.prototype = {
                 );
             }
         ).fail(function(errMsg) {
-            // TODO: display to the user
-            console.log(errMsg);
+            ui.showError('load', errMsg);
         });
     },
 
@@ -174,8 +172,7 @@ OpenAssessment.BaseUI.prototype = {
                 );
             }
         ).fail(function(errMsg) {
-            // TODO: display to the user
-            console.log(errMsg);
+            ui.showError('load', errMsg);
         });
     },
 
@@ -192,8 +189,7 @@ OpenAssessment.BaseUI.prototype = {
                 $('#openassessment__grade', ui.element).replaceWith(html);
             }
         ).fail(function(errMsg) {
-            // TODO: display to the user
-            console.log(errMsg);
+            ui.showError('load', errMsg);
         });
     },
 
@@ -209,8 +205,7 @@ OpenAssessment.BaseUI.prototype = {
             // Update the "saved" icon
             $('#response__save_status', this.element).html("Saved but not submitted");
         }).fail(function(errMsg) {
-            // TODO: display to the user
-            console.log(errMsg);
+            ui.showError('response', errMsg);
         });
 
     },
@@ -229,8 +224,7 @@ OpenAssessment.BaseUI.prototype = {
                 ui.renderPeerAssessmentStep(true);
             }
         ).fail(function(errCode, errMsg) {
-            // TODO: display to the user in a classier way
-            alert(errMsg);
+            ui.showError('response', errMsg);
         });
     },
 
@@ -259,8 +253,7 @@ OpenAssessment.BaseUI.prototype = {
                 ui.renderGradeStep(false);
             }
         ).fail(function(errMsg) {
-            // TODO: display to the user
-            console.log(errMsg);
+            ui.showError('peer', errMsg);
         });
     },
 
@@ -287,9 +280,32 @@ OpenAssessment.BaseUI.prototype = {
                 ui.renderGradeStep(true);
             }
         ).fail(function(errMsg) {
-            // TODO: display to user
-            console.log(errMsg);
+            ui.showError('self', errMsg);
         });
+    },
+
+
+    /**
+    Report an error to the user.
+
+    Args:
+        type (str): Which type of error.  Options are "load", "response", "peer", and "self".
+        msg (str): The error message to display.
+    **/
+    showError: function(type, msg) {
+        var container = null;
+        if (type == 'response') { container = '.step__actions'; }
+        else if (type == 'peer') { container = '.peer-assessment__actions'; }
+        else if (type == 'self') { container = '.self-assessment__actions'; }
+
+        // If we don't have anywhere to put the message, just log it to the console
+        if (container === null) {
+            console.log(msg);
+        }
+        else {
+            var sel = container + " .message__content";
+            $(sel).text(msg);
+        }
     }
 };
 


### PR DESCRIPTION
@talbs Not fully baked yet, but a starting point.  This just dumps error messages into one of the three error containers you created (response, peer, or self).  Load errors are still sent to the console for now.
