### PR TITLE
Concatenate validation errors with semicolons instead of newlines so they show up correctly in Studio

### DIFF
--- a/openassessment/xblock/test/test_validation.py
+++ b/openassessment/xblock/test/test_validation.py
@@ -304,7 +304,7 @@ class ValidationIntegrationTest(TestCase):
         # Expect a validation error
         is_valid, msg = self.validator(self.RUBRIC, self.SUBMISSION, mutated_assessments)
         self.assertFalse(is_valid)
-        self.assertEqual(msg, u'Example 1 has an extra option for "Invalid criterion!"\nExample 1 is missing an option for "vocabulary"')
+        self.assertEqual(msg, u'Example 1 has an extra option for "Invalid criterion!"; Example 1 is missing an option for "vocabulary"')
 
     def test_student_training_examples_invalid_option(self):
         # Mutate the assessment training examples so the option names don't match the rubric

--- a/openassessment/xblock/validation.py
+++ b/openassessment/xblock/validation.py
@@ -278,7 +278,7 @@ def validate_assessment_examples(rubric_dict, assessments):
             # examples against the rubric.
             errors = validate_training_examples(rubric_dict, examples)
             if errors:
-                return False, "\n".join(errors)
+                return False, "; ".join(errors)
 
     return True, u''
 


### PR DESCRIPTION
[TIM-659](https://edx-wiki.atlassian.net/browse/TIM-659): Studio validation errors concatenated with a space, not a comma/semicolon

@srpearce Could you please review this change?  Right now, the message looks like this:

![image](https://cloud.githubusercontent.com/assets/2948394/3363139/d5ac625c-fb10-11e3-8ca9-ee61e398d9cf.png)

This PR changes the space to a semicolon (before the second "Example 2").  Obviously not ideal, but (I think) a reasonable approach given that we're shoving the error message into Studio's UI.  I'm not sure of a way to make the error messages less verbose without making the code much more complex.
