### PR TITLE
Pass over unknown workflow steps.

### DIFF
--- a/apps/openassessment/workflow/models.py
+++ b/apps/openassessment/workflow/models.py
@@ -189,7 +189,8 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
         Simple helper function for retrieving all the steps in the given
         Workflow.
         """
-        steps = list(self.steps.all())
+        # Do not return steps that are not recognized in the AssessmentWorkflow.
+        steps = list(self.steps.filter(name__in=AssessmentWorkflow.STEPS))
         if not steps:
             # If no steps exist for this AssessmentWorkflow, assume
             # peer -> self for backwards compatibility


### PR DESCRIPTION
@wedaly @gradyward 

Don't you hate when all your afternoon's effort is summed up with a one-line change?

In order to support rolling back, with workflows that have a status in a now 'unknown' state, we do not iterate over any steps in the Workflow API if they are not explicitly declared in AssessmentWorkflow.STEPS.  This should avoid any risk of calling unknown APIs.

Test simulates this adjusted contract by adding a module to AssessmentWorkflow.STEPS, then removing it. 
