### PR TITLE
Stop waiting for peers to assess before logging in as a new user

### DIFF
--- a/performance/locustfile.py
+++ b/performance/locustfile.py
@@ -101,16 +101,6 @@ class OpenAssessmentPage(object):
         resp = self.step_resp_dict.get('self')
         return resp is not None and resp.content is not None and 'class="assessment__fields"' in resp.content.lower()
 
-    def has_grade(self):
-        """
-        Check whether the user has a grade.
-
-        Returns:
-            bool
-        """
-        resp = self.step_resp_dict.get('grade')
-        return resp is not None and resp.content is not None and "has--grade" in resp.content.lower()
-
     def submit_response(self):
         """
         Submit a response.
@@ -221,10 +211,6 @@ class OpenAssessmentTasks(TaskSet):
 
         if self.page.can_self_assess():
             self.page.self_assess()
-
-        # At the end of the workflow, log in as a new user
-        # so we can continue to make new submissions
-        if self.page.has_grade():
             self.page.log_in()
 
 


### PR DESCRIPTION
With ~17k submissions pre-loaded in the database, virtual users in the performance test would get stuck waiting for a grade.  These users were last in the queue, so they would never be assessed.

Instead of waiting for a grade, the users should reset as soon as they finish self-assessment.

This does imply that we'll need some submissions in the database before running a performance test.  If we were to start with 0 submissions, then there wouldn't be enough submissions available to peer-assess, and users wouldn't get to the self-assessment step.
