### PR TITLE
Add more info to manually created scoring analytics event.

### DIFF
--- a/apps/openassessment/workflow/models.py
+++ b/apps/openassessment/workflow/models.py
@@ -9,6 +9,7 @@ need to then generate a matching migration for it using:
     ./manage.py schemamigration openassessment.workflow --auto
 
 """
+from datetime import datetime
 import logging
 import importlib
 
@@ -162,11 +163,21 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
                     score["points_earned"],
                     score["points_possible"]
                 )
+
+                # This should be replaced by using the event tracking API, but
+                # that's not quite ready yet. So we're making this temp hack.
                 emit_event({
+                    "context": {
+                        "course_id": self.course_id
+                    },
+                    "event": {
+                        "submission_uuid": self.submission_uuid,
+                        "points_earned": score["points_earned"],
+                        "points_possible": score["points_possible"],
+                    },
+                    "event_source": "server",
                     "event_type": "openassessment.workflow.score",
-                    "submission_uuid": self.submission_uuid,
-                    "points_earned": score["points_earned"],
-                    "points_possible": score["points_possible"]
+                    "time": datetime.utcnow(),
                 })
 
                 new_status = self.STATUS.done


### PR DESCRIPTION
@wedaly, @stephensanchez, @mulby, @rocha

When a submission is finally scored (gone through the entire workflow), we emit an event that looks like:

``` python
{
    'time': datetime.datetime(2014, 3, 30, 20, 48, 45, 339065),
    'event_source': 'server',
    'event': {
        'points_possible': 20,
        'points_earned': 8,
        'submission_uuid': u'1284eaee-b84c-11e3-b4e1-040ccee02800'
    },
    'context': {
        'course_id': u'edX/Enchantment_101/April_1'
    },
    'event_type': 'openassessment.workflow.score'
}
```

This was discussed in https://github.com/edx/edx-platform/pull/3118
