### PR TITLE
Rename edx-tim to ora2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
-.. image:: https://travis-ci.org/edx/edx-tim.png?branch=master
+.. image:: https://travis-ci.org/edx/ora2.png?branch=master
     :alt: Travis build status
 
 
-.. image:: https://coveralls.io/repos/edx/edx-tim/badge.png?branch=master
-    :target: https://coveralls.io/r/edx/edx-tim?branch=master
+.. image:: https://coveralls.io/repos/edx/ora2/badge.png?branch=master
+    :target: https://coveralls.io/r/edx/ora2?branch=master
     :alt: Coverage badge
 
 

--- a/apps/openassessment/assessment/serializers.py
+++ b/apps/openassessment/assessment/serializers.py
@@ -250,7 +250,7 @@ def rubric_from_dict(rubric_dict):
     Sample data (one criterion, two options)::
 
         {
-          "prompt": "Create a plan to deliver edx-tim!",
+          "prompt": "Create a plan to deliver ora2!",
           "criteria": [
             {
               "order_num": 0,

--- a/apps/openassessment/assessment/test/rubric_data/empty_criteria.json
+++ b/apps/openassessment/assessment/test/rubric_data/empty_criteria.json
@@ -1,5 +1,5 @@
 {
-  "prompt": "Create a plan to deliver edx-tim!",
+  "prompt": "Create a plan to deliver ora2!",
   "criteria": [
   ]
 }

--- a/apps/openassessment/assessment/test/rubric_data/empty_options.json
+++ b/apps/openassessment/assessment/test/rubric_data/empty_options.json
@@ -1,5 +1,5 @@
 {
-  "prompt": "Create a plan to deliver edx-tim!",
+  "prompt": "Create a plan to deliver ora2!",
   "criteria": [
     {
       "order_num": 0,

--- a/apps/openassessment/assessment/test/rubric_data/missing_criteria.json
+++ b/apps/openassessment/assessment/test/rubric_data/missing_criteria.json
@@ -1,3 +1,3 @@
 {
-  "prompt": "Create a plan to deliver edx-tim!"
+  "prompt": "Create a plan to deliver ora2!"
 }

--- a/apps/openassessment/assessment/test/rubric_data/missing_options.json
+++ b/apps/openassessment/assessment/test/rubric_data/missing_options.json
@@ -1,5 +1,5 @@
 {
-  "prompt": "Create a plan to deliver edx-tim!",
+  "prompt": "Create a plan to deliver ora2!",
   "criteria": [
     {
       "order_num": 0,

--- a/apps/openassessment/assessment/test/rubric_data/no_points.json
+++ b/apps/openassessment/assessment/test/rubric_data/no_points.json
@@ -1,5 +1,5 @@
 {
-  "prompt": "Create a plan to deliver edx-tim!",
+  "prompt": "Create a plan to deliver ora2!",
   "criteria": [
     {
       "order_num": 0,

--- a/apps/openassessment/assessment/test/rubric_data/project_plan_rubric.json
+++ b/apps/openassessment/assessment/test/rubric_data/project_plan_rubric.json
@@ -1,5 +1,5 @@
 {
-  "prompt": "Create a plan to deliver edx-tim!",
+  "prompt": "Create a plan to deliver ora2!",
   "criteria": [
     {
       "order_num": 0,

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -77,17 +77,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/edx-tim.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/ora2.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/edx-tim.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/ora2.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/edx-tim"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/edx-tim"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/ora2"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/ora2"
 	@echo "# devhelp"
 
 epub:

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -99,9 +99,9 @@ if "%1" == "qthelp" (
 	echo.
 	echo.Build finished; now you can run "qcollectiongenerator" with the ^
 .qhcp project file in %BUILDDIR%/qthelp, like this:
-	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\edx-tim.qhcp
+	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\ora2.qhcp
 	echo.To view the help file:
-	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\edx-tim.ghc
+	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\ora2.ghc
 	goto end
 )
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -3,7 +3,7 @@
 Public API
 ----------
 
-Every Django application in edx-tim has an `api.py` that is its public
+Every Django application in ora2 has an `api.py` that is its public
 interface. If you are using one of these applications from the outside, you
 should only import things from that module. The ground rules for api modules
 are:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# edx-tim documentation build configuration file, created by
+# ora2 documentation build configuration file, created by
 # sphinx-quickstart on Fri Jan 17 08:32:59 2014.
 #
 # This file is execfile()d with the current directory set to its containing dir.
@@ -57,7 +57,7 @@ if not on_rtd: # only import and set the theme if we're building docs locally
   html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # General information about the project.
-project = u'edx-tim'
+project = u'ora2'
 copyright = u'2014, edX.org'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -181,7 +181,7 @@ html_static_path = ['_static']
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'edx-timdoc'
+htmlhelp_basename = 'ora2-doc'
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -201,8 +201,8 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
     ('index',
-     'edx-tim.tex',
-     u'edX Tim Documentation',
+     'ora2.tex',
+     u'edX ORA 2 Documentation',
      u'edX.org',
      'manual'),
     ]
@@ -233,7 +233,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'edx-tim', u'edX Tim Documentation',
+    ('index', 'ora2', u'edX ORA 2 Documentation',
      [u'edX.org'], 1)
 ]
 
@@ -248,10 +248,10 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     ('index',
-     'edx-tim',
-     u'edX Tim Documentation',
+     'ora2',
+     u'edX ORA 2 Documentation',
      u'edX.org',
-     'edx-tim',
+     'ora2',
      'Grading Modules',
      'Miscellaneous'),
     ]

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,7 +1,7 @@
-.. edx-tim documentation master file, created by
+.. ora2 documentation master file, created by
    sphinx-quickstart on Fri Jan 17 08:32:59 2014.
 
-edx-tim: Open Response Assessment (v2)
+Open Response Assessment (v2)
 ======================================
 
 This is an initial prototype for redesigning Peer Grading and general Open Ended

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -12,7 +12,7 @@ Usage
 
 1. Run the installation script.
 ```
-cd edx-tim
+cd ora2
 ./fixtures/install.sh
 ```
 **WARNING**: This will wipe out all student and course state before installing the fixtures.
@@ -34,9 +34,9 @@ Generating fixtures
 
 To regenerate test fixtures (perhaps after running a database migration):
 ```
-cd edx-tim
+cd ora2
 ./fixtures/dump.sh
 ```
 
-This will create new JSON fixtures in edx-tim/fixtures, which you can commit
-to the edx-tim repo.
+This will create new JSON fixtures in ora2/fixtures, which you can commit
+to the ora2 repo.

--- a/performance/README.rst
+++ b/performance/README.rst
@@ -5,7 +5,7 @@ Performance Tests
 
 .. code:: bash
 
-    cd edx-tim
+    cd ora2
     pip install -r requirements/perf.txt
 
 2. Import ``course.tar.gz`` into Studio:

--- a/settings/base.py
+++ b/settings/base.py
@@ -21,7 +21,7 @@ MANAGERS = ADMINS
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'timdb',                      # Or path to database file if using sqlite3.
+        'NAME': 'ora2db',                      # Or path to database file if using sqlite3.
         'USER': '',                      # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.
         'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
@@ -131,7 +131,7 @@ INSTALLED_APPS = (
     'workbench',
     'sample_xblocks.basic',  # Needs to be an app for template lookup
 
-    # edx-tim apps
+    # ora2 apps
     'submissions',
     'openassessment',
     'openassessment.workflow',

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,11 @@ REQUIREMENTS = [
 
 
 setup(
-    name='edx-tim',
+    name='ora2',
     version='0.0.1',
     author='edX',
-    url='http://github.com/edx/edx-tim',
-    description='edx-tim',
+    url='http://github.com/edx/ora2',
+    description='ora2',
     license='AGPL',
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/urls.py
+++ b/urls.py
@@ -16,10 +16,8 @@ urlpatterns = patterns(
     # Provided by XBlock
     url(r'^workbench/', include(workbench.urls)),
 
-    # edx-tim apps
+    # ora2 apps
     url(r'^submissions/', include(submissions.urls)),
-
-    # edx-tim apps
     url(r'^peer/evaluations/', include(openassessment.assessment.urls)),
 )
 


### PR DESCRIPTION
Coordinating this transition is going to be a little tricky, but it makes sense to do it ahead of the deploy to stage.  I'm planning to:

1) Merge this branch.
2) Rename the GitHub repo.
3) Update the edx-platform installation branch to point to the new repo.
4) Update Travis and Coveralls to point to the new repo.
5) Update readthedocs to point to the new repo.

In addition, this require that we uninstall `edx-tim` from any environment in which it's currently installed, including:
- The performance test environment
- Devstack VMs
- Sandboxes

@ormsbee 
