### PR TITLE
Create submissions command uses same JSON format as the XBlock

### DIFF
--- a/apps/openassessment/management/commands/create_oa_submissions.py
+++ b/apps/openassessment/management/commands/create_oa_submissions.py
@@ -95,7 +95,7 @@ class Command(BaseCommand):
                 # Create the peer assessment
                 assessment = {
                     'options_selected': options_selected,
-                    'feedback': loremipsum.get_paragraphs(2)
+                    'feedback': "  ".join(loremipsum.get_paragraphs(2))
                 }
                 peer_api.create_assessment(submission_uuid, scorer_id, assessment, rubric)
 
@@ -127,7 +127,8 @@ class Command(BaseCommand):
         Returns:
             str: submission UUID
         """
-        submission = sub_api.create_submission(student_item, loremipsum.get_paragraphs(5))
+        answer = {'text': "  ".join(loremipsum.get_paragraphs(5))}
+        submission = sub_api.create_submission(student_item, answer)
         workflow_api.create_workflow(submission['uuid'])
         workflow_api.update_from_assessments(
             submission['uuid'], {'peer': {'must_grade': 1, 'must_be_graded_by': 1}}
@@ -149,7 +150,7 @@ class Command(BaseCommand):
         for criteria_num in range(self.NUM_CRITERIA):
             criterion = {
                 'name': words[criteria_num],
-                'prompt': loremipsum.get_sentences(1),
+                'prompt': "  ".join(loremipsum.get_sentences(2)),
                 'order_num': criteria_num,
                 'options': list()
             }
@@ -159,7 +160,7 @@ class Command(BaseCommand):
                     'order_num': option_num,
                     'points': option_num,
                     'name': words[option_num],
-                    'explanation': loremipsum.get_sentences(1)
+                    'explanation': "  ".join(loremipsum.get_sentences(2))
                 })
 
             rubric['criteria'].append(criterion)

--- a/apps/openassessment/management/tests/test_create_oa_submissions.py
+++ b/apps/openassessment/management/tests/test_create_oa_submissions.py
@@ -26,7 +26,10 @@ class CreateSubmissionsTest(TestCase):
             # Check that a submission was created
             submissions = sub_api.get_submissions(student_item)
             self.assertEqual(len(submissions), 1)
-            self.assertGreater(len(submissions[0]['answer']), 0)
+
+            answer_dict = submissions[0]['answer']
+            self.assertIsInstance(answer_dict['text'], basestring)
+            self.assertGreater(len(answer_dict['text']), 0)
 
             # Check that peer and self assessments were created
             assessments = peer_api.get_assessments(submissions[0]['uuid'], scored_only=False)


### PR DESCRIPTION
1) Make the answer format from `create_oa_submissions` match what the XBlock (now) expects: JSON dict with key "text".
2) Ensure that we're concatenating the lists of strings from `loremipsum`

@stephensanchez 
