### PR TITLE
Clean up logging in peer and self assessment mixins

### DIFF
--- a/apps/openassessment/assessment/api/peer.py
+++ b/apps/openassessment/assessment/api/peer.py
@@ -525,9 +525,10 @@ def get_submission_to_assess(submission_uuid, graded_by):
     """
     workflow = PeerWorkflow.get_by_submission_uuid(submission_uuid)
     if not workflow:
-        raise PeerAssessmentWorkflowError(_(
-            u"A Peer Assessment Workflow does not exist for the specified "
-            u"student."))
+        raise PeerAssessmentWorkflowError(
+            u"A Peer Assessment Workflow does not exist for the student "
+            u"with submission UUID {}".format(submission_uuid)
+        )
     peer_submission_uuid = workflow.find_active_assessments()
     # If there is an active assessment for this user, get that submission,
     # otherwise, get the first assessment for review, otherwise,

--- a/apps/openassessment/assessment/test/test_peer.py
+++ b/apps/openassessment/assessment/test/test_peer.py
@@ -1169,6 +1169,12 @@ class TestPeerApi(CacheResetTest):
             MONDAY,
         )
 
+    def test_get_submission_to_assess_no_workflow(self):
+        # Try to retrieve a submission to assess when the student
+        # doing the assessment hasn't yet submitted.
+        with self.assertRaises(peer_api.PeerAssessmentWorkflowError):
+            peer_api.get_submission_to_assess("no_such_submission", "scorer ID")
+
     @staticmethod
     def _create_student_and_submission(student, answer, date=None):
         new_student_item = STUDENT_ITEM.copy()

--- a/apps/openassessment/xblock/self_assessment_mixin.py
+++ b/apps/openassessment/xblock/self_assessment_mixin.py
@@ -141,11 +141,20 @@ class SelfAssessmentMixin(object):
             )
             # After we've created the self-assessment, we need to update the workflow.
             self.update_workflow_status()
-        except self_api.SelfAssessmentRequestError as ex:
-            msg = _(u"Could not create self assessment: {error}").format(error=ex)
+        except (self_api.SelfAssessmentRequestError, workflow_api.AssessmentWorkflowRequestError):
+            logger.warning(
+                u"An error occurred while submitting a self assessment "
+                u"for the submission {}".format(self.submission_uuid),
+                exc_info=True
+            )
+            msg = _(u"Your self assessment could not be submitted.")
             return {'success': False, 'msg': msg}
-        except workflow_api.AssessmentWorkflowError as ex:
-            msg = _(u"Could not update workflow: {error}").format(error=ex)
+        except (self_api.SelfAssessmentInternalError, workflow_api.AssessmentWorkflowInternalError):
+            logger.exception(
+                u"An error occurred while submitting a self assessment "
+                u"for the submission {}".format(self.submission_uuid),
+            )
+            msg = _(u"Your self assessment could not be submitted.")
             return {'success': False, 'msg': msg}
         else:
             return {'success': True, 'msg': u""}

--- a/apps/openassessment/xblock/test/test_self.py
+++ b/apps/openassessment/xblock/test/test_self.py
@@ -87,14 +87,13 @@ class TestSelfAssessment(XBlockHandlerTestCase):
         with mock.patch('openassessment.xblock.workflow_mixin.workflow_api') as mock_api:
 
             # Simulate a workflow error
-            mock_api.update_from_assessments.side_effect = workflow_api.AssessmentWorkflowError
+            mock_api.update_from_assessments.side_effect = workflow_api.AssessmentWorkflowInternalError
 
             # Submit a self-assessment
             resp = self.request(xblock, 'self_assess', json.dumps(self.ASSESSMENT), response_format='json')
 
             # Verify that the we get an error response
             self.assertFalse(resp['success'])
-            self.assertIn('workflow', resp['msg'].lower())
 
     @scenario('data/self_assessment_scenario.xml', user_id='Bob')
     def test_self_assess_handler_missing_keys(self, xblock):


### PR DESCRIPTION
I was trying to debug an issue in Vagrant and discovered that, under certain circumstances, we were showing a client-side error message when the user tried to peer assess, but we weren't logging it anywhere.

While cleaning that up, I noticed a few other places where we were internationalizing log messages and displaying exceptions directly to users.  I've also added test cases for errors we weren't covering.

@stephensanchez Please review.

@srpearce There's a small user-facing change in the self-assessment error message -- instead of showing the exception on an error, this will now display the message "Your self assessment could not be submitted."  None of the other text changes are user-facing.
