### PR TITLE
Will/student training xml

### DIFF
--- a/apps/openassessment/xblock/test/data/serialize.json
+++ b/apps/openassessment/xblock/test/data/serialize.json
@@ -704,5 +704,284 @@
             "</rubric>",
             "</openassessment>"
         ]
+    },
+
+    "student_training_no_examples": {
+        "title": "Foo",
+        "prompt": "Test prompt",
+        "rubric_feedback_prompt": "Test Feedback Prompt",
+        "start": null,
+        "due": null,
+        "submission_start": null,
+        "submission_due": null,
+        "criteria": [
+            {
+                "order_num": 0,
+                "name": "Test criterion",
+                "prompt": "Test criterion prompt",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            }
+        ],
+        "assessments": [
+            {
+                "name": "student-training",
+                "start": "2014-02-27T09:46:28",
+                "due": "2014-03-01T00:00:00",
+                "examples": []
+            }
+        ],
+        "expected_xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"student-training\" start=\"2014-02-27T09:46:28\" due=\"2014-03-01T00:00:00\" />",
+            "</assessments>",
+            "<rubric>",
+                "<prompt>Test prompt</prompt>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+                "<feedbackprompt>Test Feedback Prompt</feedbackprompt>",
+            "</rubric>",
+            "</openassessment>"
+        ]
+    },
+
+    "student_training_one_example": {
+        "title": "Foo",
+        "prompt": "Test prompt",
+        "rubric_feedback_prompt": "Test Feedback Prompt",
+        "start": null,
+        "due": null,
+        "submission_start": null,
+        "submission_due": null,
+        "criteria": [
+            {
+                "order_num": 0,
+                "name": "Test criterion",
+                "prompt": "Test criterion prompt",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            },
+            {
+                "order_num": 0,
+                "name": "Another test criterion",
+                "prompt": "Another test criterion prompt",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            }
+        ],
+        "assessments": [
+            {
+                "name": "student-training",
+                "start": "2014-02-27T09:46:28",
+                "due": "2014-03-01T00:00:00",
+                "examples": [
+                    {
+                        "answer": "ẗëṡẗ äṅṡẅëṛ",
+                        "options_selected": [
+                            {
+                                "criterion": "Test criterion",
+                                "option": "No"
+                            },
+                            {
+                                "criterion": "Another test criterion",
+                                "option": "Yes"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "expected_xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"student-training\" start=\"2014-02-27T09:46:28\" due=\"2014-03-01T00:00:00\">",
+                    "<example>",
+                        "<answer>ẗëṡẗ äṅṡẅëṛ</answer>",
+                        "<select criterion=\"Test criterion\" option=\"No\" />",
+                        "<select criterion=\"Another test criterion\" option=\"Yes\" />",
+                    "</example>",
+                "</assessment>",
+            "</assessments>",
+            "<rubric>",
+                "<prompt>Test prompt</prompt>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+                "<criterion>",
+                    "<name>Another test criterion</name>",
+                    "<prompt>Another test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+                "<feedbackprompt>Test Feedback Prompt</feedbackprompt>",
+            "</rubric>",
+            "</openassessment>"
+        ]
+    },
+
+    "student_training_multiple_examples": {
+        "title": "Foo",
+        "prompt": "Test prompt",
+        "rubric_feedback_prompt": "Test Feedback Prompt",
+        "start": null,
+        "due": null,
+        "submission_start": null,
+        "submission_due": null,
+        "criteria": [
+            {
+                "order_num": 0,
+                "name": "Test criterion",
+                "prompt": "Test criterion prompt",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            },
+            {
+                "order_num": 0,
+                "name": "Another test criterion",
+                "prompt": "Another test criterion prompt",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            }
+        ],
+        "assessments": [
+            {
+                "name": "student-training",
+                "start": "2014-02-27T09:46:28",
+                "due": "2014-03-01T00:00:00",
+                "examples": [
+                    {
+                        "answer": "ẗëṡẗ äṅṡẅëṛ",
+                        "options_selected": [
+                            {
+                                "criterion": "Test criterion",
+                                "option": "No"
+                            },
+                            {
+                                "criterion": "Another test criterion",
+                                "option": "Yes"
+                            }
+                        ]
+                    },
+                    {
+                        "answer": "śéćőńd téśt áńśẃéŕ",
+                        "options_selected": [
+                            {
+                                "criterion": "Test criterion",
+                                "option": "Yes"
+                            },
+                            {
+                                "criterion": "Another test criterion",
+                                "option": "No"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "expected_xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"student-training\" start=\"2014-02-27T09:46:28\" due=\"2014-03-01T00:00:00\">",
+                    "<example>",
+                        "<answer>ẗëṡẗ äṅṡẅëṛ</answer>",
+                        "<select criterion=\"Test criterion\" option=\"No\" />",
+                        "<select criterion=\"Another test criterion\" option=\"Yes\" />",
+                    "</example>",
+                    "<example>",
+                        "<answer>śéćőńd téśt áńśẃéŕ</answer>",
+                        "<select criterion=\"Test criterion\" option=\"Yes\" />",
+                        "<select criterion=\"Another test criterion\" option=\"No\" />",
+                    "</example>",
+                "</assessment>",
+            "</assessments>",
+            "<rubric>",
+                "<prompt>Test prompt</prompt>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+                "<criterion>",
+                    "<name>Another test criterion</name>",
+                    "<prompt>Another test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+                "<feedbackprompt>Test Feedback Prompt</feedbackprompt>",
+            "</rubric>",
+            "</openassessment>"
+        ]
     }
 }

--- a/apps/openassessment/xblock/test/data/student_training_combo.json
+++ b/apps/openassessment/xblock/test/data/student_training_combo.json
@@ -1,0 +1,403 @@
+{
+    "training_peer_self": {
+        "valid": true,
+        "assessments": [
+            {
+                "name": "student-training",
+                "examples": [
+                    {
+                        "answer": "тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "good"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "excellent"
+                            }
+                        ]
+                    },
+                    {
+                        "answer": "another тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "peer-assessment",
+                "must_grade": 5,
+                "must_be_graded_by": 3
+            },
+            {
+                "name": "self-assessment"
+            }
+        ],
+        "current_assessments": null,
+        "is_released": false
+    },
+
+    "training_peer": {
+        "valid": true,
+        "assessments": [
+            {
+                "name": "student-training",
+                "examples": [
+                    {
+                        "answer": "тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "good"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "excellent"
+                            }
+                        ]
+                    },
+                    {
+                        "answer": "another тєѕт αηѕωєя",
+                        "options_selected": {
+                            "vocabulary": "poor",
+                            "grammar": "good"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "peer-assessment",
+                "must_grade": 5,
+                "must_be_graded_by": 3
+            }
+        ],
+        "current_assessments": null,
+        "is_released": false
+    },
+
+    "training_only": {
+        "valid": false,
+        "assessments": [
+            {
+                "name": "student-training",
+                "examples": [
+                    {
+                        "answer": "тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "good"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "excellent"
+                            }
+                        ]
+                    },
+                    {
+                        "answer": "another тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "current_assessments": null,
+        "is_released": false
+    },
+
+    "peer_training_self": {
+        "valid": false,
+        "assessments": [
+            {
+                "name": "peer-assessment",
+                "must_grade": 5,
+                "must_be_graded_by": 3
+            },
+            {
+                "name": "student-training",
+                "examples": [
+                    {
+                        "answer": "тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    },
+                    {
+                        "answer": "another тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "self-assessment"
+            }
+        ],
+        "current_assessments": null,
+        "is_released": false
+    },
+
+    "peer_self_training": {
+        "valid": false,
+        "assessments": [
+            {
+                "name": "peer-assessment",
+                "must_grade": 5,
+                "must_be_graded_by": 3
+            },
+            {
+                "name": "self-assessment"
+            },
+            {
+                "name": "student-training",
+                "examples": [
+                    {
+                        "answer": "тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    },
+                    {
+                        "answer": "another тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "good"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "excellent"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "current_assessments": null,
+        "is_released": false
+    },
+
+    "self_training": {
+        "valid": false,
+        "assessments": [
+            {
+                "name": "self-assessment"
+            },
+            {
+                "name": "student-training",
+                "examples": [
+                    {
+                        "answer": "тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    },
+                    {
+                        "answer": "another тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "current_assessments": null,
+        "is_released": false
+    },
+
+    "training_self": {
+        "valid": false,
+        "assessments": [
+            {
+                "name": "student-training",
+                "examples": [
+                    {
+                        "answer": "тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    },
+                    {
+                        "answer": "another тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "self-assessment"
+            }
+        ],
+        "current_assessments": null,
+        "is_released": false
+    },
+
+    "remove_training_post_release": {
+        "valid": false,
+        "assessments": [
+            {
+                "name": "peer-assessment",
+                "must_grade": 5,
+                "must_be_graded_by": 3
+            }
+        ],
+        "current_assessments": [
+            {
+                "name": "student-training",
+                "examples": [
+                    {
+                        "answer": "тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    },
+                    {
+                        "answer": "another тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "peer-assessment",
+                "must_grade": 5,
+                "must_be_graded_by": 3
+            }
+        ],
+        "is_released": true
+    },
+
+    "add_training_post_release": {
+        "valid": false,
+        "assessments": [
+            {
+                "name": "student-training",
+                "examples": [
+                    {
+                        "answer": "тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    },
+                    {
+                        "answer": "another тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "peer-assessment",
+                "must_grade": 5,
+                "must_be_graded_by": 3
+            }
+        ],
+        "current_assessments": [
+            {
+                "name": "peer-assessment",
+                "must_grade": 5,
+                "must_be_graded_by": 3
+            }
+        ],
+        "is_released": true
+    }
+}

--- a/apps/openassessment/xblock/test/data/update_from_xml.json
+++ b/apps/openassessment/xblock/test/data/update_from_xml.json
@@ -549,6 +549,252 @@
                 "must_be_graded_by": 3
             }
         ]
-    }
+    },
 
+    "student_training_no_examples": {
+        "xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"student-training\" start=\"2014-04-01T00:00:00\" due=\"2014-06-01T00:00:00\" />",
+            "</assessments>",
+            "<rubric>",
+                "<prompt>Test prompt</prompt>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+            "</rubric>",
+            "</openassessment>"
+        ],
+        "title": "Foo",
+        "prompt": "Test prompt",
+        "start": "2000-01-01T00:00:00",
+        "due": "3000-01-01T00:00:00",
+        "submission_start": null,
+        "submission_due": null,
+        "criteria": [
+            {
+                "order_num": 0,
+                "name": "Test criterion",
+                "prompt": "Test criterion prompt",
+                "feedback": "disabled",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            }
+        ],
+        "assessments": [
+            {
+                "name": "student-training",
+                "start": "2014-04-01T00:00:00",
+                "due": "2014-06-01T00:00:00",
+                "examples": []
+            }
+        ]
+    },
+
+    "student_training_one_example": {
+        "xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"student-training\" start=\"2014-04-01T00:00:00\" due=\"2014-06-01T00:00:00\">",
+                    "<example>",
+                        "<answer>ẗëṡẗ äṅṡẅëṛ</answer>",
+                        "<select criterion=\"Test criterion\" option=\"Yes\" />",
+                    "</example>",
+                "</assessment>",
+            "</assessments>",
+            "<rubric>",
+                "<prompt>Test prompt</prompt>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+            "</rubric>",
+            "</openassessment>"
+        ],
+        "title": "Foo",
+        "prompt": "Test prompt",
+        "start": "2000-01-01T00:00:00",
+        "due": "3000-01-01T00:00:00",
+        "submission_start": null,
+        "submission_due": null,
+        "criteria": [
+            {
+                "order_num": 0,
+                "name": "Test criterion",
+                "prompt": "Test criterion prompt",
+                "feedback": "disabled",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            }
+        ],
+        "assessments": [
+            {
+                "name": "student-training",
+                "start": "2014-04-01T00:00:00",
+                "due": "2014-06-01T00:00:00",
+                "examples": [
+                    {
+                        "answer": "ẗëṡẗ äṅṡẅëṛ",
+                        "options_selected": [
+                            {
+                                "criterion": "Test criterion",
+                                "option": "Yes"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+
+    "student_training_multiple_examples": {
+        "xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"student-training\" start=\"2014-04-01T00:00:00\" due=\"2014-06-01T00:00:00\">",
+                    "<example>",
+                        "<answer>ẗëṡẗ äṅṡẅëṛ</answer>",
+                        "<select criterion=\"Test criterion\" option=\"Yes\" />",
+                        "<select criterion=\"Another test criterion\" option=\"No\" />",
+                    "</example>",
+                    "<example>",
+                        "<answer>äṅöẗḧëṛ ẗëṡẗ äṅṡẅëṛ</answer>",
+                        "<select criterion=\"Another test criterion\" option=\"Yes\" />",
+                        "<select criterion=\"Test criterion\" option=\"No\" />",
+                    "</example>",
+                "</assessment>",
+            "</assessments>",
+            "<rubric>",
+                "<prompt>Test prompt</prompt>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+                "<criterion>",
+                    "<name>Another test criterion</name>",
+                    "<prompt>Another test criterion prompt</prompt>",
+                    "<option points=\"0\"><name>No</name><explanation>No explanation</explanation></option>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+            "</rubric>",
+            "</openassessment>"
+        ],
+        "title": "Foo",
+        "prompt": "Test prompt",
+        "start": "2000-01-01T00:00:00",
+        "due": "3000-01-01T00:00:00",
+        "submission_start": null,
+        "submission_due": null,
+        "criteria": [
+            {
+                "order_num": 0,
+                "name": "Test criterion",
+                "prompt": "Test criterion prompt",
+                "feedback": "disabled",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            },
+            {
+                "order_num": 1,
+                "name": "Another test criterion",
+                "prompt": "Another test criterion prompt",
+                "feedback": "disabled",
+                "options": [
+                    {
+                        "order_num": 0,
+                        "points": 0,
+                        "name": "No",
+                        "explanation": "No explanation"
+                    },
+                    {
+                        "order_num": 1,
+                        "points": 2,
+                        "name": "Yes",
+                        "explanation": "Yes explanation"
+                    }
+                ]
+            }
+        ],
+        "assessments": [
+            {
+                "name": "student-training",
+                "start": "2014-04-01T00:00:00",
+                "due": "2014-06-01T00:00:00",
+                "examples": [
+                    {
+                        "answer": "ẗëṡẗ äṅṡẅëṛ",
+                        "options_selected": [
+                            {
+                                "criterion": "Test criterion",
+                                "option": "Yes"
+                            },
+                            {
+                                "criterion": "Another test criterion",
+                                "option": "No"
+                            }
+                        ]
+                    },
+                    {
+                        "answer": "äṅöẗḧëṛ ẗëṡẗ äṅṡẅëṛ",
+                        "options_selected": [
+                            {
+                                "criterion": "Another test criterion",
+                                "option": "Yes"
+                            },
+                            {
+                                "criterion": "Test criterion",
+                                "option": "No"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/apps/openassessment/xblock/test/data/update_from_xml_error.json
+++ b/apps/openassessment/xblock/test/data/update_from_xml_error.json
@@ -318,5 +318,79 @@
             "</rubric>",
             "</openassessment>"
         ]
+    },
+
+    "training_example_missing_answer": {
+        "xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"student-training\">",
+                    "<example>",
+                        "<select criterion=\"Test criterion\" option=\"Yes\" />",
+                    "</example>",
+                "</assessment>",
+                "<assessment name=\"peer-assessment\" start=\"2014-02-27T09:46:28\" due=\"2014-03-01T00:00:00\" must_grade=\"5\" must_be_graded_by=\"3\" />",
+            "</assessments>",
+            "<rubric>",
+                "<prompt>Test prompt</prompt>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+            "</rubric>",
+            "</openassessment>"
+        ]
+    },
+
+    "training_example_select_missing_criterion": {
+        "xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"student-training\">",
+                    "<example>",
+                        "<answer>Test answer</answer>",
+                        "<select option=\"Yes\" />",
+                    "</example>",
+                "</assessment>",
+                "<assessment name=\"peer-assessment\" start=\"2014-02-27T09:46:28\" due=\"2014-03-01T00:00:00\" must_grade=\"5\" must_be_graded_by=\"3\" />",
+            "</assessments>",
+            "<rubric>",
+                "<prompt>Test prompt</prompt>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+            "</rubric>",
+            "</openassessment>"
+        ]
+    },
+
+    "training_example_select_missing_option": {
+        "xml": [
+            "<openassessment>",
+            "<title>Foo</title>",
+            "<assessments>",
+                "<assessment name=\"student-training\">",
+                    "<example>",
+                        "<answer>Test answer</answer>",
+                        "<select criterion=\"Test criterion\" />",
+                    "</example>",
+                "</assessment>",
+                "<assessment name=\"peer-assessment\" start=\"2014-02-27T09:46:28\" due=\"2014-03-01T00:00:00\" must_grade=\"5\" must_be_graded_by=\"3\" />",
+            "</assessments>",
+            "<rubric>",
+                "<prompt>Test prompt</prompt>",
+                "<criterion>",
+                    "<name>Test criterion</name>",
+                    "<prompt>Test criterion prompt</prompt>",
+                    "<option points=\"2\"><name>Yes</name><explanation>Yes explanation</explanation></option>",
+                "</criterion>",
+            "</rubric>",
+            "</openassessment>"
+        ]
     }
 }

--- a/apps/openassessment/xblock/test/test_openassessment.py
+++ b/apps/openassessment/xblock/test/test_openassessment.py
@@ -156,6 +156,19 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         self.assertEqual(student_item['course_id'], 'test_course')
         self.assertEqual(student_item['student_id'], 'test_student')
 
+    @scenario('data/basic_scenario.xml', user_id='Bob')
+    def test_ignore_unknown_assessment_types(self, xblock):
+        # If the XBlock contains an unknown assessment type
+        # (perhaps after a roll-back), it should ignore it.
+        xblock.rubric_assessments.append({'name': 'unknown'})
+
+        # Check that the name is excluded from valid assessments
+        self.assertNotIn({'name': 'unknown'}, xblock.valid_assessments)
+        self.assertNotIn('unknown', xblock.assessment_steps)
+
+        # Check that we can render the student view without error
+        self.runtime.render(xblock, 'student_view')
+
 
 class TestDates(XBlockHandlerTestCase):
 

--- a/apps/openassessment/xblock/test/test_validation.py
+++ b/apps/openassessment/xblock/test/test_validation.py
@@ -1,12 +1,16 @@
+# -*- coding: utf-8 -*-
 """
 Test OpenAssessment XBlock validation.
 """
 
+import copy
 from datetime import datetime as dt
+import mock
 import pytz
 import ddt
 from django.test import TestCase
-from openassessment.xblock.validation import validate_assessments, validate_rubric, validate_dates
+from openassessment.xblock.openassessmentblock import OpenAssessmentBlock
+from openassessment.xblock.validation import validator, validate_assessments, validate_rubric, validate_dates
 
 
 @ddt.ddt
@@ -33,12 +37,41 @@ class AssessmentValidationTest(TestCase):
     # (peer -> self), and (self)
     @ddt.file_data('data/assessment_combo.json')
     def test_enforce_assessment_combo_restrictions(self, data):
-        success, msg = validate_assessments(data["assessments"], data["current_assessments"], data["is_released"])
-        self.assertEqual(success, data['valid'], msg=msg)
+        self._assert_validation(
+            data["assessments"], data["current_assessments"],
+            data["is_released"], data['valid']
+        )
+
+    @ddt.file_data('data/student_training_combo.json')
+    def test_student_training_combos(self, data):
+        self._assert_validation(
+            data["assessments"], data["current_assessments"],
+            data["is_released"], data['valid']
+        )
+
+    def _assert_validation(self, assessments, current_assessments, is_released, expected_is_valid):
+        """
+        Check that the validation function gives the expected result.
+        If there is a validation error, check that the validation error message isn't empty.
+
+        Args:
+            assessments (list): The updated list of assessments
+            current_assessments (list): The current assessments in the problem definition.
+            is_released (bool): Whether the problem has been released yet.
+            expected_is_valid (bool): Whether the inputs should be marked valid or invalid
+
+        Returns:
+            None
+
+        Raises:
+            AssertionError
+
+        """
+        success, msg = validate_assessments(assessments, current_assessments, is_released)
+        self.assertEqual(success, expected_is_valid, msg=msg)
 
         if not success:
             self.assertGreater(len(msg), 0)
-
 
 
 @ddt.ddt
@@ -131,3 +164,117 @@ class DateValidationTest(TestCase):
 
         success, _ = validate_dates(valid, valid, [(valid, "invalid")])
         self.assertFalse(success)
+
+
+class ValidationIntegrationTest(TestCase):
+    """
+    Each validation function is combined into a single function
+    used by the OA XBlock itself.
+
+    This tests the combined function, rather than the
+    individual validation functions.
+    """
+
+    CRITERION_OPTIONS = [
+        {
+            "order_num": 0,
+            "points": 0,
+            "name": "Poor",
+            "explanation": "Poor job!"
+        },
+        {
+            "order_num": 1,
+            "points": 1,
+            "name": "Good",
+            "explanation": "Good job!"
+        }
+    ]
+
+    RUBRIC = {
+        "criteria": [
+            {
+                "order_num": 0,
+                "name": "vocabulary",
+                "prompt": "How good is the vocabulary?",
+                "options": CRITERION_OPTIONS
+            },
+            {
+                "order_num": 1,
+                "name": "grammar",
+                "prompt": "How good is the grammar?",
+                "options": CRITERION_OPTIONS
+            }
+        ]
+    }
+
+    SUBMISSION = {
+        "due": None
+    }
+
+    ASSESSMENTS = [
+        {
+            "name": "student-training",
+            "start": None,
+            "due": None,
+            "examples": [
+                {
+                    "answer": "ẗëṡẗ äṅṡẅëṛ",
+                    "options_selected": [
+                        {
+                            "criterion": "vocabulary",
+                            "option": "Good"
+                        },
+                        {
+                            "criterion": "grammar",
+                            "option": "Poor"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "peer-assessment",
+            "start": None,
+            "due": None,
+            "must_grade": 5,
+            "must_be_graded_by": 3
+        }
+    ]
+
+    def setUp(self):
+        """
+        Mock the OA XBlock and create a validator function.
+        """
+        self.oa_block = mock.MagicMock(OpenAssessmentBlock)
+        self.oa_block.is_released.return_value = False
+        self.oa_block.rubric_assessments.return_value = []
+        self.oa_block.prompt = ""
+        self.oa_block.rubric_criteria = []
+        self.oa_block.start = None
+        self.oa_block.due = None
+        self.validator = validator(self.oa_block)
+
+    def test_student_training_examples_match_rubric(self):
+        is_valid, msg = self.validator(self.RUBRIC, self.SUBMISSION, self.ASSESSMENTS)
+        self.assertTrue(is_valid, msg=msg)
+        self.assertEqual(msg, "")
+
+    def test_student_training_examples_invalid_criterion(self):
+        # Mutate the assessment training examples so the criterion names don't match the rubric
+        mutated_assessments = copy.deepcopy(self.ASSESSMENTS)
+        mutated_assessments[0]['examples'][0]['options_selected'][0]['criterion'] = 'Invalid criterion!'
+
+        # Expect a validation error
+        is_valid, msg = self.validator(self.RUBRIC, self.SUBMISSION, mutated_assessments)
+        self.assertFalse(is_valid)
+        self.assertEqual(msg, u'Example 1 has an extra option for "Invalid criterion!"\nExample 1 is missing an option for "vocabulary"')
+
+    def test_student_training_examples_invalid_option(self):
+        # Mutate the assessment training examples so the option names don't match the rubric
+        mutated_assessments = copy.deepcopy(self.ASSESSMENTS)
+        mutated_assessments[0]['examples'][0]['options_selected'][0]['option'] = 'Invalid option!'
+
+        # Expect a validation error
+        is_valid, msg = self.validator(self.RUBRIC, self.SUBMISSION, mutated_assessments)
+        self.assertFalse(is_valid)
+        self.assertEqual(msg, u'Example 1 has an invalid option for "vocabulary": "Invalid option!"')

--- a/apps/openassessment/xblock/workflow_mixin.py
+++ b/apps/openassessment/xblock/workflow_mixin.py
@@ -24,7 +24,7 @@ class WorkflowMixin(object):
         # standardize.
         return [
             _convert_rubric_assessment_name(ra["name"])
-            for ra in self.rubric_assessments
+            for ra in self.valid_assessments
         ]
 
     def workflow_requirements(self):


### PR DESCRIPTION
- Add XML serialization/deserialization for student-training assessment type
- Update the XBlock to ignore assessment types not found in a whitelist.  This allows us to gracefully handle roll-forwards and roll-backs of the code when we introduce new assessment types.

This PR includes the commit from #323 -- the second commit contains the XML-specific changes.

@stephensanchez  
