### PR TITLE
Peer API Refactor

### DIFF
--- a/apps/openassessment/assessment/errors.py
+++ b/apps/openassessment/assessment/errors.py
@@ -1,0 +1,72 @@
+"""
+Errors for the assessment app.
+"""
+import copy
+
+
+class PeerAssessmentError(Exception):
+    """Generic Peer Assessment Error
+
+    Raised when an error occurs while processing a request related to the
+    Peer Assessment Workflow.
+
+    """
+    pass
+
+
+class PeerAssessmentRequestError(PeerAssessmentError):
+    """Error indicating insufficient or incorrect parameters in the request.
+
+    Raised when the request does not contain enough information, or incorrect
+    information which does not allow the request to be processed.
+
+    """
+
+    def __init__(self, field_errors):
+        Exception.__init__(self, repr(field_errors))
+        self.field_errors = copy.deepcopy(field_errors)
+
+
+class PeerAssessmentWorkflowError(PeerAssessmentError):
+    """Error indicating a step in the workflow cannot be completed,
+
+    Raised when the action taken cannot be completed in the workflow. This can
+    occur based on parameters specific to the Submission, User, or Peer Scorers.
+
+    """
+    pass
+
+
+class PeerAssessmentInternalError(PeerAssessmentError):
+    """Error indicating an internal problem independent of API use.
+
+    Raised when an internal error has occurred. This should be independent of
+    the actions or parameters given to the API.
+
+    """
+    pass
+
+
+class SelfAssessmentError(Exception):
+    """Generic Self Assessment Error
+
+    Raised when an error occurs while processing a request related to the
+    Self Assessment Workflow.
+
+    """
+    pass
+
+
+class SelfAssessmentRequestError(SelfAssessmentError):
+    """
+    There was a problem with the request for a self-assessment.
+    """
+    pass
+
+
+class SelfAssessmentInternalError(SelfAssessmentError):
+    """
+    There was an internal problem while accessing the self-assessment api.
+    """
+    pass
+

--- a/apps/openassessment/assessment/self_api.py
+++ b/apps/openassessment/assessment/self_api.py
@@ -14,36 +14,15 @@ from openassessment.assessment.serializers import (
 from openassessment.assessment.models import (
     Assessment, AssessmentPart, InvalidOptionSelection
 )
+from openassessment.assessment.errors import (
+    SelfAssessmentRequestError, SelfAssessmentInternalError
+)
 
 
 # Assessments are tagged as "self-evaluation"
 SELF_TYPE = "SE"
 
 logger = logging.getLogger("openassessment.assessment.self_api")
-
-
-class SelfAssessmentError(Exception):
-    """Generic Self Assessment Error
-
-    Raised when an error occurs while processing a request related to the
-    Self Assessment Workflow.
-
-    """
-    pass
-
-
-class SelfAssessmentRequestError(SelfAssessmentError):
-    """
-    There was a problem with the request for a self-assessment.
-    """
-    pass
-
-
-class SelfAssessmentInternalError(SelfAssessmentError):
-    """
-    There was an internal problem while accessing the self-assessment api.
-    """
-    pass
 
 
 def create_assessment(submission_uuid, user_id, options_selected, rubric_dict, scored_at=None):

--- a/apps/openassessment/assessment/test/test_self.py
+++ b/apps/openassessment/assessment/test/test_self.py
@@ -9,8 +9,9 @@ import pytz
 from openassessment.test_utils import CacheResetTest
 from submissions.api import create_submission
 from openassessment.assessment.self_api import (
-    create_assessment, submitter_is_finished, SelfAssessmentRequestError, get_assessment
+    create_assessment, submitter_is_finished, get_assessment
 )
+from openassessment.assessment.errors import SelfAssessmentRequestError
 
 
 class TestSelfApi(CacheResetTest):

--- a/apps/openassessment/workflow/api.py
+++ b/apps/openassessment/workflow/api.py
@@ -8,6 +8,7 @@ import logging
 from django.db import DatabaseError
 
 from openassessment.assessment import peer_api
+from openassessment.assessment.errors import PeerAssessmentError
 from submissions import api as sub_api
 from .models import AssessmentWorkflow, AssessmentWorkflowStep
 from .serializers import AssessmentWorkflowSerializer
@@ -131,7 +132,7 @@ def create_workflow(submission_uuid, steps):
     if steps[0] == "peer":
         try:
             peer_api.create_peer_workflow(submission_uuid)
-        except peer_api.PeerAssessmentError as err:
+        except PeerAssessmentError as err:
             err_msg = u"Could not create assessment workflow: {}".format(err)
             logger.exception(err_msg)
             raise AssessmentWorkflowInternalError(err_msg)

--- a/apps/openassessment/xblock/grade_mixin.py
+++ b/apps/openassessment/xblock/grade_mixin.py
@@ -9,6 +9,7 @@ from xblock.core import XBlock
 
 from openassessment.assessment import peer_api
 from openassessment.assessment import self_api
+from openassessment.assessment.errors import SelfAssessmentError, PeerAssessmentError
 from submissions import api as sub_api
 
 
@@ -55,7 +56,7 @@ class GradeMixin(object):
                 path = 'openassessmentblock/grade/oa_grade_not_started.html'
             else:  # status is 'self' or 'peer', which implies that the workflow is incomplete
                 path, context = self.render_grade_incomplete(workflow)
-        except (sub_api.SubmissionError, peer_api.PeerAssessmentError, self_api.SelfAssessmentRequestError):
+        except (sub_api.SubmissionError, PeerAssessmentError, SelfAssessmentError):
             return self.render_error(_(u"An unexpected error occurred."))
         else:
             return self.render_assessment(path, context)


### PR DESCRIPTION
This is a preliminary step towards restructuring the assessment app, with the goal of making it easier to add additional assessment types.

When I started moving modules around, I got a bunch of test failures because the peer assessment tests were calling private functions in `peer_api`.  All of the private functions were associated with particular Django models, so I've made them public functions of those models.  This allows us to call them in the tests without breaking encapsulation boundaries.

Changes:
- Move peer assessment private methods into models.
- Move errors for assessment app into a module.

Question: Could we remove the queries with over-grading disabled, now that we're always leaving over-grading turned on?

@stephensanchez 
