### PR TITLE
Hide formatted due date in submission if it's not provided

### DIFF
--- a/apps/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/apps/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -28,7 +28,15 @@
     <div class="ui-toggle-visibility__content">
         <div class="wrapper--step__content">
             <div class="step__instruction">
-                <p>Please provide your response below. You can save your progress and return to complete your response at any time before the due date of <span class="step__deadline"><span class="date">{{ formatted_due_date }}</span></span>. <strong class="emphasis">After you submit your response, you cannot edit it</strong>.</p>
+                <p>
+                    Please provide your response below.
+                    {% if formatted_due_date %}
+                    You can save your progress and return to complete your response at any time before the due date of <span class="step__deadline"><span class="date">{{ formatted_due_date }}</span></span>.
+                    {% else %}
+                    You can save your progress and return to complete your response at any time.
+                    {% endif %}
+                    <strong class="emphasis">After you submit your response, you cannot edit it</strong>.
+                </p>
             </div>
 
             <div class="step__content">


### PR DESCRIPTION
Due date shows up as an empty space if not provided (verified in the LMS).

@stephensanchez 
