### PR TITLE
Prevent workflow from trying to create multiple scores for the same user

### DIFF
--- a/apps/openassessment/xblock/self_assessment_mixin.py
+++ b/apps/openassessment/xblock/self_assessment_mixin.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext as _
 
 from xblock.core import XBlock
 from openassessment.assessment import self_api
+from openassessment.workflow import api as workflow_api
 from submissions import api as submission_api
 
 logger = logging.getLogger(__name__)
@@ -79,8 +80,14 @@ class SelfAssessmentMixin(object):
                 data['options_selected'],
                 {"criteria": self.rubric_criteria}
             )
+
+            # After we've created the self-assessment, we need to update the workflow.
+            self.update_workflow_status()
         except self_api.SelfAssessmentRequestError as ex:
             msg = _(u"Could not create self assessment: {error}").format(error=ex.message)
+            return {'success': False, 'msg': msg}
+        except workflow_api.AssessmentWorkflowError as ex:
+            msg = _(u"Could not update workflow: {error}").format(error=ex.message)
             return {'success': False, 'msg': msg}
         else:
             return {'success': True, 'msg': u""}

--- a/apps/openassessment/xblock/test/test_peer.py
+++ b/apps/openassessment/xblock/test/test_peer.py
@@ -6,6 +6,9 @@ from collections import namedtuple
 
 import copy
 import json
+import mock
+import submissions.api as sub_api
+from openassessment.workflow import api as workflow_api
 from openassessment.assessment import peer_api
 from .base import XBlockHandlerTestCase, scenario
 
@@ -27,13 +30,11 @@ class TestPeerAssessment(XBlockHandlerTestCase):
         sally_student_item = copy.deepcopy(student_item)
         sally_student_item['student_id'] = "Sally"
         sally_submission = xblock.create_submission(sally_student_item, u"Sally's answer")
-        xblock.get_workflow_info()
 
         # Hal comes and submits a response.
         hal_student_item = copy.deepcopy(student_item)
         hal_student_item['student_id'] = "Hal"
         hal_submission = xblock.create_submission(hal_student_item, u"Hal's answer")
-        xblock.get_workflow_info()
 
         # Now Hal will assess Sally.
         assessment = copy.deepcopy(self.ASSESSMENT)
@@ -73,19 +74,18 @@ class TestPeerAssessment(XBlockHandlerTestCase):
         self.assertIn("Sally".encode('utf-8'), peer_response.body)
 
     @scenario('data/peer_assessment_scenario.xml', user_id='Bob')
-    def test_assess_handler(self, xblock):
+    def test_peer_assess_handler(self, xblock):
 
         # Create a submission for this problem from another user
         student_item = xblock.get_student_item_dict()
         student_item['student_id'] = 'Sally'
 
         submission = xblock.create_submission(student_item, self.SUBMISSION)
-        xblock.get_workflow_info()
+
         # Create a submission for the scorer (required before assessing another student)
         another_student = copy.deepcopy(student_item)
         another_student['student_id'] = "Bob"
         xblock.create_submission(another_student, self.SUBMISSION)
-        xblock.get_workflow_info()
         peer_api.get_submission_to_assess(another_student, 3)
 
 
@@ -114,7 +114,7 @@ class TestPeerAssessment(XBlockHandlerTestCase):
         self.assertEqual(actual[0]['feedback'], assessment['feedback'])
 
     @scenario('data/peer_assessment_scenario.xml', user_id='Bob')
-    def test_assess_rubric_option_mismatch(self, xblock):
+    def test_peer_assess_rubric_option_mismatch(self, xblock):
 
         # Create a submission for this problem from another user
         student_item = xblock.get_student_item_dict()
@@ -134,7 +134,6 @@ class TestPeerAssessment(XBlockHandlerTestCase):
 
         # Expect an error response
         self.assertFalse(resp['success'])
-
 
     @scenario('data/peer_assessment_scenario.xml', user_id='Bob')
     def test_missing_keys_in_request(self, xblock):

--- a/apps/openassessment/xblock/workflow_mixin.py
+++ b/apps/openassessment/xblock/workflow_mixin.py
@@ -1,17 +1,21 @@
 from xblock.core import XBlock
 from openassessment.workflow import api as workflow_api
 
+
 class WorkflowMixin(object):
 
     @XBlock.json_handler
     def handle_workflow_info(self, data, suffix=''):
-        if not self.submission_uuid:
-            return None
-        return workflow_api.get_workflow_for_submission(
-            self.submission_uuid, self.workflow_requirements()
-        )
+        return self.get_workflow_info()
 
     def workflow_requirements(self):
+        """
+        Retrieve the requirements from each assessment module
+        so the workflow can decide whether the student can receive a score.
+
+        Returns:
+            dict
+        """
         assessment_ui_model = self.get_assessment_module('peer-assessment')
 
         if not assessment_ui_model:
@@ -24,7 +28,40 @@ class WorkflowMixin(object):
             }
         }
 
+    def update_workflow_status(self, submission_uuid=None):
+        """
+        Update the status of a workflow.  For example, change the status
+        from peer-assessment to self-assessment.  Creates a score
+        if the student has completed all requirements.
+
+        Kwargs:
+            submission_uuid (str): The submission associated with the workflow to update.
+                Defaults to the submission created by the current student.
+
+        Returns:
+            None
+
+        Raises:
+            AssessmentWorkflowError
+        """
+        if submission_uuid is None:
+            submission_uuid = self.submission_uuid
+
+        if submission_uuid:
+            requirements = self.workflow_requirements()
+            workflow_api.update_from_assessments(submission_uuid, requirements)
+
     def get_workflow_info(self):
+        """
+        Retrieve a description of the student's progress in a workflow.
+        Note that this *may* update the workflow status if it's changed.
+
+        Returns:
+            dict
+
+        Raises:
+            AssessmentWorkflowError
+        """
         if not self.submission_uuid:
             return {}
         return workflow_api.get_workflow_for_submission(

--- a/apps/submissions/tests/test_api.py
+++ b/apps/submissions/tests/test_api.py
@@ -211,7 +211,8 @@ class TestSubmissionsApi(TestCase):
         student_item = self._get_student_item(STUDENT_ITEM)
         self._assert_submission(submission, ANSWER_ONE, student_item.pk, 1)
 
-        score = api.set_score(submission["uuid"], 11, 12)
+        api.set_score(submission["uuid"], 11, 12)
+        score = api.get_latest_score_for_submission(submission["uuid"])
         self._assert_score(score, 11, 12)
 
     def test_get_score(self):


### PR DESCRIPTION
This updates the workflow status on page load and when the user submits a self-assessment.  This prevents an integrity error that would occur when the rendering views would get-or-create a score for the same student item (triggered from the workflow update).

I'm still verifying the fix in a sandbox, but I thought I'd open this PR for review.  I'm especially interested in how we should handle error conditions from the workflow: if workflow status updates, should we bail or ignore it?  I took the approach that we should ignore it on page load, but report the error on user action, but I'm interested in hearing other opinions.

@ormsbee @stephensanchez 
