### PR TITLE
TIM-548

### DIFF
--- a/apps/openassessment/xblock/peer_assessment_mixin.py
+++ b/apps/openassessment/xblock/peer_assessment_mixin.py
@@ -148,9 +148,8 @@ class PeerAssessmentMixin(object):
             context_dict['peer_due'] = due_date
 
         workflow = self.get_workflow_info()
-        if workflow is None:
-            return self.render_assessment(path, context_dict)
-        continue_grading = continue_grading and workflow["status_details"]["peer"]["complete"]
+        peer_complete = workflow.get('status_details', {}).get('peer', {}).get('complete', False)
+        continue_grading = continue_grading and peer_complete
 
         student_item = self.get_student_item_dict()
         assessment = self.get_assessment_module('peer-assessment')

--- a/apps/openassessment/xblock/test/test_peer.py
+++ b/apps/openassessment/xblock/test/test_peer.py
@@ -449,6 +449,24 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             was_graded_enough=True,
         )
 
+    @scenario('data/peer_assessment_scenario.xml', user_id='Bob')
+    def test_continued_grading_no_submission(self, xblock):
+        # Bugfix: This used to cause a KeyError when students would click "Peer Assessment"
+        # (indicating "continued grading") before making a submission.
+        expected_context = {
+            'estimated_time': '20 minutes',
+            'graded': 0,
+            'must_grade': 5,
+            'review_num': 1,
+            'rubric_criteria': xblock.rubric_criteria,
+            'submit_button_text': 'Submit your assessment & review another response',
+        }
+        self._assert_path_and_context(
+            xblock, 'openassessmentblock/peer/oa_peer_unavailable.html',
+            expected_context,
+            continue_grading=True,
+        )
+
     def _assert_path_and_context(
         self, xblock, expected_path, expected_context,
         continue_grading=False, workflow_status=None,


### PR DESCRIPTION
[TIM-548](https://edx-wiki.atlassian.net/browse/TIM-548)
Bugfix: 500 error when clicking "peer assess" with no submission.

The `workflow is None` line was -- hopefully -- never being executed, since it returned a `Response` object instead of a `(path, context)` tuple, which would have caused a 500 error.

@stephensanchez 
