### PR TITLE
TIM-652

### DIFF
--- a/openassessment/test_utils.py
+++ b/openassessment/test_utils.py
@@ -1,8 +1,11 @@
 """
 Test utilities
 """
-from django.core.cache import cache, get_cache
+from django.core.cache import cache
 from django.test import TestCase
+from openassessment.assessment.models.ai import (
+    CLASSIFIERS_CACHE_IN_MEM, CLASSIFIERS_CACHE_IN_FILE
+)
 
 
 class CacheResetTest(TestCase):
@@ -22,7 +25,5 @@ class CacheResetTest(TestCase):
         Clear the default cache and any custom caches.
         """
         cache.clear()
-        get_cache(
-            'django.core.cache.backends.locmem.LocMemCache',
-            LOCATION='openassessment.ai.classifiers_dict'
-        ).clear()
+        CLASSIFIERS_CACHE_IN_MEM.clear()
+        CLASSIFIERS_CACHE_IN_FILE.clear()


### PR DESCRIPTION
- Fallback to file-based cache for classifier data
- Add info-level logging for cache hits/misses

Addresses [TIM-652](https://edx-wiki.atlassian.net/browse/TIM-652): Celery workers lose their cache after an exception causing many hits to S3.

@stephensanchez Please review.
