### PR TITLE
Tag i18n strings in templates

### DIFF
--- a/apps/openassessment/templates/openassessmentblock/grade/oa_grade_closed.html
+++ b/apps/openassessment/templates/openassessmentblock/grade/oa_grade_closed.html
@@ -1,12 +1,13 @@
+{% load i18n %}
 {% spaceless %}
 <li id="openassessment__grade" class="openassessment__steps__step step--grade is--complete">
     <header class="step__header ui-toggle-visibility__control">
         <h2 class="step__title">
             <span class="wrapper--copy">
-                <span class="step__label">Your Grade: </span>
+                <span class="step__label">{% trans "Your Grade" %}: </span>
                 <span class="grade__value">
-                    <span class="grade__value__title">Incomplete</span>
-                        <p class="grade__value__description">You have not completed the {% for step in incomplete_steps %}<span class="step">{{ step }} step </span> {% if not forloop.last %} and {% endif %}{% endfor %} of this problem.</p>
+                    <span class="grade__value__title">{% trans "Incomplete" %}</span>
+                        <p class="grade__value__description">{% trans "You have not completed all the steps of this problem." %}</p>
                 </span>
             </span>
         </h2>

--- a/apps/openassessment/templates/openassessmentblock/grade/oa_grade_complete.html
+++ b/apps/openassessment/templates/openassessmentblock/grade/oa_grade_complete.html
@@ -1,12 +1,17 @@
+{% load i18n %}
 {% spaceless %}
 <li id="openassessment__grade" class="openassessment__steps__step step--grade is--complete has--grade">
     <header class="step__header ui-toggle-visibility__control">
         <h2 class="step__title">
             <span class="wrapper--copy">
-                <span class="step__label">Your Grade: </span>
+                <span class="step__label">{% trans "Your Grade" %}: </span>
                 <span class="grade__value">
                     <span class="grade__value__title">
-                         <span class="grade__value__earned">{{ score.points_earned }}</span> out of <span class="grade__value__potential">{{ score.points_possible }}</span>
+                         {% blocktrans with points_earned=score.points_earned points_possible=score.points_possible%}
+                         <span class="grade__value__earned">{{ points_earned }}</span>
+                         out of
+                         <span class="grade__value__potential">{{ points_possible }}</span>
+                         {% endblocktrans %}
                     </span>
                 </span>
             </span>
@@ -17,7 +22,7 @@
         <div class="wrapper--step__content">
             <div class="step__content">
                 <article class="submission__answer__display step__content__section">
-                    <h3 class="submission__answer__display__title">Your Response</h3>
+                    <h3 class="submission__answer__display__title">{% trans "Your Response" %}</h3>
 
                     <div class="submission__answer__display__content">
                         {{ student_submission.answer.text|linebreaks }}
@@ -25,7 +30,7 @@
                 </article>
 
                 <article class="submission__peer-evaluations step__content__section">
-                    <h3 class="submission__peer-evaluations__title">Peer Assessments of Your Response</h3>
+                    <h3 class="submission__peer-evaluations__title">{% trans "Peer Assessments of Your Response" %}</h3>
 
                     <ol class="list submission__peer-evaluations__questions">
                         {% for criterion in rubric_criteria %}
@@ -36,13 +41,15 @@
                                 <span class="question__title__copy">{{ criterion.name }}</span>
 
                                 <span class="question__score">
-                                  <span class="label sr">Overall Grade</span>
-                                  <span class="question__score__value">{{ criterion.median_score }}</span>
+                                  <span class="label sr">{% trans "Overall Grade" %}</span>
+                                  {% blocktrans with score=criterion.median_score total=criterion.total_value%}
+                                  <span class="question__score__value">{{ score }}</span>
                                   <span class="label label--divider sr">out of</span>
                                   <span class="question__score__potential">
-                                    {{ criterion.total_value }}
+                                    {{ total }}
                                     <span class="unit">Points</span>
                                   </span>
+                                  {% endblocktrans %}
                                 </span>
                             </h4>
 
@@ -55,23 +62,28 @@
                                                 id="question--{{ criterion_num }}__answer-{{ peer_num }}">
                                                 <h5 class="answer__title">
                                                     <span class="answer__source">
-                                                      <span class="answer__source__label sr">Assessor: </span>
-                                                      <span class="answer__source__value">Peer {{ peer_num }}</span>
+                                                      <span class="answer__source__label sr">{% trans "Assessor" %}: </span>
+                                                      <span class="answer__source__value">
+                                                      {% blocktrans with peer_num=peer_num%}
+                                                      Peer {{ peer_num }}
+                                                      {% endblocktrans %}
+                                                      </span>
                                                     </span>
                                                     <span class="answer__value">
-                                                        <span class="answer__value__label sr">Peer's Assessment: </span>
+                                                        <span class="answer__value__label sr">{% trans "Peer's Assessment" %}: </span>
                                                         <span class="answer__value__value">
                                                             {{ part.option.name }}
 
                                                             <span class="ui-hint hint--top" data-hint="{{ part.option.explanation }}">
-                                                              <i class="ico icon-info-sign" title="More information about {{ part.option.name }}"></i>
+                                                              <i class="ico icon-info-sign"
+                                                                 title="{% blocktrans with name=part.option.name %}More information about {{ name }}{% endblocktrans %}"></i>
                                                             </span>
                                                         </span>
                                                     </span>
                                                 </h5>
                                                 <span class="answer__score">
-                                                    <span class="answer__score__label sr">Grade Earned: </span>
-                                                    <span class="answer__score__value">{{ part.option.points }} points</span>
+                                                    <span class="answer__score__label sr">{% trans "Grade Earned" %}: </span>
+                                                    <span class="answer__score__value">{{ part.option.points }} {% trans "points" %}</span>
                                                 </span>
                                             </li>
                                             {% endif %}
@@ -85,15 +97,16 @@
                                     id="question--{{ criterion_num }}__answer--self">
                                     <h5 class="answer__title">
                                         <span class="answer__source">
-                                          <span class="answer__source__value">Your Self Assessment</span>
+                                          <span class="answer__source__value">{% trans "Your Self Assessment" %}</span>
                                         </span>
                                         <span class="answer__value">
-                                            <span class="answer__value__label sr">Your Assessment: </span>
+                                            <span class="answer__value__label sr">{% trans "Your Assessment" %}: </span>
                                             <span class="answer__value__value">
                                                 {{ part.option.name }}
 
                                                 <span class="ui-hint hint--top" data-hint="{{ part.option.explanation }}">
-                                                  <i class="ico icon-info-sign" title="More information about {{ part.option.name }}"></i>
+                                                  <i class="ico icon-info-sign"
+                                                     title="{% blocktrans with name=part.option.name %}More information about {{ name }}{% endblocktrans %}"></i>
                                                 </span>
                                             </span>
                                         </span>
@@ -108,7 +121,7 @@
                         <li class="question question--feedback ui-toggle-visibility">
                             <h4 class="question__title ui-toggle-visibility__control">
                                 <i class="ico icon-caret-right"></i>
