### PR TITLE
Reset scores (null submission approach)

### DIFF
--- a/apps/openassessment/xblock/grade_mixin.py
+++ b/apps/openassessment/xblock/grade_mixin.py
@@ -76,8 +76,14 @@ class GradeMixin(object):
         self_assessment = self_api.get_assessment(student_submission['uuid'])
         has_submitted_feedback = peer_api.get_assessment_feedback(workflow['submission_uuid']) is not None
 
+        # We retrieve the score from the workflow, which in turn retrieves
+        # the score for our current submission UUID.
+        # We look up the score by submission UUID instead of student item
+        # to ensure that the score always matches the rubric.
+        score = workflow['score']
+
         context = {
-            'score': workflow['score'],
+            'score': score,
             'feedback_text': feedback_text,
             'student_submission': student_submission,
             'peer_assessments': peer_assessments,

--- a/apps/submissions/migrations/0004_auto__add_field_score_reset.py
+++ b/apps/submissions/migrations/0004_auto__add_field_score_reset.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Score.reset'
+        db.add_column('submissions_score', 'reset',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Score.reset'
+        db.delete_column('submissions_score', 'reset')
+
+
+    models = {
+        'submissions.score': {
+            'Meta': {'object_name': 'Score'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'points_earned': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'points_possible': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'reset': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'student_item': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.StudentItem']"}),
+            'submission': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.Submission']", 'null': 'True'})
+        },
+        'submissions.scoresummary': {
+            'Meta': {'object_name': 'ScoreSummary'},
+            'highest': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['submissions.Score']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latest': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['submissions.Score']"}),
+            'student_item': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.StudentItem']", 'unique': 'True'})
+        },
+        'submissions.studentitem': {
+            'Meta': {'unique_together': "(('course_id', 'student_id', 'item_id'),)", 'object_name': 'StudentItem'},
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'item_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'student_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        'submissions.submission': {
+            'Meta': {'ordering': "['-submitted_at', '-id']", 'object_name': 'Submission'},
+            'attempt_number': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'raw_answer': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'student_item': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.StudentItem']"}),
+            'submitted_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '36', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['submissions']

--- a/apps/submissions/tests/test_api.py
+++ b/apps/submissions/tests/test_api.py
@@ -233,6 +233,16 @@ class TestSubmissionsApi(TestCase):
         self._assert_score(score, 11, 12)
         self.assertEqual(score['submission_uuid'], submission['uuid'])
 
+    def test_get_score_for_submission_hidden_score(self):
+        # Create a "hidden" score for the submission
+        # (by convention, a score with points possible set to 0)
+        submission = api.create_submission(STUDENT_ITEM, ANSWER_ONE)
+        api.set_score(submission["uuid"], 0, 0)
+
+        # Expect that the retrieved score is None
+        score = api.get_latest_score_for_submission(submission['uuid'])
+        self.assertIs(score, None)
+
     def test_get_score_no_student_id(self):
         student_item = copy.deepcopy(STUDENT_ITEM)
         student_item['student_id'] = None

--- a/apps/submissions/tests/test_reset_score.py
+++ b/apps/submissions/tests/test_reset_score.py
@@ -1,0 +1,167 @@
+"""
+Test reset scores.
+"""
+
+import copy
+from mock import patch
+from django.test import TestCase
+import ddt
+from django.core.cache import cache
+from django.db import DatabaseError
+from submissions import api as sub_api
+from submissions.models import Score
+
+
+@ddt.ddt
+class TestResetScore(TestCase):
+    """
+    Test resetting scores for a specific student on a specific problem.
+    """
+
+    STUDENT_ITEM = {
+        'student_id': 'Test student',
+        'course_id': 'Test course',
+        'item_id': 'Test item',
+        'item_type': 'Test item type',
+    }
+
+    def setUp(self):
+        """
+        Clear the cache.
+        """
+        cache.clear()
+
+    def test_reset_with_no_scores(self):
+        sub_api.reset_score(
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+        self.assertIs(sub_api.get_score(self.STUDENT_ITEM), None)
+
+        scores = sub_api.get_scores(self.STUDENT_ITEM['course_id'], self.STUDENT_ITEM['student_id'])
+        self.assertEqual(len(scores), 0)
+
+    def test_reset_with_one_score(self):
+        # Create a submission for the student and score it
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 2)
+
+        # Reset scores
+        sub_api.reset_score(
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+
+        # Expect that no scores are available for the student
+        self.assertIs(sub_api.get_score(self.STUDENT_ITEM), None)
+        scores = sub_api.get_scores(self.STUDENT_ITEM['course_id'], self.STUDENT_ITEM['student_id'])
+        self.assertEqual(len(scores), 0)
+
+    def test_reset_with_multiple_scores(self):
+        # Create a submission for the student and score it
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 2)
+        sub_api.set_score(submission['uuid'], 2, 2)
+
+        # Reset scores
+        sub_api.reset_score(
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+
+        # Expect that no scores are available for the student
+        self.assertIs(sub_api.get_score(self.STUDENT_ITEM), None)
+        scores = sub_api.get_scores(self.STUDENT_ITEM['course_id'], self.STUDENT_ITEM['student_id'])
+        self.assertEqual(len(scores), 0)
+
+    @ddt.data(
+        {'student_id': 'other student'},
+        {'course_id': 'other course'},
+        {'item_id': 'other item'},
+    )
+    def test_reset_different_student_item(self, changed):
+        # Create a submissions for two students
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 2)
+
+        other_student = copy.copy(self.STUDENT_ITEM)
+        other_student.update(changed)
+        submission = sub_api.create_submission(other_student, 'other test answer')
+        sub_api.set_score(submission['uuid'], 3, 4)
+
+        # Reset the score for the first student
+        sub_api.reset_score(
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+
+        # The first student's scores should be reset
+        self.assertIs(sub_api.get_score(self.STUDENT_ITEM), None)
+        scores = sub_api.get_scores(self.STUDENT_ITEM['course_id'], self.STUDENT_ITEM['student_id'])
+        self.assertNotIn(self.STUDENT_ITEM['item_id'], scores)
+
+        # But the second student should still have a score
+        score = sub_api.get_score(other_student)
+        self.assertEqual(score['points_earned'], 3)
+        self.assertEqual(score['points_possible'], 4)
+        scores = sub_api.get_scores(other_student['course_id'], other_student['student_id'])
+        self.assertIn(other_student['item_id'], scores)
+
+    def test_reset_then_add_score(self):
+        # Create a submission for the student and score it
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 2)
+
+        # Reset scores
+        sub_api.reset_score(
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+
+        # Score the student again
+        sub_api.set_score(submission['uuid'], 3, 4)
+
+        # Expect that the new score is available
+        score = sub_api.get_score(self.STUDENT_ITEM)
+        self.assertEqual(score['points_earned'], 3)
+        self.assertEqual(score['points_possible'], 4)
+
+        scores = sub_api.get_scores(self.STUDENT_ITEM['course_id'], self.STUDENT_ITEM['student_id'])
+        self.assertIn(self.STUDENT_ITEM['item_id'], scores)
+        self.assertEqual(scores[self.STUDENT_ITEM['item_id']], (3, 4))
+
+    def test_reset_then_get_score_for_submission(self):
+        # Create a submission for the student and score it
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 2)
+
+        # Reset scores
+        sub_api.reset_score(
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+
+        # If we're retrieving the score for a particular submission,
+        # instead of a student item, then we should STILL get a score.
+        self.assertIsNot(sub_api.get_latest_score_for_submission(submission['uuid']), None)
+
+    @patch.object(Score.objects, 'create')
+    def test_database_error(self, create_mock):
+        # Create a submission for the student and score it
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 2)
+
+        # Simulate a database error when creating the reset score
+        create_mock.side_effect = DatabaseError("Test error")
+        with self.assertRaises(sub_api.SubmissionInternalError):
+            sub_api.reset_score(
+                self.STUDENT_ITEM['student_id'],
+                self.STUDENT_ITEM['course_id'],
+                self.STUDENT_ITEM['item_id'],
+            )

--- a/apps/submissions/tests/test_serializers.py
+++ b/apps/submissions/tests/test_serializers.py
@@ -1,0 +1,32 @@
+"""
+Tests for submissions serializers.
+"""
+from django.test import TestCase
+from submissions.models import Score, StudentItem
+from submissions.serializers import ScoreSerializer
+
+
+class ScoreSerializerTest(TestCase):
+    """
+    Tests for the score serializer.
+    """
+
+    def test_score_with_null_submission(self):
+        item = StudentItem.objects.create(
+            student_id="score_test_student",
+            course_id="score_test_course",
+            item_id="i4x://mycourse/special_presentation"
+        )
+
+        # Create a score with a null submission
+        score = Score.objects.create(
+            student_item=item,
+            submission=None,
+            points_earned=2,
+            points_possible=6
+        )
+        score_dict = ScoreSerializer(score).data
+
+        self.assertIs(score_dict['submission_uuid'], None)
+        self.assertEqual(score_dict['points_earned'], 2)
+        self.assertEqual(score_dict['points_possible'], 6)


### PR DESCRIPTION
Responding to @ormsbee 's concerns on #267.  In this approach, "reset" scores are created with `submission` set to null, so that we can determine the student's effective score from the `Score` model alone.

The semantics of `reset_score()` are the same for either implementation, so the test suite is almost the same (except for changing where the DB exception is raised and the order of arguments to `reset_score`)

@ormsbee @stephensanchez 
