### PR TITLE
Bugfix!  Commit the AIGradingWorkflow model before scheduling a grading task.

### DIFF
--- a/apps/openassessment/assessment/models/ai.py
+++ b/apps/openassessment/assessment/models/ai.py
@@ -590,8 +590,21 @@ class AIGradingWorkflow(AIWorkflow):
             rubric=rubric
         )
 
-        workflow._log_start_workflow()
+        # Retrieve classifier set candidates
+        classifier_set_candidates = AIClassifierSet.objects.filter(
+            rubric=rubric, algorithm_id=algorithm_id
+        )[:1]
 
+        # If we find classifiers for this rubric/algorithm
+        # then associate the classifiers with the workflow
+        # and schedule a grading task.
+        # Otherwise, the task will need to be scheduled later,
+        # once the classifiers have been trained.
+        if len(classifier_set_candidates) > 0:
+            workflow.classifier_set = classifier_set_candidates[0]
+            workflow.save()
+
+        workflow._log_start_workflow()
         return workflow
 
     @transaction.commit_on_success


### PR DESCRIPTION
First bugfix!  From examining the MySQL logs, I confirmed that Django was committing the transaction after the worker tried to retrieve the workflow.

Fortunately, `AIGradingWorkflow.start_workflow` was already wrapped in a `commit_on_success` decorator, so I moved the code that looks up and sets the classifier into that transaction.  This guarantees that if a classifier set is available, it will be included with the workflow as soon as it is committed to the database.

@stephensanchez 
