### PR TITLE
Updated setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,14 @@
 #!/usr/bin/env python
-import os
 from setuptools import setup
 
 PACKAGES = [
     'submissions',
+    'openassessment',
     'openassessment.assessment',
+    'openassessment.workflow',
+    'openassessment.management',
     'openassessment.xblock'
 ]
-
-def package_data(pkg, root):
-    """Generic function to find package_data for `pkg` under `root`."""
-    data = []
-    for dirname, _, files in os.walk(os.path.join(pkg, root)):
-        for fname in files:
-            data.append(os.path.relpath(os.path.join(dirname, fname), pkg))
-
-    return {pkg: data}
-
 
 def is_requirement(line):
     """
@@ -35,7 +27,6 @@ REQUIREMENTS = [
     open("requirements/base.txt").readlines()
     if is_requirement(line)
 ]
-
 
 setup(
     name='ora2',
@@ -60,5 +51,4 @@ setup(
             'openassessment = openassessment.xblock.openassessmentblock:OpenAssessmentBlock',
         ]
     },
-    package_data=package_data("openassessment.xblock", "static"),
 )


### PR DESCRIPTION
- Ensure all apps are included in the packages list, including the top-level `openassessment` package.
- Remove the `package_data` stuff, since we're using MANIFEST.ini to recursively include static files.

@e0d @stephensanchez 
