### PR TITLE
Serialize answer dict before calculating size for datadog

### DIFF
--- a/apps/submissions/api.py
+++ b/apps/submissions/api.py
@@ -4,11 +4,10 @@ Public interface for the submissions app.
 """
 import copy
 import logging
+import json
 
 from django.core.cache import cache
-from django.conf import settings
 from django.db import IntegrityError, DatabaseError
-from django.utils.encoding import force_unicode
 from dogapi import dog_stats_api
 
 from submissions.serializers import (
@@ -524,8 +523,16 @@ def _log_submission(submission, student_item):
         u"item_id:{item_id}".format(item_id=student_item['item_id']),
         u"item_type:{item_type}".format(item_type=student_item['item_type']),
     ]
-    dog_stats_api.histogram('submissions.submission.size', len(submission['answer']), tags=tags)
     dog_stats_api.increment('submissions.submission.count', tags=tags)
+
+    # Submission answer is a JSON serializable, so we need to serialize it to measure its size in bytes
+    try:
+        answer_size = len(json.dumps(submission['answer']))
+    except (ValueError, TypeError):
+        msg = u"Could not serialize submission answer to calculate its length: {}".format(submission['answer'])
+        logger.exception(msg)
+    else:
+        dog_stats_api.histogram('submissions.submission.size', answer_size, tags=tags)
 
 
 def _log_score(score):


### PR DESCRIPTION
When sending the submission answer size to DataDog, I was taking the length of `submission['answer']`, forgetting that this is now a JSON-serializable dict with a `text` key.  Since the length of a dictionary is the number of keys, the answer size was always reported as one.

This change serializes the answer to a JSON string, then sends the length of the string to DataDog. 
