### PR TITLE
Setting additional metadata for completing a peer workflow

### DIFF
--- a/apps/openassessment/assessment/migrations/0004_auto__add_field_peerworkflow_completed_at__add_field_peerworkflowitem_.py
+++ b/apps/openassessment/assessment/migrations/0004_auto__add_field_peerworkflow_completed_at__add_field_peerworkflowitem_.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'PeerWorkflow.completed_at'
+        db.add_column('assessment_peerworkflow', 'completed_at',
+                      self.gf('django.db.models.fields.DateTimeField')(null=True),
+                      keep_default=False)
+
+        # Adding field 'PeerWorkflowItem.scored'
+        db.add_column('assessment_peerworkflowitem', 'scored',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'PeerWorkflow.completed_at'
+        db.delete_column('assessment_peerworkflow', 'completed_at')
+
+        # Deleting field 'PeerWorkflowItem.scored'
+        db.delete_column('assessment_peerworkflowitem', 'scored')
+
+
+    models = {
+        'assessment.assessment': {
+            'Meta': {'ordering': "['-scored_at', '-id']", 'object_name': 'Assessment'},
+            'feedback': ('django.db.models.fields.TextField', [], {'default': "''", 'max_length': '10000', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'rubric': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['assessment.Rubric']"}),
+            'score_type': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'scored_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'scorer_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'submission_uuid': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'})
+        },
+        'assessment.assessmentfeedback': {
+            'Meta': {'object_name': 'AssessmentFeedback'},
+            'assessments': ('django.db.models.fields.related.ManyToManyField', [], {'default': 'None', 'related_name': "'assessment_feedback'", 'symmetrical': 'False', 'to': "orm['assessment.Assessment']"}),
+            'feedback': ('django.db.models.fields.TextField', [], {'default': "''", 'max_length': '10000'}),
+            'helpfulness': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'submission_uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128', 'db_index': 'True'})
+        },
+        'assessment.assessmentpart': {
+            'Meta': {'object_name': 'AssessmentPart'},
+            'assessment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'parts'", 'to': "orm['assessment.Assessment']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'option': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['assessment.CriterionOption']"})
+        },
+        'assessment.criterion': {
+            'Meta': {'ordering': "['rubric', 'order_num']", 'object_name': 'Criterion'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'order_num': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'prompt': ('django.db.models.fields.TextField', [], {'max_length': '10000'}),
+            'rubric': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'criteria'", 'to': "orm['assessment.Rubric']"})
+        },
+        'assessment.criterionoption': {
+            'Meta': {'ordering': "['criterion', 'order_num']", 'object_name': 'CriterionOption'},
+            'criterion': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'options'", 'to': "orm['assessment.Criterion']"}),
+            'explanation': ('django.db.models.fields.TextField', [], {'max_length': '10000', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'order_num': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'points': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        'assessment.peerworkflow': {
+            'Meta': {'ordering': "['created_at', 'id']", 'object_name': 'PeerWorkflow'},
+            'completed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'student_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'submission_uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128', 'db_index': 'True'})
+        },
+        'assessment.peerworkflowitem': {
+            'Meta': {'ordering': "['started_at', 'id']", 'object_name': 'PeerWorkflowItem'},
+            'assessment': ('django.db.models.fields.IntegerField', [], {'default': '-1'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'scored': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'scorer_id': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'items'", 'to': "orm['assessment.PeerWorkflow']"}),
+            'started_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'submission_uuid': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'})
+        },
+        'assessment.rubric': {
+            'Meta': {'object_name': 'Rubric'},
+            'content_hash': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        }
+    }
+
+    complete_apps = ['assessment']

--- a/apps/openassessment/assessment/self_api.py
+++ b/apps/openassessment/assessment/self_api.py
@@ -92,35 +92,22 @@ def create_assessment(submission_uuid, user_id, options_selected, rubric_dict, s
     return serializer.data
 
 
-def get_submission_and_assessment(submission_uuid):
+def get_assessment(submission_uuid):
     """
-    Retrieve a submission and self-assessment for a student item.
+    Retrieve a self-assessment for a submission_uuid.
 
     Args:
-        submission_uuid (str): The submission uuid for we want information for
+        submission_uuid (str): The submission UUID for we want information for
             regarding self assessment.
 
     Returns:
-        A tuple `(submission, assessment)` where:
-            submission (dict) is a serialized Submission model, or None (if the user has not yet made a submission)
-            assessment (dict) is a serialized Assessment model, or None (if the user has not yet self-assessed)
-
+        assessment (dict) is a serialized Assessment model, or None (if the user has not yet self-assessed)
         If multiple submissions or self-assessments are found, returns the most recent one.
 
     Raises:
-        SelfAssessmentRequestError: Student item dict was invalid.
+        SelfAssessmentRequestError: submission_uuid was invalid.
     """
-    # Look up the most recent submission from the student item
-    try:
-        submission = get_submission(submission_uuid)
-        if not submission:
-            return (None, None)
-    except SubmissionNotFoundError:
-        return (None, None)
-    except SubmissionRequestError:
-        raise SelfAssessmentRequestError(_('Could not retrieve submission'))
-
-    # Retrieve assessments for the submission
+    # Retrieve assessments for the submission UUID
     # We weakly enforce that number of self-assessments per submission is <= 1,
     # but not at the database level.  Someone could take advantage of the race condition
     # between checking the number of self-assessments and creating a new self-assessment.
@@ -131,9 +118,8 @@ def get_submission_and_assessment(submission_uuid):
 
     if assessments.exists():
         assessment_dict = full_assessment_dict(assessments[0])
-        return submission, assessment_dict
-    else:
-        return submission, None
+        return assessment_dict
+    return None
 
 
 def is_complete(submission_uuid):

--- a/apps/openassessment/assessment/test/test_self.py
+++ b/apps/openassessment/assessment/test/test_self.py
@@ -9,8 +9,7 @@ import pytz
 from django.test import TestCase
 from submissions.api import create_submission
 from openassessment.assessment.self_api import (
-    create_assessment, get_submission_and_assessment, is_complete,
-    SelfAssessmentRequestError
+    create_assessment, is_complete, SelfAssessmentRequestError, get_assessment
 )
 
 
@@ -53,16 +52,13 @@ class TestSelfApi(TestCase):
 
     def test_create_assessment(self):
         # Initially, there should be no submission or self assessment
-        self.assertEqual(get_submission_and_assessment("5"), (None, None))
+        self.assertEqual(get_assessment("5"), None)
 
         # Create a submission to self-assess
         submission = create_submission(self.STUDENT_ITEM, "Test answer")
 
         # Now there should be a submission, but no self-assessment
-        received_submission, assessment = get_submission_and_assessment(
-            submission["uuid"]
-        )
-        self.assertItemsEqual(received_submission, submission)
+        assessment = get_assessment(submission["uuid"])
         self.assertIs(assessment, None)
         self.assertFalse(is_complete(submission['uuid']))
 
@@ -77,10 +73,7 @@ class TestSelfApi(TestCase):
         self.assertTrue(is_complete(submission['uuid']))
 
         # Retrieve the self-assessment
-        received_submission, retrieved = get_submission_and_assessment(
-            submission["uuid"]
-        )
-        self.assertItemsEqual(received_submission, submission)
+        retrieved = get_assessment(submission["uuid"])
 
         # Check that the assessment we created matches the assessment we retrieved
         # and that both have the correct values
@@ -175,7 +168,7 @@ class TestSelfApi(TestCase):
         )
 
         # Retrieve the self-assessment
-        _, retrieved = get_submission_and_assessment(submission["uuid"])
+        retrieved = get_assessment(submission["uuid"])
 
         # Expect that both the created and retrieved assessments have the same
         # timestamp, and it's >= our recorded time.
@@ -200,7 +193,7 @@ class TestSelfApi(TestCase):
             )
 
         # Expect that we still have the original assessment
-        _, retrieved = get_submission_and_assessment(submission["uuid"])
+        retrieved = get_assessment(submission["uuid"])
         self.assertItemsEqual(assessment, retrieved)
 
     def test_is_complete_no_submission(self):

--- a/apps/openassessment/management/tests/test_create_oa_submissions.py
+++ b/apps/openassessment/management/tests/test_create_oa_submissions.py
@@ -29,20 +29,17 @@ class CreateSubmissionsTest(TestCase):
             self.assertGreater(len(submissions[0]['answer']), 0)
 
             # Check that peer and self assessments were created
-            assessments = peer_api.get_assessments(submissions[0]['uuid'])
+            assessments = peer_api.get_assessments(submissions[0]['uuid'], scored_only=False)
 
             # Verify that the assessments exist and have content
-            # TODO: currently peer_api.get_assessments() returns both peer- and self-assessments
-            # When this call gets split, we'll need to update the test
-            self.assertEqual(len(assessments), cmd.NUM_PEER_ASSESSMENTS + 1)
+            self.assertEqual(len(assessments), cmd.NUM_PEER_ASSESSMENTS)
 
             for assessment in assessments:
                 self.assertGreater(assessment['points_possible'], 0)
 
             # Check that a self-assessment was created
-            submission, assessment = self_api.get_submission_and_assessment(submissions[0]['uuid'])
+            assessment = self_api.get_assessment(submissions[0]['uuid'])
 
             # Verify that the assessment exists and has content
-            self.assertIsNot(submission, None)
             self.assertIsNot(assessment, None)
             self.assertGreater(assessment['points_possible'], 0)

--- a/apps/openassessment/xblock/self_assessment_mixin.py
+++ b/apps/openassessment/xblock/self_assessment_mixin.py
@@ -3,7 +3,7 @@ from django.utils.translation import ugettext as _
 
 from xblock.core import XBlock
 from openassessment.assessment import self_api
-
+from submissions import api as submission_api
 
 logger = logging.getLogger(__name__)
 
@@ -29,10 +29,11 @@ class SelfAssessmentMixin(object):
         if not workflow:
             return self.render_assessment(path, context)
         try:
-            submission, assessment = self_api.get_submission_and_assessment(
+            submission = submission_api.get_submission(self.submission_uuid)
+            assessment = self_api.get_assessment(
                 workflow["submission_uuid"]
             )
-        except self_api.SelfAssessmentRequestError:
+        except (submission_api.SubmissionError, self_api.SelfAssessmentRequestError):
             logger.exception(
                 u"Could not retrieve self assessment for submission {}"
                 .format(workflow["submission_uuid"])

--- a/apps/openassessment/xblock/test/test_peer.py
+++ b/apps/openassessment/xblock/test/test_peer.py
@@ -7,7 +7,6 @@ from collections import namedtuple
 import copy
 import json
 from openassessment.assessment import peer_api
-from submissions import api as submission_api
 from .base import XBlockHandlerTestCase, scenario
 
 
@@ -97,7 +96,7 @@ class TestPeerAssessment(XBlockHandlerTestCase):
         self.assertTrue(resp['success'])
 
         # Retrieve the assessment and check that it matches what we sent
-        actual = peer_api.get_assessments(submission['uuid'])
+        actual = peer_api.get_assessments(submission['uuid'], scored_only=False)
         self.assertEqual(len(actual), 1)
         self.assertEqual(actual[0]['submission_uuid'], assessment['submission_uuid'])
         self.assertEqual(actual[0]['points_earned'], 5)

--- a/apps/openassessment/xblock/test/test_self.py
+++ b/apps/openassessment/xblock/test/test_self.py
@@ -35,7 +35,7 @@ class TestSelfAssessment(XBlockHandlerTestCase):
         self.assertTrue(resp['success'])
 
         # Expect that a self-assessment was created
-        _, assessment = self_api.get_submission_and_assessment(submission["uuid"])
+        assessment = self_api.get_assessment(submission["uuid"])
         self.assertEqual(assessment['submission_uuid'], submission['uuid'])
         self.assertEqual(assessment['points_earned'], 5)
         self.assertEqual(assessment['points_possible'], 6)
@@ -117,7 +117,7 @@ class TestSelfAssessment(XBlockHandlerTestCase):
         # Simulate an error and expect a failure response
         with mock.patch('openassessment.xblock.self_assessment_mixin.self_api') as mock_api:
             mock_api.SelfAssessmentRequestError = self_api.SelfAssessmentRequestError
-            mock_api.get_submission_and_assessment.side_effect = self_api.SelfAssessmentRequestError
+            mock_api.get_assessment.side_effect = self_api.SelfAssessmentRequestError
             resp = self.request(xblock, 'render_self_assessment', json.dumps(dict()))
         self.assertIn("error", resp.lower())
 


### PR DESCRIPTION
Completes TIM-227 by making a set of peer workflow items declared as "scored", so we always know which assessments were used to generated a peer workflow score. 

Includes migration
Includes splitting up API calls in self and peer to obtain assessments.
Tests updated.

Added Serializers for PeerWorkflow, PeerWorkflowItem, which I did not end up needing, but intend to use later. I can pull this out into a separate PR if needed. 

@ormsbee @wedaly 
