### PR TITLE
Fix integrity error on submission under repeatable-read mode.

### DIFF
--- a/apps/openassessment/workflow/api.py
+++ b/apps/openassessment/workflow/api.py
@@ -7,7 +7,7 @@ import logging
 
 from django.db import DatabaseError
 
-
+from openassessment.assessment import peer_api
 from submissions import api as sub_api
 from .models import AssessmentWorkflow
 from .serializers import AssessmentWorkflowSerializer
@@ -118,11 +118,12 @@ def create_workflow(submission_uuid):
     # we're getting from the outside is the submission_uuid, which is already
     # validated by this point.
     try:
+        peer_api.create_peer_workflow(submission_uuid)
         workflow = AssessmentWorkflow.objects.create(
             submission_uuid=submission_uuid,
             status=AssessmentWorkflow.STATUS.peer
         )
-    except DatabaseError as err:
+    except (DatabaseError, peer_api.PeerAssessmentError) as err:
         err_msg = u"Could not create assessment workflow: {}".format(err)
         logger.exception(err_msg)
         raise AssessmentWorkflowInternalError(err_msg)

--- a/apps/openassessment/workflow/models.py
+++ b/apps/openassessment/workflow/models.py
@@ -122,7 +122,6 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
         else:
             # Default starting status is peer
             new_status = self.STATUS.peer
-            peer_api.create_peer_workflow(self.submission_uuid)
 
         # If we're at least waiting, let's check if we have a peer score and
         # can move all the way to done


### PR DESCRIPTION
@wedaly, @stephensanchez: (sigh) hours of env set up today for fifteen minutes of bug squashing.

Shift the creation of the peer workflow to happen when overall
workflow is created, instead of implicitly creating it if it
doesn't exist while checking for workflow status. The problem was
that the read check happens in multiple places and AJAX requests
were hitting it at the same time. Because repeatable-read mode
prevents them from seeing each others work, a couple of threads
would find that the peer workflow did not exist and would try to
create it. This cause integrity errors because those constraints
are enforced, even if those rows aren't available to other
processes.

This should have been fixed no matter what, but it's important to
note that Django should never be run under MySQL's default
repeatable-read mode. Use read-committed. For legacy reasons,
edX's own servers are misconfigured in this respect.

[TIM-262]
