### PR TITLE
Rename openassessment to peer_assessment 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
 
     entry_points={
         'xblock.v1': [
-            'openassessment = openassessment.xblock.openassessmentblock:OpenAssessmentBlock',
+            'peer_assessment = openassessment.xblock.openassessmentblock:OpenAssessmentBlock',
         ]
     },
     package_data=package_data("openassessment.xblock", "static"),


### PR DESCRIPTION
So it shows up as peer assessment in the Studio UI.
Per discussion this morning with @Lyla-Fischer and @stephensanchez 

Once this gets merged, I'll update the lms integration branch.
