### PR TITLE
Gracefully handle self-assessment with no submission.

### DIFF
--- a/apps/openassessment/xblock/self_assessment_mixin.py
+++ b/apps/openassessment/xblock/self_assessment_mixin.py
@@ -106,6 +106,9 @@ class SelfAssessmentMixin(object):
         if 'options_selected' not in data:
             return {'success': False, 'msg': _(u"Missing options_selected key in request")}
 
+        if self.submission_uuid is None:
+            return {'success': False, 'msg': _(u"You must submit a response before you can perform a self-assessment.")}
+
         try:
             assessment = self_api.create_assessment(
                 self.submission_uuid,

--- a/apps/openassessment/xblock/test/test_self.py
+++ b/apps/openassessment/xblock/test/test_self.py
@@ -53,6 +53,13 @@ class TestSelfAssessment(XBlockHandlerTestCase):
         self.assertEqual(parts[1]['option']['name'], u'ﻉซƈﻉɭɭﻉกՇ')
 
     @scenario('data/self_assessment_scenario.xml', user_id='Bob')
+    def test_self_assess_no_submission(self, xblock):
+        # Submit a self-assessment without first creating a submission
+        resp = self.request(xblock, 'self_assess', json.dumps(self.ASSESSMENT), response_format='json')
+        self.assertFalse(resp['success'])
+        self.assertGreater(len(resp['msg']), 0)
+
+    @scenario('data/self_assessment_scenario.xml', user_id='Bob')
     def test_self_assess_updates_workflow(self, xblock):
 
         # Create a submission for the student


### PR DESCRIPTION
Discovered while updating the perf/concurrency tests.  Without this fix, a 500 error is raised by the submission API when you try to retrieve the submission.

@stephensanchez 
