### PR TITLE
AI: Celery workers lose their cache after an exception causing many hits to S3

### DIFF
--- a/openassessment/assessment/api/ai_worker.py
+++ b/openassessment/assessment/api/ai_worker.py
@@ -66,19 +66,11 @@ def get_grading_task_params(grading_workflow_uuid):
         raise AIGradingInternalError(msg)
 
     try:
-        classifiers = list(classifier_set.classifiers.select_related().all())
-
         return {
             'essay_text': workflow.essay_text,
-            'classifier_set': {
-                classifier.criterion.name: classifier.download_classifier_data()
-                for classifier in classifiers
-            },
+            'classifier_set': workflow.classifier_set.classifier_data_by_criterion,
             'algorithm_id': workflow.algorithm_id,
-            'valid_scores': {
-                classifier.criterion.name: classifier.valid_scores
-                for classifier in classifiers
-            }
+            'valid_scores': workflow.classifier_set.valid_scores_by_criterion,
         }
     except (DatabaseError, ClassifierSerializeError, IncompleteClassifierSet, ValueError) as ex:
         msg = (

--- a/openassessment/assessment/test/test_ai.py
+++ b/openassessment/assessment/test/test_ai.py
@@ -107,7 +107,7 @@ class AITrainingTest(CacheResetTest):
         self.assertIsNot(classifier_set, None)
 
         # Retrieve a dictionary mapping criteria names to deserialized classifiers
-        classifiers = classifier_set.classifiers_dict
+        classifiers = classifier_set.classifier_data_by_criterion
 
         # Check that we have classifiers for all criteria in the rubric
         criteria = set(criterion['name'] for criterion in RUBRIC['criteria'])

--- a/openassessment/assessment/test/test_ai_models.py
+++ b/openassessment/assessment/test/test_ai_models.py
@@ -6,7 +6,8 @@ import copy
 from django.test.utils import override_settings
 from openassessment.test_utils import CacheResetTest
 from openassessment.assessment.models import (
-    AIClassifierSet, AIClassifier, AIGradingWorkflow, AI_CLASSIFIER_STORAGE
+    AIClassifierSet, AIClassifier, AIGradingWorkflow, AI_CLASSIFIER_STORAGE,
+    CLASSIFIERS_CACHE_IN_MEM
 )
 from openassessment.assessment.serializers import rubric_from_dict
 from .constants import RUBRIC
@@ -58,6 +59,7 @@ class AIClassifierSetTest(CacheResetTest):
     Tests for the AIClassifierSet model.
     """
     def setUp(self):
+        super(AIClassifierSetTest, self).setUp()
         rubric = rubric_from_dict(RUBRIC)
         self.classifier_set = AIClassifierSet.create_classifier_set(
             CLASSIFIERS_DICT, rubric, "test_algorithm", COURSE_ID, ITEM_ID
@@ -67,13 +69,31 @@ class AIClassifierSetTest(CacheResetTest):
         # Retrieve the classifier dict twice, which should hit the caching code.
         # We can check that we're using the cache by asserting that
         # the number of database queries decreases.
-        with self.assertNumQueries(3):
-            first = self.classifier_set.classifiers_dict
+        with self.assertNumQueries(1):
+            first = self.classifier_set.classifier_data_by_criterion
 
         with self.assertNumQueries(0):
-            second = self.classifier_set.classifiers_dict
+            second = self.classifier_set.classifier_data_by_criterion
 
         # Verify that we got the same value both times
+        self.assertEqual(first, second)
+
+    def test_file_cache_downloads(self):
+        # Retrieve the classifiers dict, which should be cached
+        # both in memory and on the file system
+        first = self.classifier_set.classifier_data_by_criterion
+
+        # Clear the in-memory cache
+        # This simulates what happens when a worker process dies
+        # after exceeding the maximum number of retries.
+        CLASSIFIERS_CACHE_IN_MEM.clear()
+
+        # We should still be able to retrieve the classifiers dict
+        # from the on-disk cache, even if memory has been cleared
+        with self.assertNumQueries(0):
+            second = self.classifier_set.classifier_data_by_criterion
+
+        # Verify that we got the correct classifiers dict back
         self.assertEqual(first, second)
 
 

--- a/openassessment/assessment/test/test_ai_worker.py
+++ b/openassessment/assessment/test/test_ai_worker.py
@@ -117,7 +117,7 @@ class AIWorkerTrainingTest(CacheResetTest):
 
         # Expect that the classifier set was created with the correct data
         self.assertIsNot(workflow.classifier_set, None)
-        saved_classifiers = workflow.classifier_set.classifiers_dict
+        saved_classifiers = workflow.classifier_set.classifier_data_by_criterion
         self.assertItemsEqual(CLASSIFIERS, saved_classifiers)
 
     def test_create_classifiers_no_workflow(self):
@@ -177,7 +177,7 @@ class AIWorkerTrainingTest(CacheResetTest):
 
         # Expect that the classifier set was created with the correct data
         self.assertIsNot(workflow.classifier_set, None)
-        saved_classifiers = workflow.classifier_set.classifiers_dict
+        saved_classifiers = workflow.classifier_set.classifier_data_by_criterion
         self.assertItemsEqual(CLASSIFIERS, saved_classifiers)
 
     def test_create_classifiers_no_training_examples(self):
@@ -234,12 +234,12 @@ class AIWorkerGradingTest(CacheResetTest):
         self.assertItemsEqual(params, expected_params)
 
     def test_get_grading_task_params_num_queries(self):
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             ai_worker_api.get_grading_task_params(self.workflow_uuid)
 
         # The second time through we should be caching the queries
         # to determine the valid scores for a classifier
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             ai_worker_api.get_grading_task_params(self.workflow_uuid)
 
     def test_get_grading_task_params_no_workflow(self):

--- a/openassessment/test_utils.py
+++ b/openassessment/test_utils.py
@@ -1,8 +1,11 @@
 """
 Test utilities
 """
-from django.core.cache import cache, get_cache
+from django.core.cache import cache
 from django.test import TestCase
+from openassessment.assessment.models.ai import (
+    CLASSIFIERS_CACHE_IN_MEM, CLASSIFIERS_CACHE_IN_FILE
+)
 
 
 class CacheResetTest(TestCase):
@@ -22,7 +25,5 @@ class CacheResetTest(TestCase):
         Clear the default cache and any custom caches.
         """
         cache.clear()
-        get_cache(
-            'django.core.cache.backends.locmem.LocMemCache',
-            LOCATION='openassessment.ai.classifiers_dict'
-        ).clear()
+        CLASSIFIERS_CACHE_IN_MEM.clear()
+        CLASSIFIERS_CACHE_IN_FILE.clear()


### PR DESCRIPTION
Fallback to file-based cache for classifier data
Add info-level logging for cache hits/misses

[TIM-652](https://edx-wiki.atlassian.net/browse/TIM-652): Celery workers lose their cache after an exception causing many hits to S3

@stephensanchez This is now ready for review :)
