### PR TITLE
Will/refactor training api call

### DIFF
--- a/apps/openassessment/assessment/api/ai.py
+++ b/apps/openassessment/assessment/api/ai.py
@@ -8,7 +8,9 @@ from openassessment.assessment.serializers import (
 from openassessment.assessment.errors import (
     AITrainingRequestError, AITrainingInternalError
 )
-from openassessment.assessment.models import AITrainingWorkflow, InvalidOptionSelection
+from openassessment.assessment.models import (
+    AITrainingWorkflow, InvalidOptionSelection, NoTrainingExamples
+)
 from openassessment.assessment.worker import training as training_tasks
 
 
@@ -89,6 +91,8 @@ def train_classifiers(rubric_dict, examples, algorithm_id):
     # Create the workflow model
     try:
         workflow = AITrainingWorkflow.start_workflow(examples, algorithm_id)
+    except NoTrainingExamples as ex:
+        raise AITrainingRequestError(ex)
     except:
         msg = (
             u"An unexpected error occurred while creating "

--- a/apps/openassessment/assessment/test/test_ai.py
+++ b/apps/openassessment/assessment/test/test_ai.py
@@ -108,6 +108,11 @@ class AITrainingTest(CacheResetTest):
         with self.assertRaises(AITrainingRequestError):
             ai_api.train_classifiers(RUBRIC, mutated_examples, self.ALGORITHM_ID)
 
+    def test_train_classifiers_no_examples(self):
+        # Empty list of training examples
+        with self.assertRaises(AITrainingRequestError):
+            ai_api.train_classifiers(RUBRIC, [], self.ALGORITHM_ID)
+
     @override_settings(ORA2_AI_ALGORITHMS=AI_ALGORITHMS)
     @mock.patch.object(AITrainingWorkflow.objects, 'create')
     def test_start_workflow_database_error(self, mock_create):


### PR DESCRIPTION
- Move logic from `create_classifiers()` API call into the `AITrainingWorkflow` model.
- Define a new exception `NoTrainingExamples` for a training workflow with no training examples provided.
