### PR TITLE
Fix grade display that was broken with i18n cleanup

### DIFF
--- a/openassessment/templates/openassessmentblock/grade/oa_grade_complete.html
+++ b/openassessment/templates/openassessmentblock/grade/oa_grade_complete.html
@@ -38,10 +38,10 @@
 
                                 <span class="question__score">
                                   <span class="label sr">{% trans "Overall Grade" %}</span>
-                                  <span class="question__score__value">{{ score.points_earned }}</span>
+                                  <span class="question__score__value">{{ criterion.median_score }}</span>
                                   <span class="label label--divider sr">out of</span>
                                   <span class="question__score__potential">
-                                    {{ score.points_possible }}
+                                    {{ criterion.total_value }}
                                     <span class="unit">{% trans "Points" %}</span>
                                   </span>
                                 </span>


### PR DESCRIPTION
This will need to go out in the next release: when I made the i18n changes, I accidentally changed the grade complete template to show the overall score for each criterion.

@stephensanchez 
