### PR TITLE
Bugfix: TIM-585

### DIFF
--- a/apps/openassessment/assessment/api/peer.py
+++ b/apps/openassessment/assessment/api/peer.py
@@ -567,8 +567,7 @@ def create_peer_workflow(submission_uuid):
         submission_uuid (str): The submission associated with this workflow.
 
     Returns:
-        Workflow (PeerWorkflow): A PeerWorkflow item created based on the given
-            student item and submission.
+        None
 
     Raises:
         SubmissionError: There was an error retrieving the submission.
@@ -587,8 +586,11 @@ def create_peer_workflow(submission_uuid):
             item_id=submission['student_item']['item_id'],
             submission_uuid=submission_uuid
         )
+        workflow.save()
     except IntegrityError:
-        workflow = PeerWorkflow.objects.get(submission_uuid=submission_uuid)
+        # If we get an integrity error, it means someone else has already
+        # created a workflow for this submission, so we don't need to do anything.
+        pass
     except DatabaseError:
         error_message = _(
             u"An internal error occurred while creating a new peer "
@@ -597,8 +599,6 @@ def create_peer_workflow(submission_uuid):
         )
         logger.exception(error_message)
         raise PeerAssessmentInternalError(error_message)
-    workflow.save()
-    return workflow
 
 
 def create_peer_workflow_item(scorer_submission_uuid, submission_uuid):

--- a/apps/openassessment/assessment/test/test_peer.py
+++ b/apps/openassessment/assessment/test/test_peer.py
@@ -358,11 +358,11 @@ class TestPeerApi(CacheResetTest):
         self.assertNotEqual(pwis[0].started_at, yesterday)
 
     def test_peer_workflow_integrity_error(self):
-        tim_sub, tim = self._create_student_and_submission("Tim", "Tim's answer")
+        tim_sub, __ = self._create_student_and_submission("Tim", "Tim's answer")
         with patch.object(PeerWorkflow.objects, "get_or_create") as mock_peer:
             mock_peer.side_effect = IntegrityError("Oh no!")
-            workflow = peer_api.create_peer_workflow(tim_sub["uuid"])
-            self.assertEquals(tim_sub["uuid"], workflow.submission_uuid)
+            # This should not raise an exception
+            peer_api.create_peer_workflow(tim_sub["uuid"])
 
     @raises(peer_api.PeerAssessmentWorkflowError)
     def test_no_submission_found_closing_assessment(self):


### PR DESCRIPTION
[TIM-585](https://edx-wiki.atlassian.net/browse/TIM-585)

Fix a 500 error caused by retrieving peer workflow after an integrity error when using repeatable-read
