### PR TITLE
Quiet noisy error log message

### DIFF
--- a/apps/openassessment/assessment/peer_api.py
+++ b/apps/openassessment/assessment/peer_api.py
@@ -207,7 +207,7 @@ def create_assessment(
                 u"There are no open assessments associated with the scorer's "
                 u"submission UUID {}.".format(scorer_submission_uuid)
             )
-            logger.error(message)
+            logger.warning(message)
             raise PeerAssessmentWorkflowError(message)
 
         peer_submission_uuid = peer_workflow_item.author.submission_uuid


### PR DESCRIPTION
[TIM-549](https://edx-wiki.atlassian.net/browse/TIM-549)

It turns out that we _are_ correctly disabling the peer assessment submit button for continued grading.

After examining the read replica for the submissions in the logs, here's what I think happened:
1. A student was viewing the problem in two different windows.
2. A student submitted a peer assessment in one window.
3. The student then tried to submit a peer assessment in the second window. Since the peer assessment had already been completed, an error was reported to the student.

This seems to me to be exactly what we'd want to happen.

To avoid cluttering the logs, I think we should continue raising the exception but log it as a warning instead of an error.

@feanil @stephensanchez 
