### PR TITLE
Cache AI classifier data

### DIFF
--- a/openassessment/test_utils.py
+++ b/openassessment/test_utils.py
@@ -1,7 +1,7 @@
 """
 Test utilities
 """
-from django.core.cache import cache
+from django.core.cache import cache, get_cache
 from django.test import TestCase
 
 
@@ -11,8 +11,18 @@ class CacheResetTest(TestCase):
     """
     def setUp(self):
         super(CacheResetTest, self).setUp()
-        cache.clear()
+        self._clear_all_caches()
 
     def tearDown(self):
         super(CacheResetTest, self).tearDown()
+        self._clear_all_caches()
+
+    def _clear_all_caches(self):
+        """
+        Clear the default cache and any custom caches.
+        """
         cache.clear()
+        get_cache(
+            'django.core.cache.backends.locmem.LocMemCache',
+            LOCATION='openassessment.ai.classifiers_dict'
+        ).clear()


### PR DESCRIPTION
This should avoid hitting S3 (and, less importantly, the database and `json`).   I'm using an in-memory cache since the objects we'll need to store are generally going to be larger than the memcached default max size.

If necessary, we could make the cache backend configurable in Django settings, but I'd like to avoid adding yet another ORA2-specific setting to edx-platform, especially since in this case the setting is being read from `lms.envs.json`.

@stephensanchez 
