### PR TITLE
Add datadog instrumentation

### DIFF
--- a/apps/openassessment/assessment/models.py
+++ b/apps/openassessment/assessment/models.py
@@ -260,6 +260,19 @@ class Assessment(models.Model):
     def points_possible(self):
         return self.rubric.points_possible
 
+    def to_float(self):
+        """
+        Calculate the score percentage (points earned / points possible).
+
+        Returns:
+            float or None
+
+        """
+        if self.points_possible == 0:
+            return None
+        else:
+            return float(self.points_earned) / self.points_possible
+
     def __unicode__(self):
         return u"Assessment {}".format(self.id)
 

--- a/apps/openassessment/assessment/test/test_peer.py
+++ b/apps/openassessment/assessment/test/test_peer.py
@@ -699,7 +699,7 @@ class TestPeerApi(CacheResetTest):
         tim, _ = self._create_student_and_submission("Tim", "Tim's answer")
         peer_api.get_assessments(tim["uuid"])
 
-    @patch.object(Submission.objects, 'get')
+    @patch.object(PeerWorkflow.objects, 'get_or_create')
     @raises(peer_api.PeerAssessmentInternalError)
     def test_error_on_assessment_creation(self, mock_filter):
         mock_filter.side_effect = DatabaseError("Bad things happened")

--- a/apps/openassessment/workflow/api.py
+++ b/apps/openassessment/workflow/api.py
@@ -125,7 +125,11 @@ def create_workflow(submission_uuid):
             course_id=submission_dict['student_item']['course_id'],
             item_id=submission_dict['student_item']['item_id'],
         )
-    except (DatabaseError, peer_api.PeerAssessmentError) as err:
+    except (
+        DatabaseError,
+        peer_api.PeerAssessmentError,
+        sub_api.SubmissionError
+    ) as err:
         err_msg = u"Could not create assessment workflow: {}".format(err)
         logger.exception(err_msg)
         raise AssessmentWorkflowInternalError(err_msg)

--- a/pylintrc
+++ b/pylintrc
@@ -94,6 +94,7 @@ generated-members=
     aq_parent,
     objects,
     DoesNotExist,
+    MultipleObjectsReturned,
     can_read,
     can_write,
     get_url,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,7 @@ git+https://github.com/edx/xblock-sdk.git@50ed1646d24f6f0a21d6d0bb074e3b7c8a78fd
 
 # Third Party Requirements
 defusedxml==0.4.1
+dogapi==1.2.1
 django==1.4.8
 django-extensions==1.2.5
 django-model-utils==1.4.0


### PR DESCRIPTION
[TIM-305](https://edx-wiki.atlassian.net/browse/TIM-305)

This generates events for all of the metrics described in the JIRA ticket, except for tagging turbo grading.  I didn't see anywhere this was exposed to the peer assessment API, and I'm hesitant to change the interfaces this late in the game.

This also cleans up some technical debt: the assessment API no longer uses the `Submission` and `StudentItem` models directly [TIM-404](https://edx-wiki.atlassian.net/browse/TIM-404)

@stephensanchez @feanil 