-                                <span class="question__title__copy">Additional feedback on your response</span>
+                                <span class="question__title__copy">{% trans "Additional feedback on your response" %}</span>
                             </h4>
 
                             <ul class="question__answers ui-toggle-visibility__content">
@@ -118,13 +131,13 @@
                                 <li class="answer peer-evaluation--{{ peer_num }}" id="question--feedback__answer-{{ peer_num }}">
                                     <h5 class="answer__title">
                                         <span class="answer__source">
-                                          <span class="label sr">Peer assessor: </span>
-                                          <span class="value">Peer {{ peer_num }}</span>
+                                          <span class="label sr">{% trans "Peer assessor" %}: </span>
+                                          <span class="value">{% blocktrans with peer_num=peer_num %}Peer {{ peer_num }}{% endblocktrans %}</span>
                                         </span>
                                     </h5>
 
                                     <div class="answer__value">
-                                        <h6 class="label sr">Peer's assessment: </h6>
+                                        <h6 class="label sr">{% trans "Peer's assessment" %}: </h6>
                                         <div class="value">
                                             <p>{{ assessment.feedback }}</p>
                                         </div>
@@ -141,7 +154,7 @@
                 <form id="submission__feedback" class="submission__feedback ui-toggle-visibility step__content__section is--collapsed" method="post">
                     <h3 class="submission__feedback__title ui-toggle-visibility__control">
                         <i class="ico icon-caret-right"></i>
-                        <span class="submission__feedback__title__copy">Provide Feedback on Peer Assessments</span>
+                        <span class="submission__feedback__title__copy">{% trans "Provide Feedback on Peer Assessments" %}</span>
                     </h3>
 
                     <div class="ui-toggle-visibility__content">
@@ -150,27 +163,27 @@
                             <span class="transition__status is--hidden" aria-hidden="true">
                                 <span class="wrapper--anim">
                                     <i class="ico icon-refresh icon-spin"></i>
-                                    <span class="copy">Submitting Feedback</span>
+                                    <span class="copy">{% trans "Submitting Feedback" %}</span>
                                 </span>
                             </span>
 
                             <div class="message message--complete {{ has_submitted_feedback|yesno:",is--hidden" }}"
                                 {{ has_submitted_feedback|yesno:'aria-hidden=false,aria-hidden=true' }}>
-                                <h3 class="message__title">Your Feedback Has Been Submitted</h3>
+                                <h3 class="message__title">{% trans "Your Feedback Has Been Submitted" %}</h3>
                                 <div class="message__content">
-                                    <p>Your feedback has been submitted. Course staff will be able to see this feedback when they review course records.</p>
+                                    <p>{% trans "Your feedback has been submitted. Course staff will be able to see this feedback when they review course records." %}</p>
                                 </div>
                             </div>
 
                             <div class="submission__feedback__instructions {{ has_submitted_feedback|yesno:"is--hidden," }}"
                                 {{ has_submitted_feedback|yesno:'aria-hidden=true,aria-hidden=false' }}>
-                                <p>Course staff will be able to see any feedback that you provide here when they review course records.</p>
+                                <p>{% trans "Course staff will be able to see any feedback that you provide here when they review course records." %}</p>
                             </div>
 
                             <ol class="list list--fields submission__feedback__fields {{ has_submitted_feedback|yesno:"is--hidden," }}"
                                 {{ has_submitted_feedback|yesno:'aria-hidden=true,aria-hidden=false' }}>
                                 <li class="field field-group field--radio feedback__overall" id="feedback__overall">
-                                    <h4 class="field-group__label">Select the statements below that best reflect your experience with peer assessments:</h4>
+                                    <h4 class="field-group__label">{% trans "Select the statements below that best reflect your experience with peer assessments" %}:</h4>
                                     <ol class="list--options">
                                         <li class="option option--useful">
                                             <input type="checkbox"
@@ -178,7 +191,7 @@
                                                 id="feedback__overall__value--useful"
                                                 class="option__input feedback__overall__value"
                                                 value="These assessments were useful." />
-                                            <label class="option__label" for="feedback__overall__value--useful">These assessments were useful.</label>
+                                            <label class="option__label" for="feedback__overall__value--useful">{% trans "These assessments were useful." %}</label>
                                         </li>
                                         <li class="option option--notuseful">
                                             <input type="checkbox"
@@ -186,7 +199,7 @@
                                                 id="feedback__overall__value--notuseful"
                                                 class="option__input feedback__overall__value"
                                                 value="These assessments were not useful." />
-                                            <label class="option__label" for="feedback__overall__value--notuseful">These assessments were not useful.</label>
+                                            <label class="option__label" for="feedback__overall__value--notuseful">{% trans "These assessments were not useful." %}</label>
                                         </li>
                                         <li class="option option--disagree">
                                             <input type="checkbox"
@@ -194,7 +207,7 @@
                                                 id="feedback__overall__value--disagree"
                                                 class="option__input feedback__overall__value"
                                                 value="I disagree with one or more of the peer assessments of my response." />
-                                            <label class="option__label" for="feedback__overall__value--disagree">I disagree with one or more of the peer assessments of my response.</label>
+                                            <label class="option__label" for="feedback__overall__value--disagree">{% trans "I disagree with one or more of the peer assessments of my response." %}</label>
                                         </li>
                                         <li class="option option--inappropriate">
                                             <input type="checkbox"
@@ -202,26 +215,26 @@
                                                 id="feedback__overall__value--inappropriate"
                                                 class="option__input feedback__overall__value"
                                                 value="Some comments I received were inappropriate." />
-                                            <label class="option__label" for="feedback__overall__value--inappropriate">Some comments I received were inappropriate.</label>
+                                            <label class="option__label" for="feedback__overall__value--inappropriate">{% trans "Some comments I received were inappropriate." %}</label>
                                         </li>
                                     </ol>
                                 </li>
                                 <li class="field field--textarea feedback__remarks" id="feedback__remarks">
-                                    <label for="feedback__remarks__value">Please provide any feedback on the grade or comments that you received from your peers.</label>
-                                    <textarea id="feedback__remarks__value" placeholder="I feel the feedback I received was...">{{ feedback_text }}</textarea>
+                                    <label for="feedback__remarks__value">{% trans "Please provide any feedback on the grade or comments that you received from your peers." %}</label>
+                                    <textarea id="feedback__remarks__value" placeholder="{% trans "I feel the feedback I received was..." %}">{{ feedback_text }}</textarea>
                                 </li>
                             </ol>
 
                             <div class="submission__feedback__actions {{ has_submitted_feedback|yesno:"is--hidden," }}"
                                 {{ has_submitted_feedback|yesno:'aria-hidden=true,aria-hidden=false' }}>
                                 <div class="message message--inline message--error message--error-server">
-                                    <h3 class="message__title">We could not submit your feedback</h3>
+                                    <h3 class="message__title">{% trans "We could not submit your feedback" %}</h3>
                                     <div class="message__content"></div>
                                 </div>
 
                                 <ul class="list list--actions submission__feedback__actions">
                                     <li class="list--actions__item">
