### PR TITLE
Add admin page for visualizing workflows

### DIFF
--- a/apps/openassessment/templates/workflow/admin/courses.html
+++ b/apps/openassessment/templates/workflow/admin/courses.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Workflows Admin</title>
+    </head>
+    <body>
+
+        <h1>Workflow admin page</h1>
+
+        <ul>
+            {% for course in courses %}
+            <li>{{ course.course_id }}
+            <ul>
+                {% for item in course.items %}
+                <li><a href="{{ item.url }}">{{ item.item_id }}</a></li>
+                {% endfor %}
+            </ul>
+            {% endfor %}
+        </ul>
+    </body>
+</html>

--- a/apps/openassessment/templates/workflow/admin/status_counts.html
+++ b/apps/openassessment/templates/workflow/admin/status_counts.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Workflows Admin</title>
+    </head>
+    <body>
+        <h1>Workflow admin page</h1>
+
+        <p>Workflow info for:</p>
+        <ul>
+            <li><b>Course</b>: {{ course_id }}</li>
+            <li><b>Item</b>: {{ item_id }}</li>
+        </ul>
+
+        <table border="1">
+            <tr>
+                {% for item in status_counts %}
+                <th>Num with status "{{ item.status }}"</th>
+                {% endfor %}
+            </tr>
+            <tr>
+                {% for item in status_counts %}
+                <td>{{ item.count }}</td>
+                {% endfor %}
+            </tr>
+        </table>
+
+        <p><b>Total submissions</b>: {{ num_submissions }}
+    </body>
+</html>

--- a/apps/openassessment/workflow/admin.py
+++ b/apps/openassessment/workflow/admin.py
@@ -1,5 +1,10 @@
 from django.contrib import admin
+from django.conf.urls import patterns, url
+from django.core.urlresolvers import reverse
+from django.shortcuts import render_to_response
 
+from submissions import api as sub_api
+from . import api as workflow_api
 from .models import AssessmentWorkflow
 
 class AssessmentWorkflowAdmin(admin.ModelAdmin):
@@ -8,3 +13,96 @@ class AssessmentWorkflowAdmin(admin.ModelAdmin):
     )
 
 admin.site.register(AssessmentWorkflow, AssessmentWorkflowAdmin)
+
+
+class WorkflowAdminSite(admin.AdminSite):
+    """
+    Admin site for visualizing assessment workflows.
+    Unlike other parts of the admin site, this is not tied to a particular model.
+    """
+
+    def get_urls(self):
+        """
+        Define URLs for the workflow admin site.
+        """
+        # We put our custom URLs before the Django admin URLs,
+        # because we want ours to take priority (the default URLs tend to match permissively)
+        return (
+            patterns('',
+                url(
+                    r'courses',
+                    self.admin_view(self.courses),
+                    name='courses'
+                ),
+                url(
+                    r'status/(?P<course_id>.+)/(?P<item_id>.+)$',
+                    self.admin_view(self.status_counts),
+                    name='status-counts'
+                )
+            ) + super(WorkflowAdminSite, self).get_urls()
+        )
+
+    def courses(self, request):
+        """
+        Show a list of courses and items with workflows.
+        """
+        courses_dict = sub_api.get_course_items()
+        context = {
+            "courses": [
+                {
+                    "course_id": course_id,
+                    "items": [
+                        {
+                            "item_id": item_id,
+                            "url": self._status_counts_url(course_id, item_id),
+                        } for item_id in course_items
+                    ]
+                } for course_id, course_items in courses_dict.iteritems()
+            ]
+        }
+        return render_to_response('workflow/admin/courses.html', context)
+
+    def status_counts(self, request, course_id=None, item_id=None):
+        """
+        Display the status counts for workflows for a particular item in a course.
+        """
+        status_counts = workflow_api.get_status_counts(
+            course_id=course_id, item_id=item_id, item_type="openassessment"
+        )
+        context = {
+            "course_id": course_id,
+            "item_id": item_id,
+            "status_counts": status_counts,
+            "num_submissions": sum(item['count'] for item in status_counts),
+        }
+        return render_to_response('workflow/admin/status_counts.html', context)
+
+    def _status_counts_url(self, course_id, item_id):
+        """
+        Return a URL to the status counts page.
+
+        Args:
+            course_id (unicode): The ID of the course.
+            item_id (unicode): The ID of the item in the course.
+
+        Returns:
+            unicode: URL to the status counts page.
+
+        """
+        kwargs = {'course_id': course_id, 'item_id': item_id}
+        return reverse("admin:status-counts", kwargs=kwargs, current_app=self.name)
+
+
+"""
+To make the workflow admin URLs available, you need to add this to urls.py:
+
+    from openassessment.workflow.admin import WORKFLOW_ADMIN_SITE
+    url(r'^path/to/workflow/admin/', include(WORKFLOW_ADMIN_SITE.urls))
+
+To reverse URLs to this site:
+
+    from django.conf.urlresolvers import reverse
+    reverse('admin:url-name', current_app='workflow-admin')
+
+"""
+WORKFLOW_ADMIN_SITE = WorkflowAdminSite('workflow-admin')

