### PR TITLE
Validation check for duplicate criteria and options

### DIFF
--- a/apps/openassessment/xblock/test/data/invalid_rubrics.json
+++ b/apps/openassessment/xblock/test/data/invalid_rubrics.json
@@ -47,6 +47,71 @@
         "is_released": false
     },
 
+    "duplicate_criteria_names": {
+        "rubric": {
+            "prompt": "Test Prompt",
+            "criteria": [
+                {
+                    "order_num": 0,
+                    "name": "Test criterion",
+                    "prompt": "Test criterion prompt",
+                    "options": [
+                        {
+                            "order_num": 0,
+                            "points": 1,
+                            "name": "No",
+                            "explanation": "No explanation"
+                        }
+                    ]
+                },
+                {
+                    "order_num": 0,
+                    "name": "Test criterion",
+                    "prompt": "Test criterion prompt",
+                    "options": [
+                        {
+                            "order_num": 0,
+                            "points": 1,
+                            "name": "Yes",
+                            "explanation": "Yes explanation"
+                        }
+                    ]
+                }
+            ]
+        },
+        "current_rubric": null,
+        "is_released": false
+    },
+
+    "duplicate_option_names": {
+        "rubric": {
+            "prompt": "Test Prompt",
+            "criteria": [
+                {
+                    "order_num": 0,
+                    "name": "Test criterion",
+                    "prompt": "Test criterion prompt",
+                    "options": [
+                        {
+                            "order_num": 0,
+                            "points": 1,
+                            "name": "No",
+                            "explanation": "No explanation"
+                        },
+                        {
+                            "order_num": 0,
+                            "points": 1,
+                            "name": "No",
+                            "explanation": "Second no explanation"
+                        }
+                    ]
+                }
+            ]
+        },
+        "current_rubric": null,
+        "is_released": false
+    },
+
     "change_points_after_release": {
         "rubric": {
             "prompt": "Test Prompt",

--- a/apps/openassessment/xblock/test/data/valid_rubrics.json
+++ b/apps/openassessment/xblock/test/data/valid_rubrics.json
@@ -40,13 +40,13 @@
                         {
                             "order_num": 0,
                             "points": 0,
-                            "name": "☃",
+                            "name": "☃ 1",
                             "explanation": "☃"
                         },
                         {
                             "order_num": 1,
                             "points": 2,
-                            "name": "☃",
+                            "name": "☃ 2",
                             "explanation": "☃"
                         }
                     ]


### PR DESCRIPTION
Add validation rules to disallow:
- Duplicate criteria names.
- Duplicate option names within a criterion.

Duplicates names are causing problems because we use the names to generate CSS ID's on the client side.  If we have two radio groups with the same CSS ID, the browser will assume they are part of the same radio group, which means you can select only one option from among all criteria with the same name.

In addition, the client sends an "options selected" dict to the server that looks like:

```
{
    Ideas: 'Fair',
    Content: 'Good'
}
```

which could get messed up by duplicate criteria/option names.

@stephensanchez 
