### PR TITLE
Reset scores

### DIFF
--- a/apps/openassessment/xblock/grade_mixin.py
+++ b/apps/openassessment/xblock/grade_mixin.py
@@ -76,8 +76,14 @@ class GradeMixin(object):
         self_assessment = self_api.get_assessment(student_submission['uuid'])
         has_submitted_feedback = peer_api.get_assessment_feedback(workflow['submission_uuid']) is not None
 
+        # We retrieve the score from the workflow, which in turn retrieves
+        # the score for our current submission UUID.
+        # We look up the score by submission UUID instead of student item
+        # to ensure that the score always matches the rubric.
+        score = workflow['score']
+
         context = {
-            'score': workflow['score'],
+            'score': score,
             'feedback_text': feedback_text,
             'student_submission': student_submission,
             'peer_assessments': peer_assessments,

--- a/apps/submissions/migrations/0004_auto__add_field_scoresummary_first_score_timestamp.py
+++ b/apps/submissions/migrations/0004_auto__add_field_scoresummary_first_score_timestamp.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+import datetime
+import pytz
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    # We default the first score timestamp to the distant past to indicate
+    # that all scores were included in the score summary.
+    # Because we have not yet allowed instructors to reset student scores,
+    # this is, in fact, accurate.
+    DISTANT_PAST = datetime.datetime(datetime.MINYEAR, 1, 1).replace(tzinfo=pytz.utc)
+
+    def forwards(self, orm):
+        # Adding field 'ScoreSummary.first_score_timestamp'
+        db.add_column('submissions_scoresummary', 'first_score_timestamp',
+                      self.gf('django.db.models.fields.DateTimeField')(default=self.DISTANT_PAST, db_index=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'ScoreSummary.first_score_timestamp'
+        db.delete_column('submissions_scoresummary', 'first_score_timestamp')
+
+
+    models = {
+        'submissions.score': {
+            'Meta': {'object_name': 'Score'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'points_earned': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'points_possible': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'student_item': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.StudentItem']"}),
+            'submission': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.Submission']", 'null': 'True'})
+        },
+        'submissions.scoresummary': {
+            'Meta': {'object_name': 'ScoreSummary'},
+            'first_score_timestamp': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'highest': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['submissions.Score']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latest': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['submissions.Score']"}),
+            'student_item': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.StudentItem']", 'unique': 'True'})
+        },
+        'submissions.studentitem': {
+            'Meta': {'unique_together': "(('course_id', 'student_id', 'item_id'),)", 'object_name': 'StudentItem'},
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'item_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'student_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        'submissions.submission': {
+            'Meta': {'ordering': "['-submitted_at', '-id']", 'object_name': 'Submission'},
+            'attempt_number': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'raw_answer': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'student_item': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.StudentItem']"}),
+            'submitted_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '36', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['submissions']

--- a/apps/submissions/tests/test_reset_score.py
+++ b/apps/submissions/tests/test_reset_score.py
@@ -1,0 +1,162 @@
+"""
+Test reset scores.
+"""
+
+import copy
+from mock import patch
+from django.test import TestCase
+import ddt
+from django.core.cache import cache
+from django.db import DatabaseError
+from submissions import api as sub_api
+from submissions.models import ScoreSummary
+
+
+@ddt.ddt
+class TestResetScore(TestCase):
+    """
+    Test resetting scores for a specific student on a specific problem.
+    """
+
+    STUDENT_ITEM = {
+        'student_id': 'Test student',
+        'course_id': 'Test course',
+        'item_id': 'Test item',
+        'item_type': 'Test item type',
+    }
+
+    def setUp(self):
+        """
+        Clear the cache.
+        """
+        cache.clear()
+
+    def test_reset_with_no_scores(self):
+        sub_api.reset_scores(
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+        self.assertIs(sub_api.get_score(self.STUDENT_ITEM), None)
+
+        scores = sub_api.get_scores(self.STUDENT_ITEM['course_id'], self.STUDENT_ITEM['student_id'])
+        self.assertEqual(len(scores), 0)
+
+    def test_reset_with_one_score(self):
+        # Create a submission for the student and score it
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 2)
+
+        # Reset scores
+        sub_api.reset_scores(
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+
+        # Expect that no scores are available for the student
+        self.assertIs(sub_api.get_score(self.STUDENT_ITEM), None)
+        scores = sub_api.get_scores(self.STUDENT_ITEM['course_id'], self.STUDENT_ITEM['student_id'])
+        self.assertEqual(len(scores), 0)
+
+    def test_reset_with_multiple_scores(self):
+        # Create a submission for the student and score it
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 2)
+        sub_api.set_score(submission['uuid'], 2, 2)
+
+        # Reset scores
+        sub_api.reset_scores(
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+
+        # Expect that no scores are available for the student
+        self.assertIs(sub_api.get_score(self.STUDENT_ITEM), None)
+        scores = sub_api.get_scores(self.STUDENT_ITEM['course_id'], self.STUDENT_ITEM['student_id'])
+        self.assertEqual(len(scores), 0)
+
+    @ddt.data(
+        {'student_id': 'other student'},
+        {'course_id': 'other course'},
+        {'item_id': 'other item'},
+    )
+    def test_reset_different_student_item(self, changed):
+        # Create a submissions for two students
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 2)
+
+        other_student = copy.copy(self.STUDENT_ITEM)
+        other_student.update(changed)
+        submission = sub_api.create_submission(other_student, 'other test answer')
+        sub_api.set_score(submission['uuid'], 3, 4)
+
+        # Reset the score for the first student
+        sub_api.reset_scores(
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+
+        # The first student's scores should be reset
+        self.assertIs(sub_api.get_score(self.STUDENT_ITEM), None)
+        scores = sub_api.get_scores(self.STUDENT_ITEM['course_id'], self.STUDENT_ITEM['student_id'])
+        self.assertNotIn(self.STUDENT_ITEM['item_id'], scores)
+
+        # But the second student should still have a score
+        score = sub_api.get_score(other_student)
+        self.assertEqual(score['points_earned'], 3)
+        self.assertEqual(score['points_possible'], 4)
+        scores = sub_api.get_scores(other_student['course_id'], other_student['student_id'])
+        self.assertIn(other_student['item_id'], scores)
+
+    def test_reset_then_add_score(self):
+        # Create a submission for the student and score it
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 2)
+
+        # Reset scores
+        sub_api.reset_scores(
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+
+        # Score the student again
+        sub_api.set_score(submission['uuid'], 3, 4)
+
+        # Expect that the new score is available
+        score = sub_api.get_score(self.STUDENT_ITEM)
+        self.assertEqual(score['points_earned'], 3)
+        self.assertEqual(score['points_possible'], 4)
+
+        scores = sub_api.get_scores(self.STUDENT_ITEM['course_id'], self.STUDENT_ITEM['student_id'])
+        self.assertIn(self.STUDENT_ITEM['item_id'], scores)
+        self.assertEqual(scores[self.STUDENT_ITEM['item_id']], (3, 4))
+
+    def test_reset_then_get_score_for_submission(self):
+        # Create a submission for the student and score it
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 2)
+
+        # Reset scores
+        sub_api.reset_scores(
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+
+        # If we're retrieving the score for a particular submission,
+        # instead of a student item, then we should STILL get a score.
+        self.assertIsNot(sub_api.get_latest_score_for_submission(submission['uuid']), None)
+
+    @patch.object(ScoreSummary.objects, 'filter')
+    def test_database_error(self, filter_mock):
+        filter_mock.side_effect = DatabaseError("Test error")
+        with self.assertRaises(sub_api.SubmissionInternalError):
+            sub_api.reset_scores(
+                self.STUDENT_ITEM['course_id'],
+                self.STUDENT_ITEM['student_id'],
+                self.STUDENT_ITEM['item_id'],
+            )


### PR DESCRIPTION
Add a new function `reset_scores()` to the Submissions API to allow the LMS instructor dash to reset a specific student's scores on a problem.

The basic approach is:
- The LMS retrieves scores from submission API calls that query the `ScoreSummary` model, which is mutable, redundant, and incrementally updated.
- By deleting the `ScoreSummary` model, we can make it appear as if a student's scores were reset without modifying the `Submission` or `Score` models.
- In order to track which scores are included in the summary, I added a `first_score_timestamp` field to the score summary model.  This defaults to the minimum datetime, indicating that current score summaries should include all scores currently in the database (which is true, since until now it was impossible to delete score summaries). 

@stephensanchez @ormsbee 