--- a/apps/openassessment/workflow/api.py
+++ b/apps/openassessment/workflow/api.py
@@ -292,6 +292,36 @@ def update_from_assessments(submission_uuid, assessment_requirements):
     return _serialized_with_details(workflow, assessment_requirements)
 
 
+def get_status_counts(**kwargs):
+    """
+    Count how many workflows have each status, for a given item in a course.
+
+    Kwargs:
+        course_id (unicode): The ID of the course.
+        item_id (unicode): The ID of the item in the course.
+        item_type (unicode): The type of the item.
+
+    Returns:
+        list of dictionaries with keys "status" (str) and "count" (int)
+
+    Example usage:
+        >>> get_status_counts("ora2/1/1", "peer-assessment-problem")
+        [
+            {"status": "peer", "count": 5},
+            {"status": "self", "count": 10},
+            {"status": "waiting", "count": 43},
+            {"status": "done", "count": 12},
+        ]
+
+    """
+    submission_uuids = sub_api.get_submission_uuids(**kwargs)
+    workflows = AssessmentWorkflow.objects.filter(submission_uuid__in=submission_uuids)
+    return [
+        {"status": status, "count": workflows.filter(status=status).count()}
+        for status in AssessmentWorkflow.STATUS_VALUES
+    ]
+
+
 def _get_workflow_model(submission_uuid):
     """Return the `AssessmentWorkflow` model for a given `submission_uuid`.
 

--- a/apps/openassessment/workflow/models.py
+++ b/apps/openassessment/workflow/models.py
@@ -30,14 +30,16 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
     an after the fact recording of the last known state of that information so
     we can search easily.
     """
-    STATUS = Choices(  # implicit "status" field
+    STATUS_VALUES = [
         "peer",  # User needs to assess peer submissions
         "self",  # User needs to assess themselves
         "waiting",  # User has done all necessary assessment but hasn't been
                     # graded yet -- we're waiting for assessments of their
                     # submission by others.
         "done",  # Complete
-    )
+    ]
+
+    STATUS = Choices(*STATUS_VALUES)  # implicit "status" field
 
     submission_uuid = models.CharField(max_length=36, db_index=True, unique=True)
     uuid = UUIDField(version=1, db_index=True, unique=True)

