### PR TITLE
Show item_id (location) in Course Staff Debug section.

### DIFF
--- a/apps/openassessment/templates/openassessmentblock/staff_debug.html
+++ b/apps/openassessment/templates/openassessmentblock/staff_debug.html
@@ -37,6 +37,9 @@
             </table>
         </div>
 
+        <div class="staff-info__status ui-staff__content__section">
+          Location: {{ item_id }}
+        </div>
     </div>
   </div>
 </div>

--- a/apps/openassessment/xblock/openassessmentblock.py
+++ b/apps/openassessment/xblock/openassessmentblock.py
@@ -298,6 +298,7 @@ class OpenAssessmentBlock(
             context_dict['is_course_staff'] = True
             context_dict['status_counts'] = status_counts
             context_dict['num_submissions'] = num_submissions
+            context_dict['item_id'] = unicode(self.scope_ids.usage_id)
 
         template = get_template("openassessmentblock/oa_base.html")
         context = Context(context_dict)


### PR DESCRIPTION
It's cumbersome to get otherwise, and staff will want it for state resetting (if it comes to that).

This isn't in sprint work, but it occurred to me because I was doing the equivalent of state resets while testing the event code.
