### PR TITLE
Separate Python and JavaScript install/test scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,13 +75,13 @@ To limit Python tests to a particular Django app:
 
 .. code:: bash
 
-    ./scripts/test.sh openassessment.xblock
+    ./scripts/test-python.sh openassessment.xblock
 
 To run just the JavaScript tests:
 
 .. code:: bash
 
-    npm test
+    ./scripts/test-js.sh
 
 To run the JavaScript tests in Chrome so you can use the debugger:
 

--- a/scripts/install-js.sh
+++ b/scripts/install-js.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+cd `dirname $BASH_SOURCE` && cd ..
+
+STATIC_JS="apps/openassessment/xblock/static/js"
+
+echo "Installing Node requirements..."
+if [ -z `which npm` ]; then
+    echo "Please install NodeJS: http://nodejs.org/"
+    exit 1
+fi
+
+npm config set loglevel warn
+npm install
+
+echo "Minimizing XBlock JavaScript..."
+echo "(set DEBUG_JS=1 to preserve indentation and line breaks)"
+if [[ -n "$DEBUG_JS" ]]; then
+    UGLIFY_EXTRA_ARGS="--beautify"
+fi
+
+node_modules/.bin/uglifyjs $STATIC_JS/src/oa_shared.js $STATIC_JS/src/*.js $UGLIFY_EXTRA_ARGS > "$STATIC_JS/openassessment.min.js"

--- a/scripts/install-python.sh
+++ b/scripts/install-python.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+cd `dirname $BASH_SOURCE` && cd ..
+STATIC_JS="apps/openassessment/xblock/static/js"
+
+if [[ -n "$1" ]]; then
+    REQS="$1"
+else
+    REQS="dev"
+fi
+
+echo "Installing Python requirements..."
+pip install -q -r requirements/$REQS.txt
+
+echo "Installing XBlock..."
+pip install -q -e .

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,33 +1,4 @@
 #!/usr/bin/env bash
 
-cd `dirname $BASH_SOURCE` && cd ..
-STATIC_JS="apps/openassessment/xblock/static/js"
-
-if [[ -n "$1" ]]; then
-    REQS="$1"
-else
-    REQS="dev"
-fi
-
-echo "Installing Python requirements..."
-pip install -q -r requirements/$REQS.txt
-
-echo "Installing XBlock..."
-pip install -q -e .
-
-echo "Installing Node requirements..."
-if [ -z `which npm` ]; then
-    echo "Please install NodeJS: http://nodejs.org/"
-    exit 1
-fi
-
-npm config set loglevel warn
-npm install
-
-echo "Minimizing XBlock JavaScript..."
-echo "(set DEBUG_JS=1 to preserve indentation and line breaks)"
-if [[ -n "$DEBUG_JS" ]]; then
-    UGLIFY_EXTRA_ARGS="--beautify"
-fi
-
-node_modules/.bin/uglifyjs $STATIC_JS/src/oa_shared.js $STATIC_JS/src/*.js $UGLIFY_EXTRA_ARGS > "$STATIC_JS/openassessment.min.js"
+./scripts/install-python.sh
+./scripts/install-js.sh

--- a/scripts/test-js.sh
+++ b/scripts/test-js.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+cd `dirname $BASH_SOURCE` && cd ..
+./scripts/install-js.sh
+
+echo "Generating HTML fixtures for JavaScript tests..."
+export DJANGO_SETTINGS_MODULE="settings.test"
+./scripts/render_templates.py apps/openassessment/xblock/static/js/fixtures/templates.json
+
+echo "Running JavaScript tests..."
+npm test

--- a/scripts/test-python.sh
+++ b/scripts/test-python.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd `dirname $BASH_SOURCE` && cd ..
+./scripts/install-python.sh test
+
+echo "Running Python tests..."
+export DJANGO_SETTINGS_MODULE="settings.test"
+python manage.py test $1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,14 +4,5 @@
 set -e
 
 cd `dirname $BASH_SOURCE` && cd ..
-./scripts/install.sh test
-
-echo "Running Python tests..."
-export DJANGO_SETTINGS_MODULE="settings.test"
-python manage.py test $1
-
-echo "Generating HTML fixtures for JavaScript tests..."
-./scripts/render_templates.py apps/openassessment/xblock/static/js/fixtures/templates.json
-
-echo "Running JavaScript tests..."
-npm test
+./scripts/test-python.sh
+./scripts/test-js.sh


### PR DESCRIPTION
Create a script that runs just the JavaScript tests.  The main motivation is that I kept forgetting to regenerate the templates before running the JS tests last week :)

@stephensanchez @gradyward 
