### PR TITLE
Make rubric prompt display and instructions optional

### DIFF
--- a/apps/openassessment/templates/openassessmentblock/oa_base.html
+++ b/apps/openassessment/templates/openassessmentblock/oa_base.html
@@ -30,6 +30,7 @@
             {% endblock %}
 
             <div class="wrapper--openassessment__prompt">
+                {% if question %}
                 <article class="openassessment__prompt ui-toggle-visibility">
                     <h2 class="openassessment__prompt__title">{% trans "The prompt for this assignment" %}</h2>
 
@@ -37,6 +38,7 @@
                         {{ question|linebreaks }}
                     </div>
                 </article>
+                {% endif %}
             </div>
 
             <ol class="openassessment__steps" id="openassessment__steps">

--- a/apps/openassessment/xblock/openassessmentblock.py
+++ b/apps/openassessment/xblock/openassessmentblock.py
@@ -120,8 +120,9 @@ class OpenAssessmentBlock(
     course_id = String(
         default=u"TestCourse",
         scope=Scope.content,
-        help="The course_id associated with this prompt (until we can get it from runtime).",
+        help="The course_id associated with this prompt (until we can get it from runtime)."
     )
+
     submission_uuid = String(
         default=None,
         scope=Scope.user_state,
@@ -310,6 +311,10 @@ class OpenAssessmentBlock(
             (
                 "OpenAssessmentBlock Censorship Rubric",
                 load('static/xml/censorship_rubric_example.xml')
+            ),
+            (
+                "OpenAssessmentBlock Promptless Rubric",
+                load('static/xml/promptless_rubric_example.xml')
             ),
         ]
 

--- a/apps/openassessment/xblock/static/xml/promptless_rubric_example.xml
+++ b/apps/openassessment/xblock/static/xml/promptless_rubric_example.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<openassessment>
+    <title>
+        Promptless rubric
+    </title>
+    <rubric>
+        <criterion>
+            <name>concise</name>
+            <prompt>How concise is it?</prompt>
+            <option points="0">
+                <name>The Bible</name>
+                <explanation></explanation>
+            </option>
+            <option points="1">
+                <name>Earnest Hemingway</name>
+                <explanation></explanation>
+            </option>
+            <option points="3">
+                <name>Matsuo Basho</name>
+                <explanation></explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="peer-assessment"
+                    start="2014-12-20T19:00-7:00"
+                    due="2014-12-21T22:22-7:00"
+                    must_grade="2"
+                    must_be_graded_by="1" />
+        <assessment name="self-assessment" />
+    </assessments>
+</openassessment>

--- a/apps/openassessment/xblock/test/data/empty_prompt.xml
+++ b/apps/openassessment/xblock/test/data/empty_prompt.xml
@@ -1,0 +1,21 @@
+<openassessment>
+    <title>Open Assessment Test</title>
+    <rubric>
+        <criterion>
+            <name>Concise</name>
+            <prompt>How concise is it?</prompt>
+            <option points="0">
+                <name>Neal Stephenson (late)</name>
+                <explanation>Neal Stephenson explanation</explanation>
+            </option>
+            <option points="1">
+                <name>HP Lovecraft</name>
+                <explanation>HP Lovecraft explanation</explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="peer-assessment" must_grade="2" must_be_graded_by="1" />
+        <assessment name="self-assessment" />
+    </assessments>
+</openassessment>

--- a/apps/openassessment/xblock/test/data/serialize.json
+++ b/apps/openassessment/xblock/test/data/serialize.json
@@ -63,6 +63,133 @@
         ]
     },
 
