### PR TITLE
Make django-debug-toolbar >= 1.0 work properly with syncdb and admin.

### DIFF
--- a/settings/dev.py
+++ b/settings/dev.py
@@ -1,14 +1,13 @@
 """
 Dev-specific Django settings.
 """
-
 # Inherit from base settings
 from .base import *
 
 INSTALLED_APPS += (
     'django_pdb',            # Allows post-mortem debugging on exceptions
-    'debug_panel',
     'debug_toolbar',
+    'debug_panel',
 )
 
 MIDDLEWARE_CLASSES += (
@@ -16,20 +15,9 @@ MIDDLEWARE_CLASSES += (
     'debug_panel.middleware.DebugPanelMiddleware',
 )
 
+# We need to use explicit discovery or we'll have problems with syncdb and
+# displaying the admin site. See:
+# http://django-debug-toolbar.readthedocs.org/en/1.0/installation.html#explicit-setup
+DEBUG_TOOLBAR_PATCH_SETTINGS = False
+
 INTERNAL_IPS = ('127.0.0.1',)
-
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'debug-panel',
-    },
-
-    # this cache backend will be used by django-debug-panel
-    'debug-panel': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'debug-panel',
-        'OPTIONS': {
-            'MAX_ENTRIES': 200
-        }
-    }
-}

--- a/urls.py
+++ b/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.conf.urls import include, patterns, url
 from django.contrib import admin
 
@@ -21,3 +22,13 @@ urlpatterns = patterns(
     # edx-tim apps
     url(r'^peer/evaluations/', include(openassessment.assessment.urls)),
 )
+
+# We need to do explicit setup of the Django debug toolbar because autodiscovery
+# causes problems when you mix debug toolbar >= 1.0 + django < 1.7, and the
+# admin uses autodiscovery. See:
+# http://django-debug-toolbar.readthedocs.org/en/1.0/installation.html#explicit-setup
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += patterns('',
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    )


### PR DESCRIPTION
@wedaly, @jrbl, @stephensanchez: The autodiscovery used by admin will interact badly with Django Debug Toolbar's own auto-setup. So we have to be more explicit about everything and add some settings manually. See:

http://django-debug-toolbar.readthedocs.org/en/1.0/installation.html#explicit-setup

@dianakhuang, @flowerhack, @nedbat: I originally tried the fix used in https://github.com/edx/xblock-sdk/pull/2, but that didn't work for me. Don't know if this might be useful in xblock-sdk as well.