-                                        <button type="submit" id="feedback__submit" class="action action--submit feedback__submit">Submit Feedback on Peer Assessments</button>
+                                        <button type="submit" id="feedback__submit" class="action action--submit feedback__submit">{% trans "Submit Feedback on Peer Assessments" %}</button>
                                     </li>
                                 </ul>
                             </div>

--- a/apps/openassessment/templates/openassessmentblock/grade/oa_grade_incomplete.html
+++ b/apps/openassessment/templates/openassessmentblock/grade/oa_grade_incomplete.html
@@ -1,11 +1,12 @@
+{% load i18n %}
 {% spaceless %}
 <li id="openassessment__grade" class="openassessment__steps__step step--grade">
     <header class="step__header ui-toggle-visibility__control">
         <h2 class="step__title">
             <span class="wrapper--copy">
-                <span class="step__label">Your Grade: </span>
+                <span class="step__label">{% trans "Your Grade" %}: </span>
                 <span class="grade__value">
-                    <span class="grade__value__title">Not Completed</span>
+                    <span class="grade__value__title">{% trans "Not Completed" %}</span>
                 </span>
             </span>
         </h2>
@@ -15,7 +16,7 @@
         <div class="wrapper--step__content">
             <div class="step__content">
                 <div class="grade__value__description">
-                    <p>You have not completed the {% for step in incomplete_steps %}<span class="step">{{ step }} step </span> {% if not forloop.last %} and {% endif %}{% endfor %} of this problem.</p>
+                    <p>{% trans "You have not completed all the steps of this problem." %}</p>
                 </div>
             </div>
         </div>

--- a/apps/openassessment/templates/openassessmentblock/grade/oa_grade_not_started.html
+++ b/apps/openassessment/templates/openassessmentblock/grade/oa_grade_not_started.html
@@ -1,11 +1,12 @@
+{% load i18n %}
 {% spaceless %}
 <li id="openassessment__grade" class="openassessment__steps__step step--grade is--unstarted">
     <header class="step__header ui-toggle-visibility__control">
         <h2 class="step__title">
             <span class="wrapper--copy">
-                <span class="step__label">Your Grade:</span>
+                <span class="step__label">{% trans "Your Grade" %}:</span>
                 <span class="grade__value">
-                    <span class="grade__value__title">Not Started</span>
+                    <span class="grade__value__title">{% trans "Not Started" %}</span>
                 </span>
             </span>
         </h2>
@@ -15,7 +16,7 @@
         <div class="wrapper--step__content">
             <div class="step__content">
                 <div class="grade__value__description">
-                    <p>You have not started this problem yet.</p>
+                    <p>{% trans "You have not started this problem yet." %}</p>
                 </div>
             </div>
         </div>

--- a/apps/openassessment/templates/openassessmentblock/grade/oa_grade_waiting.html
+++ b/apps/openassessment/templates/openassessmentblock/grade/oa_grade_waiting.html
@@ -1,11 +1,12 @@
+{% load i18n %}
 {% spaceless %}
 <li id="openassessment__grade" class="openassessment__steps__step step--grade">
     <header class="step__header ui-toggle-visibility__control">
         <h2 class="step__title">
             <span class="wrapper--copy">
-                <span class="step__label">Your Grade:</span>
+                <span class="step__label">{% trans "Your Grade" %}:</span>
                 <span class="grade__value">
-                    <span class="grade__value__title">Waiting for Peer Assessment</span>
+                    <span class="grade__value__title">{% trans "Waiting for Peer Assessment" %}</span>
                 </span>
             </span>
         </h2>
@@ -15,7 +16,7 @@
         <div class="wrapper--step__content">
             <div class="step__content">
                 <div class="grade__value__description">
-                    <p>Your response is still undergoing peer assessment. After your peers have assessed your response, you'll see their comments and receive your final grade.</p>
+                    <p>{% trans "Your response is still undergoing peer assessment. After your peers have assessed your response, you'll see their comments and receive your final grade." %}</p>
                 </div>
             </div>
         </div>

--- a/apps/openassessment/templates/openassessmentblock/oa_base.html
+++ b/apps/openassessment/templates/openassessmentblock/oa_base.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% spaceless %}
 <div class="wrapper wrapper--xblock wrapper--openassessment theme--basic">
     <div class="openassessment problem" id="openassessment">
@@ -5,7 +6,7 @@
             <h2 class="openassessment__title problem__header">{{ title }}</h2>
 
             <nav class="nav--contents">
-                <h2 class="title">Skip to a specific step</h2>
+                <h2 class="title">{% trans "Skip to a specific step" %}</h2>
 
                 <ol class="list list--nav">
                     {%  for assessment in rubric_assessments %}
@@ -14,7 +15,7 @@
                     </li>
                     {% endfor %}
                     <li class="list--nav__item">
-                        <a class="action" href="#openassessment__grade">Your grade for this problem</a>
+                        <a class="action" href="#openassessment__grade">{% trans "Your grade for this problem" %}</a>
                     </li>
                 </ol>
             </nav>
@@ -23,14 +24,14 @@
             <!-- if the problem is unstarted or response hasn't been submitted -->
             <div id="openassessment__message" class="openassessment__message message">
                 <div class="message__content">
-                    <p>This assignment has several steps. In the first step, you'll provide a response to the question. The other steps appear below the <strong>Your Response</strong> field.</p>
+                    <p>{% trans "This assignment has several steps. In the first step, you'll provide a response to the question. The other steps appear below the <strong>Your Response</strong> field." %}</p>
                 </div>
             </div>
             {% endblock %}
 
             <div class="wrapper--openassessment__prompt">
                 <article class="openassessment__prompt ui-toggle-visibility">
-                    <h2 class="openassessment__prompt__title">The prompt for this assignment</h2>
+                    <h2 class="openassessment__prompt__title">{% trans "The prompt for this assignment" %}</h2>
 
                     <div class="openassessment__prompt__copy ui-toggle-visibility__content">
                         {{ question|linebreaks }}
@@ -51,10 +52,10 @@
 
 
                             <span class="step__status">
-                                <span class="step__status__label">This step's status:</span>
+                                <span class="step__status__label">{% trans "This step's status:" %}</span>
                                 <span class="step__status__value">
                                   <i class="ico icon-refresh icon-spin"></i>
-                                  <span class="copy">Loading</span>
+                                  <span class="copy">{% trans "Loading" %}</span>
                                 </span>
                             </span>
                         </header>

--- a/apps/openassessment/templates/openassessmentblock/oa_edit.html
+++ b/apps/openassessment/templates/openassessmentblock/oa_edit.html
@@ -3,6 +3,6 @@
 <div id="openassessment-edit">
     <script id="metadata-editor-tpl" type="text/template"><!-- empty --></script>
     <textarea class="openassessment-editor"></textarea>
-    <input type="button" class="openassessment-save-button" value="{% trans 'Save' %}"/>
-    <input type="button" class="openassessment-cancel-button" value="{% trans 'Cancel' %}"/>
+    <input type="button" class="openassessment-save-button" value="{% trans "Save" %}"/>
+    <input type="button" class="openassessment-cancel-button" value="{% trans "Cancel" %}"/>
 </div>

