### PR TITLE
More workflow refactoring

### DIFF
--- a/openassessment/assessment/api/peer.py
+++ b/openassessment/assessment/api/peer.py
@@ -31,6 +31,10 @@ def submitter_is_finished(submission_uuid, requirements):
     """
     Check whether the submitter has made the required number of assessments.
 
+    If the requirements dict is None (because we're being updated
+    asynchronously or when the workflow is first created),
+    then automatically return False.
+
     Args:
         submission_uuid (str): The UUID of the submission being tracked.
         requirements (dict): Dictionary with the key "must_grade" indicating
@@ -40,6 +44,9 @@ def submitter_is_finished(submission_uuid, requirements):
         bool
 
     """
+    if requirements is None:
+        return False
+
     try:
         workflow = PeerWorkflow.objects.get(submission_uuid=submission_uuid)
         if workflow.completed_at is not None:
@@ -58,6 +65,10 @@ def assessment_is_finished(submission_uuid, requirements):
     Check whether the submitter has received enough assessments
     to get a score.
 
+    If the requirements dict is None (because we're being updated
+    asynchronously or when the workflow is first created),
+    then automatically return False.
+
     Args:
         submission_uuid (str): The UUID of the submission being tracked.
         requirements (dict): Dictionary with the key "must_be_graded_by"
@@ -68,6 +79,8 @@ def assessment_is_finished(submission_uuid, requirements):
 
         bool
     """
+    if requirements is None:
+        return False
     return bool(get_score(submission_uuid, requirements))
 
 
@@ -126,6 +139,7 @@ def get_score(submission_uuid, requirements):
         dict with keys "points_earned" and "points_possible".
 
     """
+
     # User hasn't completed their own submission yet
     if not submitter_is_finished(submission_uuid, requirements):
         return None

--- a/openassessment/assessment/api/student_training.py
+++ b/openassessment/assessment/api/student_training.py
@@ -41,6 +41,9 @@ def submitter_is_finished(submission_uuid, requirements):   # pylint:disable=W06
         StudentTrainingRequestError
 
     """
+    if requirements is None:
+        return False
+
     try:
         num_required = int(requirements['num_required'])
     except KeyError:

--- a/openassessment/assessment/test/test_peer.py
+++ b/openassessment/assessment/test/test_peer.py
@@ -1095,12 +1095,12 @@ class TestPeerApi(CacheResetTest):
             1
         )
 
-    @patch.object(Assessment.objects, 'filter')
     @raises(peer_api.PeerAssessmentInternalError)
-    def test_max_score_db_error(self, mock_filter):
-        mock_filter.side_effect = DatabaseError("Bad things happened")
+    def test_max_score_db_error(self):
         tim, _ = self._create_student_and_submission("Tim", "Tim's answer")
-        peer_api.get_rubric_max_scores(tim["uuid"])
+        with patch.object(Assessment.objects, 'filter') as mock_filter:
+            mock_filter.side_effect = DatabaseError("Bad things happened")
+            peer_api.get_rubric_max_scores(tim["uuid"])
 
     @patch.object(PeerWorkflow.objects, 'get')
     @raises(peer_api.PeerAssessmentInternalError)

--- a/openassessment/workflow/test/test_api.py
+++ b/openassessment/workflow/test/test_api.py
@@ -14,7 +14,7 @@ import submissions.api as sub_api
 from openassessment.assessment.api import peer as peer_api
 from openassessment.assessment.api import self as self_api
 from openassessment.workflow.models import AssessmentWorkflow
-from openassessment.workflow.errors import AssessmentApiLoadError
+from openassessment.workflow.errors import AssessmentWorkflowInternalError
 
 
 ITEM_1 = {
@@ -264,9 +264,10 @@ class TestAssessmentWorkflowApi(CacheResetTest):
             "item_type": "openassessment",
         }, "test answer")
 
-        workflow_api.create_workflow(submission['uuid'], ['self'])
+        with self.assertRaises(AssessmentWorkflowInternalError):
+            workflow_api.create_workflow(submission['uuid'], ['self'])
 
-        with self.assertRaises(AssessmentApiLoadError):
+        with self.assertRaises(AssessmentWorkflowInternalError):
             workflow_api.update_from_assessments(submission['uuid'], {})
 
     def _create_workflow_with_status(


### PR DESCRIPTION
- Avoid hard-coding assessment logic for the first step.
- Add an `on_init()` call to assessment APIs that support it (not currently used, but will be for AI)
- Avoid rejecting new workflows with unrecognized steps (support rollbacks)
- Small fixup with a key error in a log message.

@stephensanchez 
