### PR TITLE
Catch a peer API workflow exception

### DIFF
--- a/apps/openassessment/xblock/peer_assessment_mixin.py
+++ b/apps/openassessment/xblock/peer_assessment_mixin.py
@@ -6,8 +6,7 @@ from xblock.core import XBlock
 
 from openassessment.assessment.api import peer as peer_api
 from openassessment.assessment.errors import (
-    PeerAssessmentInternalError, PeerAssessmentRequestError,
-    PeerAssessmentWorkflowError
+    PeerAssessmentError, PeerAssessmentWorkflowError
 )
 import openassessment.workflow.api as workflow_api
 from .resolve_dates import DISTANT_FUTURE
@@ -80,12 +79,8 @@ class PeerAssessmentMixin(object):
 
                 # Emit analytics event...
                 self._publish_peer_assessment_event(assessment)
-            except PeerAssessmentRequestError:
+            except PeerAssessmentError:
                 return {'success': False, 'msg': _(u"Your peer assessment could not be submitted.")}
-            except PeerAssessmentInternalError:
-                msg = _("Internal error occurred while creating the assessment")
-                logger.exception(msg)
-                return {'success': False, 'msg': msg}
 
             # Update both the workflow that the submission we're assessing
             # belongs to, as well as our own (e.g. have we evaluated enough?)

--- a/apps/openassessment/xblock/test/test_peer.py
+++ b/apps/openassessment/xblock/test/test_peer.py
@@ -90,6 +90,18 @@ class TestPeerAssessment(XBlockHandlerTestCase):
         self.assertGreater(len(resp['msg']), 0)
 
     @scenario('data/peer_assessment_scenario.xml', user_id='Bob')
+    def test_peer_assess_without_leasing_submission(self, xblock):
+        # Create a submission
+        student_item = xblock.get_student_item_dict()
+        submission = xblock.create_submission(student_item, u"Bob's answer")
+
+        # Attempt to assess a peer without first leasing their submission
+        # (usually occurs by rendering the peer assessment step)
+        resp = self.request(xblock, 'peer_assess', json.dumps(self.ASSESSMENT), response_format='json')
+        self.assertEqual(resp['success'], False)
+        self.assertGreater(len(resp['msg']), 0)
+
+    @scenario('data/peer_assessment_scenario.xml', user_id='Bob')
     def test_missing_keys_in_request(self, xblock):
         for missing in ['criterion_feedback', 'overall_feedback', 'options_selected']:
             assessment = copy.deepcopy(self.ASSESSMENT)


### PR DESCRIPTION
We should have been catching `PeerAssessmentWorkflowError` in the peer assessment mixin, but weren't.  The error occurs when someone tries to assess a peer without first obtaining a lease on the submission.  We've seen this error a few times in the logs and downgraded it to a warning, but because we weren't catching it, it was causing a 500 error.

@stephensanchez 
