### PR TITLE
Remove deprecated Exception.message calls; fix TIM-497

### DIFF
--- a/apps/openassessment/assessment/api/peer.py
+++ b/apps/openassessment/assessment/api/peer.py
@@ -163,7 +163,7 @@ def create_assessment(
         try:
             option_ids = rubric.options_ids(options_selected)
         except InvalidOptionSelection as ex:
-            msg = _("Selected options do not match the rubric: {error}").format(error=ex.message)
+            msg = _("Selected options do not match the rubric: {error}").format(error=ex)
             raise PeerAssessmentRequestError(msg)
 
         scorer_workflow = PeerWorkflow.objects.get(submission_uuid=scorer_submission_uuid)
@@ -192,7 +192,12 @@ def create_assessment(
         peer_serializer = AssessmentSerializer(data=peer_assessment)
 
         if not peer_serializer.is_valid():
-            raise PeerAssessmentRequestError(peer_serializer.errors)
+            msg = (
+                u"An error occurred while serializing "
+                u"the peer assessment associated with "
+                u"the scorer's submission UUID {}."
+            ).format(scorer_submission_uuid)
+            raise PeerAssessmentRequestError(msg)
 
         assessment = peer_serializer.save()
 

--- a/apps/openassessment/assessment/api/student_training.py
+++ b/apps/openassessment/assessment/api/student_training.py
@@ -322,7 +322,7 @@ def get_training_example(submission_uuid, rubric, examples):
         logger.exception(
             "Could not deserialize training examples for submission UUID {}".format(submission_uuid)
         )
-        raise StudentTrainingRequestError(ex.message)
+        raise StudentTrainingRequestError(ex)
     except sub_api.SubmissionNotFoundError as ex:
         msg = _(u"Could not retrieve the submission with UUID {}").format(submission_uuid)
         logger.exception(msg)

--- a/apps/openassessment/assessment/errors/peer.py
+++ b/apps/openassessment/assessment/errors/peer.py
@@ -1,7 +1,6 @@
 """
 Errors for the peer assessment.
 """
-import copy
 
 
 class PeerAssessmentError(Exception):
@@ -21,10 +20,7 @@ class PeerAssessmentRequestError(PeerAssessmentError):
     information which does not allow the request to be processed.
 
     """
-
-    def __init__(self, field_errors):
-        super(PeerAssessmentRequestError, self).__init__(repr(field_errors))
-        self.field_errors = copy.deepcopy(field_errors)
+    pass
 
 
 class PeerAssessmentWorkflowError(PeerAssessmentError):

--- a/apps/openassessment/xblock/peer_assessment_mixin.py
+++ b/apps/openassessment/xblock/peer_assessment_mixin.py
@@ -77,9 +77,9 @@ class PeerAssessmentMixin(object):
 
                 # Emit analytics event...
                 self._publish_peer_assessment_event(assessment)
-            except PeerAssessmentRequestError as ex:
-                return {'success': False, 'msg': ex.message}
-            except PeerAssessmentInternalError as ex:
+            except PeerAssessmentRequestError:
+                return {'success': False, 'msg': _(u"Your peer assessment could not be submitted.")}
+            except PeerAssessmentInternalError:
                 msg = _("Internal error occurred while creating the assessment")
                 logger.exception(msg)
                 return {'success': False, 'msg': msg}

--- a/apps/openassessment/xblock/self_assessment_mixin.py
+++ b/apps/openassessment/xblock/self_assessment_mixin.py
@@ -139,10 +139,10 @@ class SelfAssessmentMixin(object):
             # After we've created the self-assessment, we need to update the workflow.
             self.update_workflow_status()
         except self_api.SelfAssessmentRequestError as ex:
-            msg = _(u"Could not create self assessment: {error}").format(error=ex.message)
+            msg = _(u"Could not create self assessment: {error}").format(error=ex)
             return {'success': False, 'msg': msg}
         except workflow_api.AssessmentWorkflowError as ex:
-            msg = _(u"Could not update workflow: {error}").format(error=ex.message)
+            msg = _(u"Could not update workflow: {error}").format(error=ex)
             return {'success': False, 'msg': msg}
         else:
             return {'success': True, 'msg': u""}

--- a/apps/openassessment/xblock/student_training_mixin.py
+++ b/apps/openassessment/xblock/student_training_mixin.py
@@ -161,7 +161,7 @@ class StudentTrainingMixin(object):
         except (student_training.StudentTrainingRequestError, student_training.StudentTrainingInternalError) as ex:
             return {
                 'success': False,
-                'msg': _(u"Your scores could not be checked: {error}.").format(error=ex.message)
+                'msg': _(u"Your scores could not be checked: {error}.").format(error=ex)
             }
         except:
             return {

--- a/apps/openassessment/xblock/studio_mixin.py
+++ b/apps/openassessment/xblock/studio_mixin.py
@@ -56,10 +56,10 @@ class StudioMixin(object):
                 update_from_xml_str(self, data['xml'], validator=validator(self))
 
             except ValidationError as ex:
-                return {'success': False, 'msg': _('Validation error: {error}').format(error=ex.message)}
+                return {'success': False, 'msg': _('Validation error: {error}').format(error=ex)}
 
             except UpdateFromXmlError as ex:
-                return {'success': False, 'msg': _('An error occurred while saving: {error}').format(error=ex.message)}
+                return {'success': False, 'msg': _('An error occurred while saving: {error}').format(error=ex)}
 
             else:
                 return {'success': True, 'msg': _('Successfully updated OpenAssessment XBlock')}
@@ -87,7 +87,7 @@ class StudioMixin(object):
         # We do not expect `serialize_content` to raise an exception,
         # but if it does, handle it gracefully.
         except Exception as ex:
-            msg = _('An unexpected error occurred while loading the problem: {error}').format(error=ex.message)
+            msg = _('An unexpected error occurred while loading the problem: {error}').format(error=ex)
             logger.error(msg)
             return {'success': False, 'msg': msg, 'xml': u''}
         else:

--- a/apps/openassessment/xblock/validation.py
+++ b/apps/openassessment/xblock/validation.py
@@ -207,7 +207,7 @@ def validate_dates(start, end, date_ranges):
     try:
         resolve_dates(start, end, date_ranges)
     except (DateValidationError, InvalidDateFormat) as ex:
-        return (False, ex.message)
+        return (False, unicode(ex))
     else:
         return (True, u'')
 


### PR DESCRIPTION
`Exception.message` is deprecated in Python 2.6, and the Ubuntu Python interpreter complains bitterly about this when running the test suite.

Also fixes [TIM-497](https://edx-wiki.atlassian.net/browse/TIM-497): Some error messages have u"" around them

@srpearce Please review the error message text in apps/openassessment/xblock/peer_assessment_mixin.py (line 81)