+    "promptless": {
+        "title": "Foo",
+        "prompt": null,
+        "rubric_feedback_prompt": "Test Feedback Prompt",
+        "start": null,
+        "due": null,
+        "submission_start": null,
+        "submission_due": null,
+        "criteria": [
+            {
+                "order_num": 0,
+                "name": "Test criterion",
+                "prompt": "Test criterion prompt",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            }
+        ],
+        "assessments": [
+            {
+                "name": "peer-assessment",
+                "start": "2014-02-27T09:46:28",
+                "due": "2014-03-01T00:00:00",
+                "must_grade": 5,
+                "must_be_graded_by": 3
+            },
+            {
+                "name": "self-assessment",
+                "start": "2014-04-01T00:00:00",
+                "due": "2014-06-01T00:00:00"
+            }
+        ],
+        "expected_xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"peer-assessment\" start=\"2014-02-27T09:46:28\" due=\"2014-03-01T00:00:00\" must_grade=\"5\" must_be_graded_by=\"3\" />",
+                "<assessment name=\"self-assessment\" start=\"2014-04-01T00:00:00\" due=\"2014-06-01T00:00:00\" />",
+            "</assessments>",
+            "<rubric>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+                "<feedbackprompt>Test Feedback Prompt</feedbackprompt>",
+            "</rubric>",
+            "</openassessment>"
+        ]
+    },
+
+    "empty_prompt": {
+        "title": "Foo",
+        "prompt": "",
+        "rubric_feedback_prompt": "Test Feedback Prompt",
+        "start": null,
+        "due": null,
+        "submission_start": null,
+        "submission_due": null,
+        "criteria": [
+            {
+                "order_num": 0,
+                "name": "Test criterion",
+                "prompt": "Test criterion prompt",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            }
+        ],
+        "assessments": [
+            {
+                "name": "peer-assessment",
+                "start": "2014-02-27T09:46:28",
+                "due": "2014-03-01T00:00:00",
+                "must_grade": 5,
+                "must_be_graded_by": 3
+            },
+            {
+                "name": "self-assessment",
+                "start": "2014-04-01T00:00:00",
+                "due": "2014-06-01T00:00:00"
+            }
+        ],
+        "expected_xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"peer-assessment\" start=\"2014-02-27T09:46:28\" due=\"2014-03-01T00:00:00\" must_grade=\"5\" must_be_graded_by=\"3\" />",
+                "<assessment name=\"self-assessment\" start=\"2014-04-01T00:00:00\" due=\"2014-06-01T00:00:00\" />",
+            "</assessments>",
+            "<rubric>",
+                "<prompt></prompt>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+                "<feedbackprompt>Test Feedback Prompt</feedbackprompt>",
+            "</rubric>",
+            "</openassessment>"
+        ]
+    },
+
     "unicode": {
         "title": "ƒσσ",
         "prompt": "Ṫëṡẗ ṗṛöṁṗẗ",

--- a/apps/openassessment/xblock/test/data/update_from_xml.json
+++ b/apps/openassessment/xblock/test/data/update_from_xml.json
@@ -61,6 +61,113 @@
         ]
     },
 
+    "promptless": {
+        "xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"self-assessment\" start=\"2014-04-01T00:00:00\" due=\"2014-06-01T00:00:00\" />",
+            "</assessments>",
+            "<rubric>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+            "</rubric>",
+            "</openassessment>"
+        ],
+        "title": "Foo",
+        "prompt": null,
+        "start": "2000-01-01T00:00:00",
+        "due": "3000-01-01T00:00:00",
+        "submission_start": null,
+        "submission_due": null,
+        "criteria": [
+            {
+                "order_num": 0,
+                "name": "Test criterion",
+                "prompt": "Test criterion prompt",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            }
+        ],
+        "assessments": [
+            {
+                "name": "self-assessment",
+                "start": "2014-04-01T00:00:00",
+                "due": "2014-06-01T00:00:00"
+            }
+        ]
+    },
+
+    "empty_prompt": {
+        "xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"self-assessment\" start=\"2014-04-01T00:00:00\" due=\"2014-06-01T00:00:00\" />",
+            "</assessments>",
+            "<rubric>",
+                "<prompt></prompt>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+            "</rubric>",
+            "</openassessment>"
+        ],
+        "title": "Foo",
+        "prompt": "",
+        "start": "2000-01-01T00:00:00",
+        "due": "3000-01-01T00:00:00",
+        "submission_start": null,
+        "submission_due": null,
+        "criteria": [
+            {
+                "order_num": 0,
+                "name": "Test criterion",
+                "prompt": "Test criterion prompt",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            }
+        ],
+        "assessments": [
+            {
+                "name": "self-assessment",
+                "start": "2014-04-01T00:00:00",
+                "due": "2014-06-01T00:00:00"
+            }
+        ]
+    },
+
     "unicode": {
         "xml": [
             "<openassessment>",

--- a/apps/openassessment/xblock/test/data/update_from_xml_error.json
+++ b/apps/openassessment/xblock/test/data/update_from_xml_error.json
@@ -202,25 +202,6 @@
         ]
     },
 
