### PR TITLE
Make Google font URLs work under HTTPS

### DIFF
--- a/apps/openassessment/xblock/static/css/openassessment.css
+++ b/apps/openassessment/xblock/static/css/openassessment.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,300,600,700);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,300,600,700);
 * {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;

--- a/apps/openassessment/xblock/static/sass/themes/edx/_assets.scss
+++ b/apps/openassessment/xblock/static/sass/themes/edx/_assets.scss
@@ -8,7 +8,7 @@
 // --------------------
 // font: Open Sans - http://www.google.com/fonts/specimen/Open+Sans
 // --------------------
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,300,600,700);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,300,600,700);
 
 
 // --------------------


### PR DESCRIPTION
Use protocol-relative URLs for the fonts.

Fixes [TIM-362](https://edx-wiki.atlassian.net/browse/TIM-362)

@stephensanchez @talbs 
