### PR TITLE
Hide course staff debug info in studio preview

### DIFF
--- a/apps/openassessment/xblock/openassessmentblock.py
+++ b/apps/openassessment/xblock/openassessmentblock.py
@@ -293,7 +293,7 @@ class OpenAssessmentBlock(
             "is_course_staff": False,
         }
 
-        if self.is_course_staff:
+        if self.is_course_staff and not self.in_studio_preview:
             status_counts, num_submissions = self.get_workflow_status_counts()
             context_dict['is_course_staff'] = True
             context_dict['status_counts'] = status_counts
@@ -320,6 +320,20 @@ class OpenAssessmentBlock(
             return getattr(self.xmodule_runtime, 'user_is_staff', False)
         else:
             return False
+
+    @property
+    def in_studio_preview(self):
+        """
+        Check whether we are in Studio preview mode.
+
+        Returns:
+            bool
+
+        """
+        # When we're running in Studio Preview mode, the XBlock won't provide us with a user ID.
+        # (Note that `self.xmodule_runtime` will still provide an anonymous
+        # student ID, so we can't rely on that)
+        return self.scope_ids.user_id is None
 
     def _create_ui_models(self):
         """Combine UI attributes and XBlock configuration into a UI model.

--- a/apps/openassessment/xblock/submission_mixin.py
+++ b/apps/openassessment/xblock/submission_mixin.py
@@ -59,9 +59,7 @@ class SubmissionMixin(object):
 
         # Short-circuit if no user is defined (as in Studio Preview mode)
         # Since students can't submit, they will never be able to progress in the workflow
-        # Studio Preview provides an anonymous student ID, so we need to check the scope ids directly
-        # to check that we are in preview mode.
-        if self.scope_ids.user_id is None:
+        if self.in_studio_preview:
             return False, 'ENOPREVIEW', self.submit_errors['ENOPREVIEW']
 
         workflow = self.get_workflow_info()

--- a/apps/openassessment/xblock/test/test_openassessment.py
+++ b/apps/openassessment/xblock/test/test_openassessment.py
@@ -145,7 +145,7 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         self.assertEqual(student_item['course_id'], 'test_course')
         self.assertEqual(student_item['student_id'], 'test_student')
 
-    @scenario('data/basic_scenario.xml')
+    @scenario('data/basic_scenario.xml', user_id='Bob')
     def test_is_course_staff(self, xblock):
         # By default, we shouldn't be course staff
         self.assertFalse(xblock.is_course_staff)
@@ -160,7 +160,7 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         xblock.xmodule_runtime.user_is_staff = True
         self.assertTrue(xblock.is_course_staff)
 
-    @scenario('data/basic_scenario.xml')
+    @scenario('data/basic_scenario.xml', user_id='Bob')
     def test_course_staff_debug_info(self, xblock):
         # If we're not course staff, we shouldn't see the debug info
         xblock.xmodule_runtime = Mock(
@@ -175,6 +175,19 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         xblock.xmodule_runtime.user_is_staff = True
         xblock_fragment = self.runtime.render(xblock, "student_view")
         self.assertIn("course staff information", xblock_fragment.body_html().lower())
+
+    @scenario('data/basic_scenario.xml')
+    def test_hide_course_staff_debug_info_in_studio_preview(self, xblock):
+        # If we are in Studio preview mode, don't show the staff debug info
+        # In this case, the runtime will tell us that we're staff,
+        # but no user ID will be set.
+        xblock.xmodule_runtime = Mock(
+            course_id='test_course',
+            anonymous_student_id='test_student',
+            user_is_staff=True
+        )
+        xblock_fragment = self.runtime.render(xblock, "student_view")
+        self.assertNotIn("course staff information", xblock_fragment.body_html().lower())
 
 
 class TestDates(XBlockHandlerTestCase):


### PR DESCRIPTION
Course staff debug info was showing up in Studio Preview, which is inconsistent with other problem types.

@stephensanchez 
