### PR TITLE
Add missing view-level tests

### DIFF
--- a/apps/openassessment/xblock/test/data/grade_incomplete_scenario.xml
+++ b/apps/openassessment/xblock/test/data/grade_incomplete_scenario.xml
@@ -1,0 +1,46 @@
+<openassessment>
+    <title>Open Assessment Test</title>
+    <prompt>
+        Given the state of the world today, what do you think should be done to
+        combat poverty? Please answer in a short essay of 200-300 words.
+    </prompt>
+    <rubric>
+        <prompt>Read for conciseness, clarity of thought, and form.</prompt>
+        <criterion>
+            <name>𝓒𝓸𝓷𝓬𝓲𝓼𝓮</name>
+            <prompt>How concise is it?</prompt>
+            <option points="3">
+                <name>ﻉซƈﻉɭɭﻉกՇ</name>
+                <explanation>Extremely concise</explanation>
+            </option>
+            <option points="2">
+                <name>Ġööḋ</name>
+                <explanation>Concise</explanation>
+            </option>
+            <option points="1">
+                <name>ק๏๏г</name>
+                <explanation>Wordy</explanation>
+            </option>
+        </criterion>
+        <criterion>
+            <name>Form</name>
+            <prompt>How well-formed is it?</prompt>
+            <option points="3">
+                <name>Good</name>
+                <explanation>Good</explanation>
+            </option>
+            <option points="2">
+                <name>Fair</name>
+                <explanation>Fair</explanation>
+            </option>
+            <option points="1">
+                <name>Poor</name>
+                <explanation>Poor</explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="peer-assessment" must_grade="1" must_be_graded_by="1" />
+        <assessment name="self-assessment" />
+    </assessments>
+</openassessment>

--- a/apps/openassessment/xblock/test/data/peer_closed_scenario.xml
+++ b/apps/openassessment/xblock/test/data/peer_closed_scenario.xml
@@ -1,0 +1,46 @@
+<openassessment>
+    <title>Open Assessment Test</title>
+    <prompt>
+        Given the state of the world today, what do you think should be done to
+        combat poverty? Please answer in a short essay of 200-300 words.
+    </prompt>
+    <rubric>
+        <prompt>Read for conciseness, clarity of thought, and form.</prompt>
+        <criterion>
+            <name>𝓒𝓸𝓷𝓬𝓲𝓼𝓮</name>
+            <prompt>How concise is it?</prompt>
+            <option points="3">
+                <name>ﻉซƈﻉɭɭﻉกՇ</name>
+                <explanation>Extremely concise</explanation>
+            </option>
+            <option points="2">
+                <name>Ġööḋ</name>
+                <explanation>Concise</explanation>
+            </option>
+            <option points="1">
+                <name>ק๏๏г</name>
+                <explanation>Wordy</explanation>
+            </option>
+        </criterion>
+        <criterion>
+            <name>Form</name>
+            <prompt>How well-formed is it?</prompt>
+            <option points="3">
+                <name>Good</name>
+                <explanation>Good</explanation>
+            </option>
+            <option points="2">
+                <name>Fair</name>
+                <explanation>Fair</explanation>
+            </option>
+            <option points="1">
+                <name>Poor</name>
+                <explanation>Poor</explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="peer-assessment" must_grade="5" must_be_graded_by="3" due="2000-01-01T00:00:00"/>
+        <assessment name="self-assessment" />
+    </assessments>
+</openassessment>

--- a/apps/openassessment/xblock/test/test_submission.py
+++ b/apps/openassessment/xblock/test/test_submission.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Test submission to the OpenAssessment XBlock.
 """
@@ -49,7 +50,7 @@ class SubmissionTest(XBlockHandlerTestCase):
 
     # In Studio preview mode, the runtime sets the user ID to None
     @scenario('data/basic_scenario.xml', user_id=None)
-    def test_cannot_submit_in_preview_mode(self, xblock,):
+    def test_cannot_submit_in_preview_mode(self, xblock):
 
         # The Studio runtime apparently provides an anonymous student ID,
         # even though we're running in Preview mode.  We should check the scope id
@@ -66,6 +67,15 @@ class SubmissionTest(XBlockHandlerTestCase):
 
     # In Studio preview mode, the runtime sets the user ID to None
     @scenario('data/over_grade_scenario.xml', user_id='Alice')
-    def test_closed_submissions(self, xblock,):
+    def test_closed_submissions(self, xblock):
         resp = self.request(xblock, 'render_submission', json.dumps(dict()))
         self.assertIn("Incomplete", resp)
+
+    @scenario('data/basic_scenario.xml', user_id='Omar Little')
+    def test_response_submitted(self, xblock):
+        # Create a submission for the user
+        xblock.create_submission(xblock.get_student_item_dict(), u'Ⱥ mȺn mᵾsŧ ħȺvɇ Ⱥ ȼøđɇ.')
+
+        # Expect that the response step is "submitted"
+        resp = self.request(xblock, 'render_submission', json.dumps(dict()))
+        self.assertIn('your response has been submitted', resp.lower())


### PR DESCRIPTION
Add view-level tests.  This should give us 100% coverage of XBlock rendered steps.  The tests aren't very rigorous, but they will protect against runtime errors when rendering the templates.

@stephensanchez 