--- a/apps/openassessment/templates/openassessmentblock/peer/oa_peer_assessment.html
+++ b/apps/openassessment/templates/openassessmentblock/peer/oa_peer_assessment.html
@@ -1,4 +1,5 @@
 {% load tz %}
+{% load i18n %}
 {% block list_item %}
 <li id="openassessment__peer-assessment" class="openassessment__steps__step step--peer-assessment ui-toggle-visibility">
 {% endblock %}
@@ -11,16 +12,16 @@
         <h2 class="step__title">
             <span class="step__counter"></span>
             <span class="wrapper--copy">
-                <span class="step__label">Assess Peers</span>
+                <span class="step__label">{% trans "Assess Peers" %}</span>
                 {% if peer_start %}
-                <span class="step__deadline">available
+                <span class="step__deadline">{% trans "available" %}
                     <span class="date">
                         {{ peer_start|utc|date:"N j, Y H:i e" }}
                         (in {{ peer_start|timeuntil }})
                     </span>
                 </span>
                 {% elif peer_due %}
-                <span class="step__deadline">due
+                <span class="step__deadline">{% trans "due" %}
                     <span class="date">
                         {{ peer_due|utc|date:"N j, Y H:i e" }}
                         (in {{ peer_due|timeuntil }})
@@ -32,10 +33,10 @@
 
         {% block title %}
         <span class="step__status">
-          <span class="step__status__label">This step's status:</span>
+          <span class="step__status__label">{% trans "This step's status" %}:</span>
           <span class="step__status__value">
             <span class="copy">
-                In Progress
+                {% trans "In Progress" %}
                 (<span class="step__status__value--completed">{{ graded }}</span> of
                 <span class="step__status__value--required">{{ must_grade }}</span>)
             </span>
@@ -48,7 +49,7 @@
     <div class="ui-toggle-visibility__content">
         <div class="wrapper--step__content">
             <div class="step__instruction">
-                <p>Read and assess the following response from one of your peers.</p>
+                <p>{% trans "Read and assess the following response from one of your peers." %}</p>
             </div>
 
             <div class="step__content">
@@ -57,7 +58,7 @@
                         <article class="peer-assessment" id="peer-assessment--001">
                             <div class="peer-assessment__display">
                                 <header class="peer-assessment__display__header">
-                                    <h3 class="peer-assessment__display__title">Assessment #
+                                    <h3 class="peer-assessment__display__title">{% trans "Assessment #" %}
                                         <span class="peer-assessment__number--current">{{ review_num }}</span> of
                                         <span class="peer-assessment__number--required">{{ must_grade }}</span>
                                     </h3>
@@ -77,7 +78,7 @@
                                             <h4 class="question__title ui-toggle-visibility__control">
                                                 <i class="ico icon-caret-right"></i>
                                                 <span class="ui-toggle-visibility__control__copy question__title__copy">{{ criterion.prompt }}</span>
-                                                <span class="label--required sr">* (Required)</span>
+                                                <span class="label--required sr">* ({% trans "Required" %})</span>
                                             </h4>
 
                                             <div class="ui-toggle-visibility__content">
@@ -96,7 +97,7 @@
                                                         </div>
                                                         <div class="wrapper--metadata">
                                                             <span class="answer__tip">{{ option.explanation }}</span>
-                                                            <span class="answer__points">{{option.points}} <span class="answer__points__label">points</span></span>
+                                                            <span class="answer__points">{{option.points}} <span class="answer__points__label">{% trans "points" %}</span></span>
                                                         </div>
                                                     </li>
                                                     {% endfor %}
@@ -107,11 +108,11 @@
 
                                         <li class="wrapper--input field field--textarea assessment__rubric__question assessment__rubric__question--feedback" id="assessment__rubric__question--feedback">
                                             <label class="question__title" for="assessment__rubric__question--feedback__value">
-                                                <span class="question__title__copy">(Optional) What aspects of this response stood out to you? What did it do well? How could it improve?</span>
+                                                <span class="question__title__copy">{% trans "(Optional) What aspects of this response stood out to you? What did it do well? How could it improve?" %}</span>
                                             </label>
 
                                             <div class="wrapper--input">
-                                                <textarea id="assessment__rubric__question--feedback__value" placeholder="I noticed that this response..."></textarea>
+                                                <textarea id="assessment__rubric__question--feedback__value" placeholder="{% trans "I noticed that this response..." %}"></textarea>
                                             </div>
                                         </li>
                                     </ol>
@@ -124,7 +125,7 @@
 
             <div class="step__actions">
                 <div class="message message--inline message--error message--error-server">
-                    <h3 class="message__title">We could not submit your assessment</h3>
+                    <h3 class="message__title">{% trans "We could not submit your assessment" %}</h3>
                     <div class="message__content"></div>
                 </div>
 

--- a/apps/openassessment/templates/openassessmentblock/peer/oa_peer_closed.html
+++ b/apps/openassessment/templates/openassessmentblock/peer/oa_peer_closed.html
@@ -1,4 +1,5 @@
 {%  extends "openassessmentblock/peer/oa_peer_assessment.html" %}
+{% load i18n %}
 
 {% block list_item %}
 <li id="openassessment__peer-assessment"class="openassessment__steps__step step--peer-assessment is--incomplete ui-toggle-visibility">
@@ -6,11 +7,11 @@
 
 {% block title %}
 <span class="step__status">
-  <span class="step__status__label">This step's status:</span>
+  <span class="step__status__label">{% trans "This step's status" %}:</span>
   <span class="step__status__value">
     <span class="copy">
     <i class="ico icon-warning-sign"></i>
-      Incomplete
+      {% trans "Incomplete" %}
       (<span class="step__status__value--completed">{{ graded }}</span> of
       <span class="step__status__value--required">{{ must_grade }}</span>)
     </span>
@@ -23,9 +24,9 @@
     <div class="wrapper--step__content">
 
         <div class="step__message message message--incomplete">
-            <h3 class="message__title">The Due Date for This Step Has Passed</h3>
+            <h3 class="message__title">{% trans "The Due Date for This Step Has Passed" %}</h3>
             <div class="message__content">
-              <p>This step is now closed. You can no longer complete peer assessments or continue with this assignment, and you'll receive a grade of Incomplete.</p>
+              <p>{% trans "This step is now closed. You can no longer complete peer assessments or continue with this assignment, and you'll receive a grade of Incomplete." %}</p>
             </div>
         </div>
     </div>

--- a/apps/openassessment/templates/openassessmentblock/peer/oa_peer_complete.html
+++ b/apps/openassessment/templates/openassessmentblock/peer/oa_peer_complete.html
@@ -1,4 +1,5 @@
 {%  extends "openassessmentblock/peer/oa_peer_assessment.html" %}
+{% load i18n %}
 
 {% block list_item %}
 <li id="openassessment__peer-assessment" class="openassessment__steps__step step--peer-assessment ui-toggle-visibility is--empty is--complete is--collapsed">
@@ -6,11 +7,11 @@
 
 {% block title %}
 <span class="step__status">
-  <span class="step__status__label">This step's status:</span>
+  <span class="step__status__label">{% trans "This step's status" %}:</span>
   <span class="step__status__value">
     <i class="ico icon-ok"></i>
     <span class="copy">