--- a/apps/openassessment/workflow/test/test_admin.py
+++ b/apps/openassessment/workflow/test/test_admin.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the workflow admin site.
+"""
+
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from submissions import api as sub_api
+import openassessment.workflow.api as workflow_api
+
+
+class WorkflowAdminSiteTest(TestCase):
+    """
+    View-level tests of the workflow admin site.
+    """
+
+    STUDENT_ITEM = {
+        "student_id": "Omar Little",
+        "course_id": "test/1/1",
+        "item_id": "peer-assessment",
+        "item_type": "openassessment",
+    }
+
+    ANSWER = u"ﾑ ﾶﾑ刀 ﾶu丂ｲ んﾑ√乇 ﾑ cod乇."
+
+    def setUp(self):
+        """
+        Create submissions and workflows.
+        """
+        super(WorkflowAdminSiteTest, self).setUp()
+
+        # Log in as an admin user
+        User.objects.create_superuser('admin', 'admin@example.com', 'admin')
+        self.client.login(username='admin', password='admin')
+
+        # Create a submission and workflow
+        submission = sub_api.create_submission(self.STUDENT_ITEM, self.ANSWER)
+        workflow_api.create_workflow(submission['uuid'])
+
+    def test_courses_page(self):
+        url = reverse('admin:courses', current_app='workflow-admin')
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.template.name, 'workflow/admin/courses.html')
+
+        expected_courses = [{
+            'course_id': u'test/1/1',
+            'items': [{
+                'item_id': u'peer-assessment',
+                'url': '/workflow/admin/status/test/1/1/peer-assessment'
+            }]
+        }]
+        self.assertEqual(resp.context['courses'], expected_courses)
+
+    def test_status_counts_page(self):
+        kwargs = {
+            'course_id': self.STUDENT_ITEM['course_id'],
+            'item_id': self.STUDENT_ITEM['item_id'],
+        }
+        url = reverse('admin:status-counts', kwargs=kwargs, current_app='workflow-admin')
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.template.name, 'workflow/admin/status_counts.html')
+        self.assertEqual(resp.context['course_id'], self.STUDENT_ITEM['course_id'])
+        self.assertEqual(resp.context['item_id'], self.STUDENT_ITEM['item_id'])
+        self.assertEqual(resp.context['num_submissions'], 1)
+        self.assertItemsEqual(
+            resp.context['status_counts'],
+            [
+                {'status': 'peer', 'count': 1},
+                {'status': 'self', 'count': 0},
+                {'status': 'waiting', 'count': 0},
+                {'status': 'done', 'count': 0}
+            ]
+        )

--- a/apps/submissions/tests/test_api.py
+++ b/apps/submissions/tests/test_api.py
@@ -177,6 +177,61 @@ class TestSubmissionsApi(TestCase):
         submissions = api.get_submissions(STUDENT_ITEM, 1)
         self.assertEqual(u"Testing unicode answers.", submissions[0]["answer"])
 
+    def test_get_course_items(self):
+        # Initially, no course items available
+        self.assertEqual(api.get_course_items(), dict())
+
+        # Same course, same item
+        api.create_submission({
+            'student_id': 'Tim',
+            'course_id': 'Foo',
+            'item_id': 'Bar',
+            'item_type': 'openassessment'
+        }, "answer 1")
+        api.create_submission({
+            'student_id': 'Alice',
+            'course_id': 'Foo',
+            'item_id': 'Bar',
+            'item_type': 'openassessment'
+        }, "answer 2")
+        self.assertItemsEqual(api.get_course_items(), {"Foo": ["Bar"]})
+
+        # Same course, different items
+        api.create_submission({
+            'student_id': 'Alice',
+            'course_id': 'Foo',
+            'item_id': 'Different',
+            'item_type': 'openassessment'
+        }, "answer 3")
+        course_items = api.get_course_items()
+        self.assertItemsEqual(course_items.keys(), ["Foo"])
+        self.assertItemsEqual(api.get_course_items()["Foo"], ["Bar", "Different"])
+
+        # Different course, same item
+        api.create_submission({
+            'student_id': 'Alice',
+            'course_id': 'Lorem',
+            'item_id': 'Bar',
+            'item_type': 'openassessment'
+        }, "answer 3")
+        course_items = api.get_course_items()
+        self.assertItemsEqual(course_items.keys(), ["Foo", "Lorem"])
+        self.assertItemsEqual(api.get_course_items()["Foo"], ["Bar", "Different"])
+        self.assertItemsEqual(api.get_course_items()["Lorem"], ["Bar"])
+
+        # Different course, different item
+        api.create_submission({
+            'student_id': 'Alice',
+            'course_id': 'Ipsum',
+            'item_id': 'Dolar',
+            'item_type': 'openassessment'
+        }, "answer 3")
+        course_items = api.get_course_items()
+        self.assertItemsEqual(course_items.keys(), ["Foo", "Lorem", "Ipsum"])
+        self.assertItemsEqual(api.get_course_items()["Foo"], ["Bar", "Different"])
+        self.assertItemsEqual(api.get_course_items()["Lorem"], ["Bar"])
+        self.assertItemsEqual(api.get_course_items()["Ipsum"], ["Dolar"])
+
     def _assert_submission(self, submission, expected_answer, expected_item,
                            expected_attempt):
         self.assertIsNotNone(submission)

--- a/urls.py
+++ b/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import include, patterns, url
 from django.contrib import admin
 
 import openassessment.assessment.urls
+from openassessment.workflow.admin import WORKFLOW_ADMIN_SITE
 import submissions.urls
 import workbench.urls
 
@@ -19,6 +20,7 @@ urlpatterns = patterns(
     # edx-ora2 apps
     url(r'^submissions/', include(submissions.urls)),
     url(r'^peer/evaluations/', include(openassessment.assessment.urls)),
+    url(r'^workflow/admin/', include(WORKFLOW_ADMIN_SITE.urls)),
 )
 
 # We need to do explicit setup of the Django debug toolbar because autodiscovery


### PR DESCRIPTION
[TIM-373](https://edx-wiki.atlassian.net/browse/TIM-373)

URLs:
- workflow/admin/courses: Display list of courses/items with workflows.
- workflow/admin/status/course_id/item_id: Display counts of workflows based on status.

The courses page looks like:
![image](https://cloud.githubusercontent.com/assets/2948394/2542464/e21b305e-b5e7-11e3-8e7e-f7da6765caef.png)

The status counts page looks like:
![image](https://cloud.githubusercontent.com/assets/2948394/2542469/ee7ee566-b5e7-11e3-802f-cfb48e8b964b.png)

@stephensanchez
