### PR TITLE
Revert setup.py name change back to ora2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ REQUIREMENTS = [
 
 
 setup(
-    name='edx-ora2',
+    name='ora2',
     version='0.0.1',
     author='edX',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
I'm changing just the "setup.py" package name, but leaving the GitHub repo the same.  Most people won't see this name, unless they're poking around a virtualenv or if we upload to PyPi.

@ormsbee 
