### PR TITLE
Enable django-debug-toolbar to help with AJAX requests.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,8 @@
 
 # Debug tools
 bpython==0.12
-django-debug-toolbar==0.11.0
+django-debug-panel==0.8.0
+django-debug-toolbar==1.0.1
 django-pdb==0.3.2
 sqlparse==0.1.10
 

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -7,12 +7,29 @@ from .base import *
 
 INSTALLED_APPS += (
     'django_pdb',            # Allows post-mortem debugging on exceptions
+    'debug_panel',
     'debug_toolbar',
 )
 
 MIDDLEWARE_CLASSES += (
     'django_pdb.middleware.PdbMiddleware',  # Needed to enable shell-on-crash behavior
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
+    'debug_panel.middleware.DebugPanelMiddleware',
 )
 
 INTERNAL_IPS = ('127.0.0.1',)
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'debug-panel',
+    },
+
+    # this cache backend will be used by django-debug-panel
+    'debug-panel': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'debug-panel',
+        'OPTIONS': {
+            'MAX_ENTRIES': 200
+        }
+    }
+}


### PR DESCRIPTION
Requires installation of Chrome extension:
https://chrome.google.com/webstore/detail/django-debug-panel/nbiajhhibgfgkjegbnflpdccejocmbbn

@wedaly, @stephensanchez: This slows down rendering a bit, but gives really nice debug toolbar info on all your ajax requests.