-      Complete
+      {% trans "Complete" %}
       (<span class="step__status__value--completed">{{ graded }}</span> of
       <span class="step__status__value--required">{{ must_grade }}</span>)
     </span>

--- a/apps/openassessment/templates/openassessmentblock/peer/oa_peer_turbo_mode.html
+++ b/apps/openassessment/templates/openassessmentblock/peer/oa_peer_turbo_mode.html
@@ -1,4 +1,5 @@
-{%  extends "openassessmentblock/peer/oa_peer_assessment.html" %}
+{% extends "openassessmentblock/peer/oa_peer_assessment.html" %}
+{% load i18n %}
 
 {% block list_item %}
 <li id="openassessment__peer-assessment"class="openassessment__steps__step step--peer-assessment ui-toggle-visibility is--complete">
@@ -6,11 +7,11 @@
 
 {% block title %}
 <span class="step__status">
-  <span class="step__status__label">This step's status:</span>
+  <span class="step__status__label">{% trans "This step's status" %}:</span>
   <span class="step__status__value">
     <i class="ico icon-ok"></i>
     <span class="copy">
-      Complete
+      {% trans "Complete" %}
       (<span class="step__status__value--completed">{{ graded }}</span>)
     </span>
   </span>
@@ -22,12 +23,12 @@
     <div class="wrapper--step__content">
 
         <div class="step__message message message--complete">
-            <h3 class="message__title">Peer Assessments Complete</h3>
-            <div class="message__content">You have successfully completed all of the required peer assessments for this assignment. You may assess additional peer responses if you want to. Completing additional assessments will not affect your final grade.</div>
+            <h3 class="message__title">{% trans "Peer Assessments Complete" %}</h3>
+            <div class="message__content">{% trans "You have successfully completed all of the required peer assessments for this assignment. You may assess additional peer responses if you want to. Completing additional assessments will not affect your final grade." %}</div>
         </div>
 
         <div class="step__instruction">
-            <p>Read and assess the following response from one of your peers.</p>
+            <p>{% trans "Read and assess the following response from one of your peers." %}</p>
         </div>
 
         <div class="step__content">
@@ -36,7 +37,7 @@
                     <article class="peer-assessment" id="peer-assessment--001">
                         <div class="peer-assessment__display">
                             <header class="peer-assessment__display__header">
-                                <h3 class="peer-assessment__display__title">Assessment #
+                                <h3 class="peer-assessment__display__title">{% trans "Assessment #" %}
                                     <span class="peer-assessment__number--current">{{ review_num }}</span> of
                                     <span class="peer-assessment__number--required">{{ must_grade }}</span>
                                 </h3>
@@ -56,7 +57,7 @@
                                         <h4 class="question__title ui-toggle-visibility__control">
                                             <i class="ico icon-caret-right"></i>
                                             <span class="ui-toggle-visibility__control__copy question__title__copy">{{ criterion.prompt }}</span>
-                                            <span class="label--required sr">* (Required)</span>
+                                            <span class="label--required sr">* ({% trans "Required" %})</span>
                                         </h4>
 
                                         <div class="ui-toggle-visibility__content">
@@ -75,7 +76,7 @@
                                                     </div>
                                                     <div class="wrapper--metadata">
                                                         <span class="answer__tip">{{ option.explanation }}</span>
-                                                        <span class="answer__points">{{option.points}} <span class="answer__points__label">points</span></span>
+                                                        <span class="answer__points">{{option.points}} <span class="answer__points__label">{% trans "points" %}</span></span>
                                                     </div>
                                                 </li>
                                                 {% endfor %}
@@ -86,10 +87,10 @@
 
                                     <li class="wrapper--input field field--textarea assessment__rubric__question assessment__rubric__question--feedback" id="assessment__rubric__question--feedback">
                                         <label class="question__title" for="assessment__rubric__question--feedback__value">
-                                            <span class="question__title__copy">(Optional) What aspects of this response stood out to you? What did it do well? How could it improve?</span>
+                                            <span class="question__title__copy">{% trans "(Optional) What aspects of this response stood out to you? What did it do well? How could it improve?" %}</span>
                                         </label>
                                         <div class="wrapper--input">
-                                            <textarea id="assessment__rubric__question--feedback__value" placeholder="I felt this response was..."></textarea>
+                                            <textarea id="assessment__rubric__question--feedback__value" placeholder="{% trans "I felt this response was..." %}"></textarea>
                                         </div>
                                     </li>
                                 </ol>
@@ -102,7 +103,7 @@
 
         <div class="step__actions">
             <div class="message message--inline message--error message--error-server">
-                <h3 class="message__title">We could not submit your assessment</h3>
+                <h3 class="message__title">{% trans "We could not submit your assessment" %}</h3>
             </div>
 
             <ul class="list list--actions">

--- a/apps/openassessment/templates/openassessmentblock/peer/oa_peer_turbo_mode_waiting.html
+++ b/apps/openassessment/templates/openassessmentblock/peer/oa_peer_turbo_mode_waiting.html
@@ -1,4 +1,5 @@
 {%  extends "openassessmentblock/peer/oa_peer_assessment.html" %}
+{% load i18n %}
 
 {% block list_item %}
 <li id="openassessment__peer-assessment" class="openassessment__steps__step step--peer-assessment ui-toggle-visibility is--complete">
@@ -6,7 +7,7 @@
 
 {% block title %}
 <span class="step__status">
-  <span class="step__status__label">This step's status:</span>
+  <span class="step__status__label">{% trans "This step's status" %}:</span>
   <span class="step__status__value">
     <i class="ico icon-ok"></i>
     <span class="copy">
@@ -22,11 +23,11 @@
     <div class="wrapper--step__content">
 
         <div class="step__message message message--complete">
-            <h3 class="message__title">Peer Assessments Complete</h3>
+            <h3 class="message__title">{% trans "Peer Assessments Complete" %}</h3>
             <div class="message__content">
-              <p>You have successfully completed all of the required peer assessments for this assignment. You may assess additional peer responses if you want to. Completing additional assessments will not affect your final grade.</p>
+              <p>{% trans "You have successfully completed all of the required peer assessments for this assignment. You may assess additional peer responses if you want to. Completing additional assessments will not affect your final grade." %}</p>
 
-              <p><strong>All submitted peer responses have been assessed. Check back later to see if more students have submitted responses.</strong></p>
+              <p><strong>{% trans "All submitted peer responses have been assessed. Check back later to see if more students have submitted responses." %}</strong></p>
             </div>
         </div>
     </div>

--- a/apps/openassessment/templates/openassessmentblock/peer/oa_peer_unavailable.html
+++ b/apps/openassessment/templates/openassessmentblock/peer/oa_peer_unavailable.html
@@ -1,4 +1,5 @@
-{%  extends "openassessmentblock/peer/oa_peer_assessment.html" %}
+{% extends "openassessmentblock/peer/oa_peer_assessment.html" %}
+{% load i18n %}
 
 {% block list_item %}
 <li id="openassessment__peer-assessment" class="openassessment__steps__step step--peer-assessment is--unavailable is--empty is--collapsed">
