### PR TITLE
Added markupsafe for requirements

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@
 
 sphinx
 sphinxcontrib-napoleon
+markupsafe


### PR DESCRIPTION
@wedaly @stephensanchez  I needed to add this to make read the docs work.  after this is merged, you can use this as the real URL:  http://edx.readthedocs.org/projects/edx-ora-2/en/latest/

I won't remove the old one (http://edx-tim.readthedocs.org/en/latest/)  for a while.
