### PR TITLE
Remove cache key versioning

### DIFF
--- a/apps/openassessment/assessment/models/training.py
+++ b/apps/openassessment/assessment/models/training.py
@@ -23,10 +23,6 @@ class TrainingExample(models.Model):
     # SHA1 hash
     content_hash = models.CharField(max_length=40, unique=True, db_index=True)
 
-    # Version for models serialized to the cache
-    # Increment this number whenever you update this model!
-    CACHE_KEY_VERSION = 1
-
     class Meta:
         app_label = "assessment"
 
@@ -102,12 +98,11 @@ class TrainingExample(models.Model):
 
         """
         if attribute is None:
-            key_template = u"TrainingExample.json.v{version}.{content_hash}"
+            key_template = u"TrainingExample.json.{content_hash}"
         else:
-            key_template = u"TrainingExample.{attribute}.json.v{version}.{content_hash}"
+            key_template = u"TrainingExample.{attribute}.json.{content_hash}"
 
         cache_key = key_template.format(
-            version=self.CACHE_KEY_VERSION,
             content_hash=self.content_hash,
             attribute=attribute
         )
@@ -149,8 +144,7 @@ class TrainingExample(models.Model):
 
         """
         content_hash = cls.calculate_hash(answer, options_selected, rubric)
-        cache_key = u"TrainingExample.model.v{version}.{content_hash}".format(
-            version=cls.CACHE_KEY_VERSION,
+        cache_key = u"TrainingExample.model.{content_hash}".format(
             content_hash=content_hash
         )
         return cache_key, content_hash

--- a/apps/openassessment/assessment/serializers/base.py
+++ b/apps/openassessment/assessment/serializers/base.py
@@ -15,26 +15,6 @@ from openassessment.assessment.models import (
 logger = logging.getLogger(__name__)
 
 
-# Current version of the models in the cache
-# Increment this to ignore assessment models currently in the cache
-# when model fields change.
-CACHE_VERSION = 1
-
-
-def _versioned_cache_key(key):
-    """
-    Add a version number to a cache key, so we
-
-    Args:
-        key (unicode): The original, unversioned, cache key.
-
-    Returns:
-        unicode: Cache key with the version appended.
-
-    """
-    return u"{}.v{}".format(key, CACHE_VERSION)
-
-
 class InvalidRubric(Exception):
     """This can be raised during the deserialization process."""
     def __init__(self, errors):
@@ -218,10 +198,8 @@ def full_assessment_dict(assessment, rubric_dict=None):
     Returns:
         dict with keys 'rubric' (serialized Rubric model) and 'parts' (serialized assessment parts)
     """
-    assessment_cache_key = _versioned_cache_key(
-        "assessment.full_assessment_dict.{}.{}.{}".format(
-            assessment.id, assessment.submission_uuid, assessment.scored_at.isoformat()
-        )
+    assessment_cache_key = "assessment.full_assessment_dict.{}.{}.{}".format(
+        assessment.id, assessment.submission_uuid, assessment.scored_at.isoformat()
     )
     assessment_dict = cache.get(assessment_cache_key)
     if assessment_dict:


### PR DESCRIPTION
The LMS is already doing cache key versioning based on the git hash of edx-platform.  In the interest of code cleanliness, I'd like to remove our (redundant) cache-key versioning.

@ormsbee please review.