@@ -6,9 +7,9 @@
 
 {% block title %}
 <span class="step__status">
-  <span class="step__status__label">This step's status:</span>
+  <span class="step__status__label">{% trans "This step's status" %}:</span>
   <span class="step__status__value">
-    <span class="copy">Not Available</span>
+    <span class="copy">{% trans "Not Available" %}</span>
   </span>
 </span>
 {% endblock %}

--- a/apps/openassessment/templates/openassessmentblock/peer/oa_peer_waiting.html
+++ b/apps/openassessment/templates/openassessmentblock/peer/oa_peer_waiting.html
@@ -1,4 +1,5 @@
-{%  extends "openassessmentblock/peer/oa_peer_assessment.html" %}
+{% extends "openassessmentblock/peer/oa_peer_assessment.html" %}
+{% load i18n %}
 
 {% block list_item %}
 <li id="openassessment__peer-assessment" class="openassessment__steps__step step--peer-assessment">
@@ -6,10 +7,10 @@
 
 {% block title %}
 <span class="step__status">
-  <span class="step__status__label">This step's status:</span>
+  <span class="step__status__label">{% trans "This step's status" %}:</span>
   <span class="step__status__value">
     <span class="copy">
-        In Progress
+        {% trans "In Progress" %}
         (<span class="step__status__value--completed">{{ graded }}</span> of
         <span class="step__status__value--required">{{ must_grade }}</span>)
     </span>
@@ -22,10 +23,10 @@
     <div class="wrapper--step__content">
 
         <div class="step__message message message--incomplete">
-            <h3 class="message__title">Waiting for Peer Responses</h3>
+            <h3 class="message__title">{% trans "Waiting for Peer Responses" %}</h3>
 
             <div class="message__content">
-              <p>All submitted peer responses have been assessed. Check back later to see if more students have submitted responses. You'll receive your grade after you complete the <a data-behavior="ui-scroll" href="#openassessment__peer-assessment">peer assessment</a> and <a data-behavior="ui-scroll" href="#openassessment__self-assessment">self assessment</a> steps, and after your peers have assessed your response.</p>
+              <p>{% blocktrans %}All submitted peer responses have been assessed. Check back later to see if more students have submitted responses. You'll receive your grade after you complete the <a data-behavior="ui-scroll" href="#openassessment__peer-assessment">peer assessment</a> and <a data-behavior="ui-scroll" href="#openassessment__self-assessment">self assessment</a> steps, and after your peers have assessed your response.{% endblocktrans %}</p>
             </div>
         </div>
     </div>

--- a/apps/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/apps/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -1,4 +1,5 @@
 {% load tz %}
+{% load i18n %}
 {% spaceless %}
 {% block list_item %}
 <li id="openassessment__response" class="openassessment__steps__step step--response ui-toggle-visibility">
@@ -8,7 +9,7 @@
         <h2 class="step__title">
             <span class="step__counter"></span>
             <span class="wrapper--copy">
-                <span class="step__label">Your Response</span>
+                <span class="step__label">{% trans "Your Response" %}</span>
                 {% if submission_start %}
                 <span class="step__deadline">available
                     <span class="date">
@@ -29,9 +30,9 @@
 
         {%  block title %}
         <span class="step__status">
-            <span class="step__status__label">This step's status:</span>
+            <span class="step__status__label">{% trans "This step's status" %}:</span>
             <span class="step__status__value">
-                <span class="copy">In Progress</span>
+                <span class="copy">{% trans "In Progress" %}</span>
             </span>
         </span>
         {% endblock %}
@@ -42,13 +43,13 @@
         <div class="wrapper--step__content">
             <div class="step__instruction">
                 <p>
-                    Enter your response to the question.
+                    {% trans "Enter your response to the question." %}
                     {% if submission_due %}
-                    You can save your progress and return to complete your response at any time before the due date (<span class="step__deadline"><span class="date">{{ submission_due|utc|date:"l, N j, Y H:i e" }}</span></span>).
+                    {% trans "You can save your progress and return to complete your response at any time before the due date" %} (<span class="step__deadline"><span class="date">{{ submission_due|utc|date:"l, N j, Y H:i e" }}</span></span>).
                     {% else %}
-                    You can save your progress and return to complete your response at any time.
+                    {% trans "You can save your progress and return to complete your response at any time." %}
                     {% endif %}
-                    <strong class="emphasis">After you submit your response, you cannot edit it</strong>.
+                    <strong class="emphasis">{% trans "After you submit your response, you cannot edit it" %}</strong>.
                 </p>
             </div>
 
@@ -56,15 +57,15 @@
                 <form id="response__submission" class="response__submission">
                     <ol class="list list--fields response__submission__content">
                         <li class="field field--textarea submission__answer" id="submission__answer">
-                            <label class="sr" for="submission__answer__value">Enter your response to the question.</label>
+                            <label class="sr" for="submission__answer__value">{% trans "Enter your response to the question." %}</label>
                             <textarea id="submission__answer__value" placeholder="">{{ saved_response }}</textarea>
-                            <span class="tip">You may continue to work on your response until you submit it.</span>
+                            <span class="tip">{% trans "You may continue to work on your response until you submit it." %}</span>
                         </li>
                     </ol>
 
                     <div class="response__submission__actions">
                         <div class="message message--inline message--error message--error-server">
-                            <h3 class="message__title">We could not save your progress</h3>
+                            <h3 class="message__title">{% trans "We could not save your progress" %}</h3>
                             <div class="message__content"></div>
                         </div>
 
@@ -74,7 +75,7 @@
 
                                 <div id="response__save_status" class="response__submission__status">
                                     <h3 class="response__submission__status__title">
-                                        <span class="sr">Your Submission Status:</span>
+                                        <span class="sr">{% trans "Your Submission Status" %}:</span>
                                         {{ save_status }}
                                     </h3>
                                 </div>
@@ -86,7 +87,7 @@
 
             <div class="step__actions">
                 <div class="message message--inline message--error message--error-server">
-                    <h3 class="message__title">We could not submit your response</h3>
+                    <h3 class="message__title">{% trans "We could not submit your response" %}</h3>
                     <div class="message__content"></div>
                 </div>
 
@@ -94,7 +95,7 @@
                     <li class="list--actions__item">
                         <a aria-role="button" href="#" id="step--response__submit"
                             class="action action--submit step--response__submit {{ submit_enabled|yesno:",is--disabled" }}">
-                            <span class="copy">Submit your response and move to the next step</span>
+                            <span class="copy">{% trans "Submit your response and move to the next step" %}</span>
                             <i class="ico icon-caret-right"></i>
                         </a>
                     </li>

--- a/apps/openassessment/templates/openassessmentblock/response/oa_response_closed.html
+++ b/apps/openassessment/templates/openassessmentblock/response/oa_response_closed.html
@@ -1,14 +1,15 @@
 {%  extends "openassessmentblock/response/oa_response.html" %}
+{% load i18n %}
 {% block list_item %}
 <li id="openassessment__response" class="openassessment__steps__step step--response is--incomplete ui-toggle-visibility">
 {% endblock %}
 
 {% block title %}
 <span class="step__status">