-    "missing_rubric_prompt": {
-        "xml": [
-            "<openassessment>",
-            "<title>Foo</title>",
-            "<assessments>",
-                "<assessment name=\"peer-assessment\" start=\"2014-02-27T09:46:28\" due=\"2014-03-01T00:00:00\" must_grade=\"5\" must_be_graded_by=\"3\" />",
-            "</assessments>",
-            "<rubric>",
-                "<criterion>",
-                    "<name>Test criterion</name>",
-                    "<prompt>Test criterion prompt</prompt>",
-                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
-                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
-                "</criterion>",
-            "</rubric>",
-            "</openassessment>"
-        ]
-    },
-
     "missing_option_points": {
         "xml": [
             "<openassessment>",

--- a/apps/openassessment/xblock/test/test_openassessment.py
+++ b/apps/openassessment/xblock/test/test_openassessment.py
@@ -54,6 +54,16 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         expected_prompt = u"<p><br />Line 1</p><p>Line 2</p><p>Line 3<br /></p>"
         self.assertIn(expected_prompt, xblock_fragment.body_html())
 
+    @scenario('data/empty_prompt.xml')
+    def test_prompt_intentionally_empty(self, xblock):
+        # Verify that prompts intentionally left empty don't create DOM elements
+        xblock_fragment = self.runtime.render(xblock, "student_view")
+        body_html = xblock_fragment.body_html()
+        present_prompt_text = "you'll provide a response to the question"
+        missing_article = u'<article class="openassessment__prompt'
+        self.assertIn(present_prompt_text, body_html)
+        self.assertNotIn(missing_article, body_html)
+
     @scenario('data/basic_scenario.xml')
     def test_page_load_updates_workflow(self, xblock):
 

--- a/apps/openassessment/xblock/xml.py
+++ b/apps/openassessment/xblock/xml.py
@@ -136,9 +136,10 @@ def _serialize_rubric(rubric_root, oa_block):
     Returns:
         None
     """
-    # Rubric prompt (default to empty text)
-    prompt = etree.SubElement(rubric_root, 'prompt')
-    prompt.text = unicode(oa_block.prompt)
+    # Rubric prompt (default to empty text); None indicates no input element
+    if oa_block.prompt is not None:
+        prompt = etree.SubElement(rubric_root, 'prompt')
+        prompt.text = unicode(oa_block.prompt)
 
     # Criteria
     criteria_list = oa_block.rubric_criteria
@@ -293,7 +294,7 @@ def _parse_rubric_xml(rubric_root):
     if prompt_el is not None:
         rubric_dict['prompt'] = _safe_get_text(prompt_el)
     else:
-        raise UpdateFromXmlError(_('Every "criterion" element must contain a "prompt" element.'))
+        rubric_dict['prompt'] = None
 
     feedback_prompt_el = rubric_root.find('feedbackprompt')
     if feedback_prompt_el is not None:


### PR DESCRIPTION
TIM-410: if users want rich prompts, they can do that with an HTML
Components above the ORA2 question, but doing this makes the prompt
instructions and the prompt box look bad. This adds an optional
'with_instructions' attribute to the prompt tag for toggling the prompt
instructions separately from the prompt. This also adds a check so that
neither the prompt box nor the instructions will display if the prompt
is empty or whitespace-only.

Includes tests for each of these conditions.

@stephensanchez @wedaly 
