### PR TITLE
Add script for starting JS tests in Chrome for debugging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,18 @@ To limit Python tests to a particular Django app:
 
     ./scripts/test.sh openassessment.xblock
 
+To run just the JavaScript tests:
+
+.. code:: bash
+
+    npm test
+
+To run the JavaScript tests in Chrome so you can use the debugger:
+
+.. code:: bash
+
+    ./scripts/js-debugger.sh
+
 
 Quality Check
 =============

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,7 +43,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress', 'coverage'],
+    reporters: ['progress'],
 
     coverageReporter: {
         type : 'text'

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
     "karma-jasmine": "0.1.3",
     "karma-coverage": "0.1.5",
     "karma-firefox-launcher": "~0.1.3",
+    "karma-chrome-launcher": "0.1.3",
     "uglify-js": "2.3.6"
   },
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start"
+    "test": "./node_modules/karma/bin/karma start --reporters progress,coverage"
   }
 }

--- a/scripts/js-debugger.sh
+++ b/scripts/js-debugger.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cd `dirname $BASH_SOURCE` && cd ..
+./scripts/install.sh test
+
+echo "Starting JavaScript tests in a browser..."
+./node_modules/karma/bin/karma start --single-run=false --browsers Chrome


### PR DESCRIPTION
Usage:

```
./scripts/js-debugger.sh
```

@stephensanchez 
