### PR TITLE
Bugfix: validate duplicate point values for rubrics with example-based assessments

### DIFF
--- a/openassessment/xblock/test/test_validation.py
+++ b/openassessment/xblock/test/test_validation.py
@@ -321,6 +321,7 @@ class ValidationIntegrationTest(TestCase):
         # for a particular criterion.
         # This should cause a validation error with example-based assessment.
         mutated_rubric = copy.deepcopy(self.RUBRIC)
+        mutated_rubric['criteria'][0]['options'] = copy.deepcopy(self.CRITERION_OPTIONS)
         for option in mutated_rubric['criteria'][0]['options']:
             option['points'] = 1
 

--- a/openassessment/xblock/validation.py
+++ b/openassessment/xblock/validation.py
@@ -186,14 +186,14 @@ def validate_rubric(rubric_dict, current_rubric, is_released, is_example_based):
             )
             return (False, msg)
 
-    # Example-based assessments impose the additional restriction
-    # that the point values for options must be unique within
-    # a particular rubric criterion.
-    if is_example_based:
-        duplicates = _duplicates([option['points'] for option in criterion['options']])
-        if len(duplicates) > 0:
-            msg = _(u"Example-based assessments cannot have duplicate point values.")
-            return (False, msg)
+        # Example-based assessments impose the additional restriction
+        # that the point values for options must be unique within
+        # a particular rubric criterion.
+        if is_example_based:
+            duplicates = _duplicates([option['points'] for option in criterion['options']])
+            if len(duplicates) > 0:
+                msg = _(u"Example-based assessments cannot have duplicate point values.")
+                return (False, msg)
 
     # After a problem is released, authors are allowed to change text,
     # but nothing that would change the point value of a rubric.


### PR DESCRIPTION
[TIM-660](https://edx-wiki.atlassian.net/browse/TIM-660): AI: Duplicate point values are being allowed by Studio for example-based grading, but they shouldn't be.

The indentation level was wrong; fixed and updated the test to catch the error.

@stephensanchez 
