### PR TITLE
Back to old-style locations for course staff info

### DIFF
--- a/apps/openassessment/xblock/staff_info_mixin.py
+++ b/apps/openassessment/xblock/staff_info_mixin.py
@@ -37,11 +37,7 @@ class StaffInfoMixin(object):
         status_counts, num_submissions = self.get_workflow_status_counts()
         context['status_counts'] = status_counts
         context['num_submissions'] = num_submissions
-
-        # We need to display the new-style locations in the course staff
-        # info, even if we're using old-style locations internally,
-        # so course staff can use the locations to delete student state.
-        context['item_id'] = unicode(self.scope_ids.usage_id)
+        context['item_id'] = student_item["item_id"]
 
         # Include release/due dates for each step in the problem
         context['step_dates'] = list()


### PR DESCRIPTION
The LMS team has updated the instructor dash to use old-style locations, so we should go back to displaying old-style locations in the course staff debug info.

Revert "Show new-style locations in course staff debug info (opaque keys update)"
This reverts commit 24df7773beffa932b04a66345a764a0f2ac34c2c.

@dianakhuang 
