### PR TITLE
Upgrade `requests` module to 2.3.0

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -50,7 +50,7 @@ python-memcached==1.48
 python-openid==2.2.5
 pytz==2012h
 PyYAML==3.10
-requests==1.2.3
+requests==2.3.0
 Shapely==1.2.16
 sorl-thumbnail==11.12
 South==0.7.6


### PR DESCRIPTION
Pretty minor upgrade: http://docs.python-requests.org/en/latest/api/#migrating-to-2-x

Here's the companion PR for edx-platform: https://github.com/edx/edx-platform/pull/4026
