### PR TITLE
Skip installation of the OA XBlock if it's already installed

### DIFF
--- a/scripts/install-python.sh
+++ b/scripts/install-python.sh
@@ -12,5 +12,7 @@ fi
 echo "Installing Python requirements..."
 pip install -q -r requirements/$REQS.txt
 
-echo "Installing XBlock..."
-pip install -q -e .
+echo "Installing the OpenAssessment XBlock..."
+if [ -z `pip freeze | grep ora2` ]; then
+    pip install -q -e .
+fi


### PR DESCRIPTION
Because installation on Vagrant is really slow... @stephensanchez 
