### PR TITLE
Remove option to disable over-grading

### DIFF
--- a/apps/openassessment/assessment/test/test_peer.py
+++ b/apps/openassessment/assessment/test/test_peer.py
@@ -637,8 +637,6 @@ class TestPeerApi(CacheResetTest):
             RUBRIC_DICT,
             REQUIRED_GRADED_BY,
         )
-        sub = peer_api.get_submission_to_assess(buffy_sub['uuid'], REQUIRED_GRADED_BY)
-        self.assertIsNone(sub)
 
         # 11) Xander comes along and submits.
         xander_sub, xander = self._create_student_and_submission("Xander", "Xander's answer")

--- a/apps/openassessment/xblock/peer_assessment_mixin.py
+++ b/apps/openassessment/xblock/peer_assessment_mixin.py
@@ -224,8 +224,7 @@ class PeerAssessmentMixin(object):
         try:
             peer_submission = peer_api.get_submission_to_assess(
                 self.submission_uuid,
-                assessment["must_be_graded_by"],
-                True
+                assessment["must_be_graded_by"]
             )
             self.runtime.publish(
                 self,


### PR DESCRIPTION
Over-grading is currently always enabled, so we no longer need the option to disable it.
@stephensanchez 