-  <span class="step__status__label">This step's status:</span>
+  <span class="step__status__label">{% trans "This step's status" %}:</span>
   <span class="step__status__value">
     <i class="ico icon-warning-sign"></i>
-    <span class="copy">Incomplete</span>
+    <span class="copy">{% trans "Incomplete" %}</span>
   </span>
 </span>
 {% endblock %}
@@ -18,10 +19,10 @@
     <div class="wrapper--step__content">
 
         <div class="step__message message message--incomplete">
-            <h3 class="message__title">The Due Date for This Step Has Passed</h3>
+            <h3 class="message__title">{% trans "The Due Date for This Step Has Passed" %}</h3>
 
             <div class="message__content">
-              <p>This step is now closed. You can no longer submit a response or continue with this problem, and you'll receive a grade of Incomplete. If you saved but did not submit a response, the response appears in the course records.</p>
+              <p>{% trans "This step is now closed. You can no longer submit a response or continue with this problem, and you'll receive a grade of Incomplete. If you saved but did not submit a response, the response appears in the course records." %}</p>
             </div>
         </div>
     </div>

--- a/apps/openassessment/templates/openassessmentblock/response/oa_response_graded.html
+++ b/apps/openassessment/templates/openassessmentblock/response/oa_response_graded.html
@@ -1,4 +1,5 @@
 {% extends "openassessmentblock/response/oa_response.html" %}
+{% load i18n %}
 
 {% block list_item %}
 <li id="openassessment__response" class="openassessment__steps__step step--response is--complete ui-toggle-visibility is--collapsed">
@@ -6,10 +7,10 @@
 
 {% block title %}
 <span class="step__status">
-  <span class="step__status__label">This step's status:</span>
+  <span class="step__status__label">{% trans "This step's status" %}:</span>
   <span class="step__status__value">
     <i class="ico icon-ok"></i>
-    <span class="copy">Complete</span>
+    <span class="copy">{% trans "Complete" %}</span>
   </span>
 </span>
 {% endblock %}
@@ -19,7 +20,7 @@
     <div class="wrapper--step__content">
         <div class="step__content">
             <article class="submission__answer__display">
-                <h3 class="submission__answer__display__title">Your Response</h3>
+                <h3 class="submission__answer__display__title">{% trans "Your Response" %}</h3>
 
                 <div class="submission__answer__display__content">
                     {{ student_submission.answer.text|linebreaks }}

--- a/apps/openassessment/templates/openassessmentblock/response/oa_response_submitted.html
+++ b/apps/openassessment/templates/openassessmentblock/response/oa_response_submitted.html
@@ -1,4 +1,5 @@
 {% extends "openassessmentblock/response/oa_response.html" %}
+{% load i18n %}
 
 {% block list_item %}
 <li id="openassessment__response" class="openassessment__steps__step step--response is--complete ui-toggle-visibility is--collapsed">
@@ -6,10 +7,10 @@
 
 {% block title %}
 <span class="step__status">
-  <span class="step__status__label">This step's status:</span>
+  <span class="step__status__label">{% trans "This step's status" %}:</span>
   <span class="step__status__value">
     <i class="ico icon-ok"></i>
-    <span class="copy">Complete</span>
+    <span class="copy">{% trans "Complete" %}</span>
   </span>
 </span>
 {% endblock %}
@@ -19,13 +20,13 @@
     <div class="wrapper--step__content">
 
         <div class="step__message message message--complete">
-            <h3 class="message__title">Your Response Has Been Submitted</h3>
-            <div class="message__content">You'll receive your grade after some of your peers have assessed your response and you complete the <a data-behavior="ui-scroll" href="#openassessment__peer-assessment">peer assessment</a> and <a data-behavior="ui-scroll" href="#openassessment__self-assessment">self assessment</a> steps.</div>
+            <h3 class="message__title">{% trans "Your Response Has Been Submitted" %}</h3>
+            <div class="message__content">{% trans "You'll receive your grade after some of your peers have assessed your response and you complete the <a data-behavior=\"ui-scroll\" href=\"#openassessment__peer-assessment\">peer assessment</a> and <a data-behavior=\"ui-scroll\" href=\"#openassessment__self-assessment\">self assessment</a> steps" %}.</div>
         </div>
 
         <div class="step__content">
             <article class="submission__answer__display">
-                <h3 class="submission__answer__display__title">Your Response</h3>
+                <h3 class="submission__answer__display__title">{% trans "Your Response" %}</h3>
 
                 <div class="submission__answer__display__content">
                     {{ student_submission.answer.text|linebreaks }}

--- a/apps/openassessment/templates/openassessmentblock/self/oa_self_assessment.html
+++ b/apps/openassessment/templates/openassessmentblock/self/oa_self_assessment.html
@@ -12,9 +12,9 @@
        <h2 class="step__title">
             <span class="step__counter"></span>
             <span class="wrapper--copy">
-                <span class="step__label">Assess Your Response</span>
+                <span class="step__label">{% trans "Assess Your Response" %}</span>
                 {% if self_start %}
-                <span class="step__deadline">available
+                <span class="step__deadline">{% trans "available" %}
                     <span class="date">
                         {{ self_start|utc|date:"N j, Y H:i e" }}
                         (in {{ self_start|timeuntil }})
@@ -33,9 +33,9 @@
 
         {% block title %}
         <span class="step__status">
-          <span class="step__status__label">This step's status:</span>
+          <span class="step__status__label">{% trans "This step's status" %}:</span>
           <span class="step__status__value">
-              <span class="copy">In Progress</span>
+              <span class="copy">{% trans "In Progress" %}</span>
           </span>
         </span>
         {% endblock %}
@@ -47,7 +47,7 @@
             <div class="step__content">
                 <article class="self-assessment__display" id="self-assessment">
                     <header class="self-assessment__display__header">
-                        <h3 class="self-assessment__display__title">Your Response</h3>
+                        <h3 class="self-assessment__display__title">{% trans "Your Response" %}</h3>
                     </header>
 
                     <div class="self-assessment__display__response">
@@ -63,7 +63,7 @@
                                  <h4 class="question__title ui-toggle-visibility__control">
                                     <i class="ico icon-caret-right"></i>
                                     <span class="question__title__copy">{{ criterion.prompt }}</span>
-                                    <span class="label--required sr">* (Required)</span>
+                                    <span class="label--required sr">* ({% trans "Required" %})</span>
                                 </h4>
 
                                 <div class="ui-toggle-visibility__content">
@@ -81,7 +81,7 @@
                                             </div>
                                             <div class="wrapper--metadata">
                                                 <span class="answer__tip">{{ option.explanation }}</span>
-                                                <span class="answer__points">{{option.points}} <span class="answer__points__label">points</span></span>
+                                                <span class="answer__points">{{option.points}} <span class="answer__points__label">{% trans "points" %}</span></span>
                                             </div>
                                         </li>
                                         {% endfor %}
@@ -96,7 +96,7 @@
 
             <div class="step__actions">
                 <div class="message message--inline message--error message--error-server">
