### PR TITLE
Fixing the count problem on peer api, completed assessments.

### DIFF
--- a/apps/openassessment/assessment/models.py
+++ b/apps/openassessment/assessment/models.py
@@ -417,6 +417,10 @@ class PeerWorkflowItem(models.Model):
     associated workflow represents the scorer of the given submission, and the
     assessment represents the completed assessment for this work item.
 
+    Assessments are represented as their ID, defaulting to -1. This is done to
+    optimized complex queries against PeerWorkflowItems with the Assessments
+    indexed, whereas a Null reference would be costly.
+
     """
     scorer_id = models.ForeignKey(PeerWorkflow, related_name='items')
     submission_uuid = models.CharField(max_length=128, db_index=True)

--- a/apps/openassessment/assessment/peer_api.py
+++ b/apps/openassessment/assessment/peer_api.py
@@ -332,7 +332,7 @@ def has_finished_required_evaluating(student_item_dict, required_assessments):
     count = 0
     if workflow:
         done = _check_student_done_grading(workflow, required_assessments)
-        count = workflow.items.all().count()
+        count = workflow.items.all().exclude(assessment=-1).count()
     return done, count
 
 

--- a/apps/openassessment/assessment/test/test_peer.py
+++ b/apps/openassessment/assessment/test/test_peer.py
@@ -155,6 +155,25 @@ class TestPeerApi(TestCase):
         self.assertEqual(1, len(assessments))
         self.assertEqual(assessments[0]["scored_at"], MONDAY)
 
+    def test_has_finished_evaluation(self):
+        """
+        Verify unfinished assessments do not get counted when determining a
+        complete workflow.
+        """
+        tim_sub, tim = self._create_student_and_submission("Tim", "Tim's answer")
+        bob_sub, bob = self._create_student_and_submission("Bob", "Bob's answer")
+        sub = peer_api.get_submission_to_assess(bob, REQUIRED_GRADED)
+        self.assertEqual(sub["uuid"], tim_sub["uuid"])
+        finished, count = peer_api.has_finished_required_evaluating(bob, 1)
+        self.assertFalse(finished)
+        self.assertEqual(count, 0)
+        peer_api.create_assessment(
+            sub["uuid"], bob["student_id"], ASSESSMENT_DICT, RUBRIC_DICT
+        )
+        finished, count = peer_api.has_finished_required_evaluating(bob, 1)
+        self.assertTrue(finished)
+        self.assertEqual(count, 1)
+
     def test_peer_assessment_workflow(self):
         tim_sub, tim = self._create_student_and_submission("Tim", "Tim's answer")
         bob_sub, bob = self._create_student_and_submission("Bob", "Bob's answer")


### PR DESCRIPTION
Problem existed where you could:
1) Go in as Bob
2) Create submission
3) Go in as Tim
4) Create submission
5) Get Bob's submission for evaluation
6) Switch to Tim
7) Switch back to Bob
Even if you did not assess Tim (as Bob) the "completed" is "1 of 3". 

Now filtering the unfinished assessments. 

@wedaly @ormsbee @jrbl 
