### PR TITLE
Add display name for Studio Advanced Component menu

### DIFF
--- a/apps/openassessment/xblock/lms_mixin.py
+++ b/apps/openassessment/xblock/lms_mixin.py
@@ -1,8 +1,31 @@
-from xblock.core import XBlock
-from xblock.fields import Float, Scope
+"""
+Fields and methods used by the LMS and Studio.
+"""
+
+from xblock.fields import String, Float, Scope, DateTime
+
 
 class LmsCompatibilityMixin(object):
-    """Extra methods we tack on because the LMS expects them for grading."""
+    """
+    Extra fields and methods used by LMS/Studio.
+    """
+    # Studio the default value for this field to show this XBlock
+    # in the list of "Advanced Components"
+    display_name = String(
+        default="Peer Assessment", scope=Scope.settings,
+        help="Display name"
+    )
+
+    start = DateTime(
+        default=None, scope=Scope.settings,
+        help="ISO-8601 formatted string representing the start date of this assignment."
+    )
+
+    due = DateTime(
+        default=None, scope=Scope.settings,
+        help="ISO-8601 formatted string representing the due date of this assignment."
+    )
+
     weight = Float(
         display_name="Problem Weight",
         help=("Defines the number of points each problem is worth. "

--- a/apps/openassessment/xblock/openassessmentblock.py
+++ b/apps/openassessment/xblock/openassessmentblock.py
@@ -12,7 +12,7 @@ from django.template.loader import get_template
 from webob import Response
 
 from xblock.core import XBlock
-from xblock.fields import DateTime, List, Scope, String, Boolean
+from xblock.fields import List, Scope, String, Boolean
 from xblock.fragment import Fragment
 from openassessment.xblock.grade_mixin import GradeMixin
 
@@ -170,16 +170,6 @@ class OpenAssessmentBlock(
     WorkflowMixin,
     LmsCompatibilityMixin):
     """Displays a question and gives an area where students can compose a response."""
-
-    start = DateTime(
-        default=None, scope=Scope.settings,
-        help="ISO-8601 formatted string representing the start date of this assignment."
-    )
-
-    due = DateTime(
-        default=None, scope=Scope.settings,
-        help="ISO-8601 formatted string representing the due date of this assignment."
-    )
 
     submission_due = String(
         default=None, scope=Scope.settings,


### PR DESCRIPTION
Studio uses the `display_name` field default for the list of "Advanced Components".

![image](https://f.cloud.github.com/assets/2948394/2432827/2051eeb4-ad76-11e3-8a1b-0ed4e9474dc7.png)

This field is also used by the LMS for the "tool tip" in the horizontal nav:
![image](https://f.cloud.github.com/assets/2948394/2432839/c1c52d74-ad76-11e3-8166-49755c2eb26b.png)

I'm not sure whether `display_name` should be configurable from the XML or not, but this at least uses the correct terminology in the Advanced Components menu.
