### PR TITLE
Supporting Peer Only configuration for ORA2

### DIFF
--- a/apps/openassessment/xblock/openassessmentblock.py
+++ b/apps/openassessment/xblock/openassessmentblock.py
@@ -314,6 +314,10 @@ class OpenAssessmentBlock(
                 load('static/xml/poverty_rubric_example.xml')
             ),
             (
+                "OpenAssessmentBlock (Peer Only) Rubric",
+                load('static/xml/poverty_peer_only_example.xml')
+            ),
+            (
                 "OpenAssessmentBlock (Self Only) Rubric",
                 load('static/xml/poverty_self_only_example.xml')
             ),

--- a/apps/openassessment/xblock/static/xml/poverty_peer_only_example.xml
+++ b/apps/openassessment/xblock/static/xml/poverty_peer_only_example.xml
@@ -1,0 +1,113 @@
+<openassessment submission_due="2030-03-11T18:20">
+    <title>
+        Global Poverty
+    </title>
+    <rubric>
+        <prompt>
+            Given the state of the world today, what do you think should be done to combat poverty?
+
+            Read for conciseness, clarity of thought, and form.
+        </prompt>
+        <criterion feedback='optional'>
+            <name>concise</name>
+            <prompt>How concise is it?</prompt>
+            <option points="0">
+                <name>Neal Stephenson (late)</name>
+                <explanation>
+                    In "Cryptonomicon", Stephenson spent multiple pages talking about breakfast cereal.
+                    While hilarious, in recent years his work has been anything but 'concise'.
+                </explanation>
+            </option>
+            <option points="1">
+                <name>HP Lovecraft</name>
+                <explanation>
+                    If the author wrote something cyclopean that staggers the mind, score it thus.
+                </explanation>
+            </option>
+            <option points="3">
+                <name>Robert Heinlein</name>
+                <explanation>
+                    Tight prose that conveys a wealth of information about the world in relatively
+                    few words. Example, "The door irised open and he stepped inside."
+                </explanation>
+            </option>
+            <option points="4">
+                <name>Neal Stephenson (early)</name>
+                <explanation>
+                    When Stephenson still had an editor, his prose was dense, with anecdotes about
+                    nitrox abuse implying main characters' whole life stories.
+                </explanation>
+            </option>
+            <option points="5">
+                <name>Earnest Hemingway</name>
+                <explanation>
+                    Score the work this way if it makes you weep, and the removal of a single
+                    word would make you sneer.
+                </explanation>
+            </option>
+        </criterion>
+        <criterion>
+            <name>clear-headed</name>
+            <prompt>How clear is the thinking?</prompt>
+            <option points="0">
+                <name>Yogi Berra</name>
+                <explanation></explanation>
+            </option>
+            <option points="1">
+                <name>Hunter S. Thompson</name>
+                <explanation></explanation>
+            </option>
+            <option points="2">
+                <name>Robert Heinlein</name>
+                <explanation></explanation>
+            </option>
+            <option points="3">
+                <name>Isaac Asimov</name>
+                <explanation></explanation>
+            </option>
+            <option points="10">
+                <name>Spock</name>
+                <explanation>
+                    Coolly rational, with a firm grasp of the main topics, a crystal-clear train of thought,
+                    and unemotional examination of the facts.  This is the only item explained in this category,
+                    to show that explained and unexplained items can be mixed.
+                </explanation>
+            </option>
+        </criterion>
+        <criterion feedback='optional'>
+            <name>form</name>
+            <prompt>Lastly, how is its form? Punctuation, grammar, and spelling all count.</prompt>
+            <option points="0">
+                <name>lolcats</name>
+                <explanation></explanation>
+            </option>
+            <option points="1">
+                <name>Facebook</name>
+                <explanation></explanation>
+            </option>
+            <option points="2">
+                <name>Reddit</name>
+                <explanation></explanation>
+            </option>
+            <option points="3">
+                <name>metafilter</name>
+                <explanation></explanation>
+            </option>
+            <option points="4">
+                <name>Usenet, 1996</name>
+                <explanation></explanation>
+            </option>
+            <option points="5">
+                <name>The Elements of Style</name>
+                <explanation></explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="peer-assessment"
+                    start="2014-03-11T10:00-18:10"
+                    due="2030-12-21T22:22-7:00"
+                    must_grade="1"
+                    must_be_graded_by="1" />
+    </assessments>
+</openassessment>

--- a/apps/openassessment/xblock/test/data/assessment_combo.json
+++ b/apps/openassessment/xblock/test/data/assessment_combo.json
@@ -15,7 +15,7 @@
         "is_released": false
     },
     "peer_only": {
-        "valid": false,
+        "valid": true,
         "assessments": [
             {
                 "name": "peer-assessment",

--- a/apps/openassessment/xblock/test/test_studio.py
+++ b/apps/openassessment/xblock/test/test_studio.py
@@ -92,7 +92,7 @@ class StudioViewTest(XBlockHandlerTestCase):
     # Test that we enforce that there are exactly two assessments,
     # peer ==> self
     # If and when we remove this restriction, this test can be deleted.
-    @data('data/invalid_assessment_combo_order.xml', 'data/invalid_assessment_combo_peer_only.xml')
+    @data('data/invalid_assessment_combo_order.xml')
     @scenario('data/basic_scenario.xml')
     def test_update_xml_invalid_assessment_combo(self, xblock, invalid_workflow):
         request = json.dumps(

--- a/apps/openassessment/xblock/validation.py
+++ b/apps/openassessment/xblock/validation.py
@@ -66,8 +66,10 @@ def validate_assessments(assessments, current_assessments, is_released):
             is_valid is a boolean indicating whether the assessment is semantically valid
             and msg describes any validation errors found.
     """
-    def _self_only(assessments):
-        return len(assessments) == 1 and assessments[0].get('name') == 'self-assessment'
+    def _only_peer_or_self(assessments):
+        return (len(assessments) == 1
+                and (assessments[0].get('name') == 'self-assessment'
+                or assessments[0].get('name') == 'peer-assessment'))
 
     def _peer_then_self(assessments):
         return (
@@ -80,17 +82,15 @@ def validate_assessments(assessments, current_assessments, is_released):
         return (False, _("This problem must include at least one assessment."))
 
     # Right now, there are two allowed scenarios: (peer -> self) and (self)
-    if not (_self_only(assessments) or _peer_then_self(assessments)):
+    if not (_only_peer_or_self(assessments) or _peer_then_self(assessments)):
         return (
             False,
-            _("For this assignment, you can set either a peer assessment followed by a self assessment or a self assessment only.")
+            _("For this assignment, you can set either a peer assessment "
+              "followed by a self assessment, peer assessment only, or a "
+              "self assessment only.")
         )
 
     for assessment_dict in assessments:
-        # Supported assessment
-        if not assessment_dict.get('name') in ['peer-assessment', 'self-assessment']:
-            return (False, _('The "name" value must be "peer-assessment" or "self-assessment".'))
-
         # Number you need to grade is >= the number of people that need to grade you
         if assessment_dict.get('name') == 'peer-assessment':
             must_grade = assessment_dict.get('must_grade')


### PR DESCRIPTION
@wedaly @ormsbee 

This covers the requirements of TIM-253.  Peer can now be configured for a question without self assessment. 
- Tests updated, still full coverage.
- Loading into devstack to test through there as well. 

@srpearce Please see Line 88 of validation.py  That's the message that'll require updating (I tried my hand at it)