-                    <h3 class="message__title">We could not submit your assessment</h3>
+                    <h3 class="message__title">{% trans "We could not submit your assessment" %}</h3>
                     <div class="message__content"></div>
                 </div>
 

--- a/apps/openassessment/templates/openassessmentblock/self/oa_self_closed.html
+++ b/apps/openassessment/templates/openassessmentblock/self/oa_self_closed.html
@@ -1,4 +1,5 @@
-{%  extends "openassessmentblock/self/oa_self_assessment.html" %}
+{% extends "openassessmentblock/self/oa_self_assessment.html" %}
+{% load i18n %}
 
 {% block list_item %}
 <li id="openassessment__self-assessment" class="openassessment__steps__step step--self-assessment is--incomplete ui-toggle-visibility">
@@ -6,10 +7,10 @@
 
 {% block title %}
 <span class="step__status">
-  <span class="step__status__label">This step's status:</span>
+  <span class="step__status__label">{% trans "This step's status" %}:</span>
   <span class="step__status__value">
     <i class="ico icon-warning-sign"></i>
-    <span class="copy">Incomplete</span>
+    <span class="copy">{% trans "Incomplete" %}</span>
   </span>
 </span>
 {% endblock %}
@@ -19,9 +20,9 @@
     <div class="wrapper--step__content">
 
         <div class="step__message message message--incomplete">
-            <h3 class="message__title">The Due Date for This Step Has Passed</h3>
+            <h3 class="message__title">{% trans "The Due Date for This Step Has Passed" %}</h3>
             <div class="message__content">
-                 <p>This step is now closed. You can no longer complete a self assessment or continue with this assignment, and you'll receive a grade of Incomplete.</p>
+                 <p>{% trans "This step is now closed. You can no longer complete a self assessment or continue with this assignment, and you'll receive a grade of Incomplete." %}</p>
             </div>
         </div>
     </div>

--- a/apps/openassessment/templates/openassessmentblock/self/oa_self_complete.html
+++ b/apps/openassessment/templates/openassessmentblock/self/oa_self_complete.html
@@ -1,4 +1,5 @@
-{%  extends "openassessmentblock/self/oa_self_assessment.html" %}
+{% extends "openassessmentblock/self/oa_self_assessment.html" %}
+{% load i18n %}
 
 {% block list_item %}
 <li id="openassessment__self-assessment" class="openassessment__steps__step step--self-assessment is--complete is--empty is--collapsed">
@@ -6,10 +7,10 @@
 
 {% block title %}
 <span class="step__status">
-  <span class="step__status__label">This step's status:</span>
+  <span class="step__status__label">{% trans "This step's status" %}:</span>
   <span class="step__status__value">
     <i class="ico icon-ok"></i>
-    <span class="copy">Complete</span>
+    <span class="copy">{% trans "Complete" %}</span>
   </span>
 </span>
 {% endblock %}

--- a/apps/openassessment/templates/openassessmentblock/self/oa_self_unavailable.html
+++ b/apps/openassessment/templates/openassessmentblock/self/oa_self_unavailable.html
@@ -1,4 +1,5 @@
-{%  extends "openassessmentblock/self/oa_self_assessment.html" %}
+{% extends "openassessmentblock/self/oa_self_assessment.html" %}
+{% load i18n %}
 
 {% block list_item %}
 <li id="openassessment__self-assessment" class="openassessment__steps__step step--self-assessment is--empty is--unavailable is--collapsed">
@@ -6,9 +7,9 @@
 
 {% block title %}
 <span class="step__status">
-  <span class="step__status__label">This step's status:</span>
+  <span class="step__status__label">{% trans "This step's status" %}:</span>
   <span class="step__status__value">
-    <span class="copy">Not Available</span>
+    <span class="copy">{% trans "Not Available" %}</span>
   </span>
 </span>
 {% endblock %}

--- a/apps/openassessment/templates/openassessmentblock/staff_debug.html
+++ b/apps/openassessment/templates/openassessmentblock/staff_debug.html
@@ -1,28 +1,29 @@
+{% load i18n %}
 <div class="wrapper--staff-info wrapper--ui-staff">
 <div class="staff-info ui-staff ui-toggle-visibility is--collapsed">
     <h2 class="staff-info__title ui-staff__title ui-toggle-visibility__control">
       <i class="ico icon-caret-right"></i>
-      <span class="staff-info__title__copy">Course Staff Information</span>
+      <span class="staff-info__title__copy">{% trans "Course Staff Information" %}</span>
     </h2>
 
     <div class="staff-info__content ui-staff__content ui-toggle-visibility__content">
 
         <div class="staff-info__summary ui-staff__content__section">
             <dl class="submissions--total">
-                <dt class="label">Response total:</dt>
+                <dt class="label">{% trans "Response total" %}:</dt>
                 <dd class="value">{{ num_submissions }}</dd>
             </dl>
         </div>
 
         <div class="staff-info__status ui-staff__content__section">
-            <table class="staff-info__status__table" summary="Where are your students currently in this problem">
+            <table class="staff-info__status__table" summary="{% trans "Where are your students currently in this problem" %}">
 
-                <caption class="title">Student Progress</caption>
+                <caption class="title">{% trans "Student Progress" %}</caption>
 
                 <thead>
                     <tr>
-                        <th abbr="Step" scope="col">Problem Step</th>
-                        <th abbr="# of Students" scope="col">Active Students in Step</th>
+                        <th abbr="Step" scope="col">{% trans "Problem Step" %}</th>
+                        <th abbr="# of Students" scope="col">{% trans "Active Students in Step" %}</th>
                     </tr>
                 </thead>
 
@@ -38,7 +39,7 @@
         </div>
 
         <div class="staff-info__status ui-staff__content__section">
-          Location: {{ item_id }}
+          {% trans "Location" %}: {{ item_id }}
         </div>
     </div>
   </div>

--- a/apps/openassessment/xblock/test/test_grade.py
+++ b/apps/openassessment/xblock/test/test_grade.py
@@ -80,7 +80,6 @@ class TestGrade(XBlockHandlerTestCase):
 
         # Verify that we're on the right template
         self.assertIn(u'not completed', resp.decode('utf-8').lower())
-        self.assertIn(u'self assessment', resp.decode('utf-8').lower())
 
     @scenario('data/grade_incomplete_scenario.xml', user_id='Daniels')
     def test_grade_incomplete_missing_peer(self, xblock):
@@ -92,7 +91,6 @@ class TestGrade(XBlockHandlerTestCase):
 
         # Verify that we're on the right template
         self.assertIn(u'not completed', resp.decode('utf-8').lower())
-        self.assertIn(u'peer assessment', resp.decode('utf-8').lower())
 
     @scenario('data/grade_scenario.xml', user_id='Greggs')
     def test_submit_feedback(self, xblock):


### PR DESCRIPTION
First pass at tagging translation strings in the templates.  The main goal is to do extraction for proofing the text, so this isn't 100% exhaustive.  We're still missing some of the "x of y" strings (which are hard to translate out of context) and all of the JavaScript (which will require some changes to XBlock SDK before we can assume that `gettext` is loaded on the page).

@stephensanchez 
