### PR TITLE
Add criterion foreign key to assessment part model (write only)

### DIFF
--- a/openassessment/assessment/migrations/0018_auto__add_field_assessmentpart_criterion.py
+++ b/openassessment/assessment/migrations/0018_auto__add_field_assessmentpart_criterion.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'AssessmentPart.criterion'
+        db.add_column('assessment_assessmentpart', 'criterion',
+                      self.gf('django.db.models.fields.related.ForeignKey')(related_name='+', null=True, to=orm['assessment.Criterion']),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'AssessmentPart.criterion'
+        db.delete_column('assessment_assessmentpart', 'criterion_id')
+
+
+    models = {
+        'assessment.aiclassifier': {
+            'Meta': {'object_name': 'AIClassifier'},
+            'classifier_data': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            'classifier_set': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'classifiers'", 'to': "orm['assessment.AIClassifierSet']"}),
+            'criterion': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['assessment.Criterion']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'assessment.aiclassifierset': {
+            'Meta': {'ordering': "['-created_at', '-id']", 'object_name': 'AIClassifierSet'},
+            'algorithm_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'rubric': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['assessment.Rubric']"})
+        },
+        'assessment.aigradingworkflow': {
+            'Meta': {'object_name': 'AIGradingWorkflow'},
+            'algorithm_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'assessment': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'related_name': "'+'", 'null': 'True', 'to': "orm['assessment.Assessment']"}),
+            'classifier_set': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'related_name': "'+'", 'null': 'True', 'to': "orm['assessment.AIClassifierSet']"}),
+            'completed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'essay_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'rubric': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['assessment.Rubric']"}),
+            'scheduled_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'student_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'submission_uuid': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        'assessment.aitrainingworkflow': {
+            'Meta': {'object_name': 'AITrainingWorkflow'},
+            'algorithm_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'classifier_set': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'related_name': "'+'", 'null': 'True', 'to': "orm['assessment.AIClassifierSet']"}),
+            'completed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'scheduled_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'training_examples': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'+'", 'symmetrical': 'False', 'to': "orm['assessment.TrainingExample']"}),
+            'uuid': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        'assessment.assessment': {
+            'Meta': {'ordering': "['-scored_at', '-id']", 'object_name': 'Assessment'},
+            'feedback': ('django.db.models.fields.TextField', [], {'default': "''", 'max_length': '10000', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'rubric': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['assessment.Rubric']"}),
+            'score_type': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'scored_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'scorer_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'submission_uuid': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'})
+        },
+        'assessment.assessmentfeedback': {
+            'Meta': {'object_name': 'AssessmentFeedback'},
+            'assessments': ('django.db.models.fields.related.ManyToManyField', [], {'default': 'None', 'related_name': "'assessment_feedback'", 'symmetrical': 'False', 'to': "orm['assessment.Assessment']"}),
+            'feedback_text': ('django.db.models.fields.TextField', [], {'default': "''", 'max_length': '10000'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'options': ('django.db.models.fields.related.ManyToManyField', [], {'default': 'None', 'related_name': "'assessment_feedback'", 'symmetrical': 'False', 'to': "orm['assessment.AssessmentFeedbackOption']"}),
+            'submission_uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128', 'db_index': 'True'})
+        },
+        'assessment.assessmentfeedbackoption': {
+            'Meta': {'object_name': 'AssessmentFeedbackOption'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'text': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'assessment.assessmentpart': {
+            'Meta': {'object_name': 'AssessmentPart'},
+            'assessment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'parts'", 'to': "orm['assessment.Assessment']"}),
+            'criterion': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'to': "orm['assessment.Criterion']"}),
+            'feedback': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'option': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['assessment.CriterionOption']"})
+        },
+        'assessment.criterion': {
+            'Meta': {'ordering': "['rubric', 'order_num']", 'object_name': 'Criterion'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'order_num': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'prompt': ('django.db.models.fields.TextField', [], {'max_length': '10000'}),
+            'rubric': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'criteria'", 'to': "orm['assessment.Rubric']"})
+        },
+        'assessment.criterionoption': {
+            'Meta': {'ordering': "['criterion', 'order_num']", 'object_name': 'CriterionOption'},
+            'criterion': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'options'", 'to': "orm['assessment.Criterion']"}),
+            'explanation': ('django.db.models.fields.TextField', [], {'max_length': '10000', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'order_num': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'points': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        'assessment.peerworkflow': {
+            'Meta': {'ordering': "['created_at', 'id']", 'object_name': 'PeerWorkflow'},
+            'completed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'grading_completed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'student_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'submission_uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128', 'db_index': 'True'})
+        },
+        'assessment.peerworkflowitem': {
+            'Meta': {'ordering': "['started_at', 'id']", 'object_name': 'PeerWorkflowItem'},
+            'assessment': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['assessment.Assessment']", 'null': 'True'}),
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'graded_by'", 'to': "orm['assessment.PeerWorkflow']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'scored': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'scorer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'graded'", 'to': "orm['assessment.PeerWorkflow']"}),
+            'started_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'submission_uuid': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'})
+        },
+        'assessment.rubric': {
+            'Meta': {'object_name': 'Rubric'},
+            'content_hash': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'structure_hash': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'})
+        },
+        'assessment.studenttrainingworkflow': {
+            'Meta': {'object_name': 'StudentTrainingWorkflow'},
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'student_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'submission_uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128', 'db_index': 'True'})
+        },
+        'assessment.studenttrainingworkflowitem': {
+            'Meta': {'ordering': "['workflow', 'order_num']", 'unique_together': "(('workflow', 'order_num'),)", 'object_name': 'StudentTrainingWorkflowItem'},
+            'completed_at': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order_num': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'started_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'training_example': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['assessment.TrainingExample']"}),
+            'workflow': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'items'", 'to': "orm['assessment.StudentTrainingWorkflow']"})
+        },
+        'assessment.trainingexample': {
+            'Meta': {'object_name': 'TrainingExample'},
+            'content_hash': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'options_selected': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['assessment.CriterionOption']", 'symmetrical': 'False'}),
+            'raw_answer': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'rubric': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['assessment.Rubric']"})
+        }
+    }
+
+    complete_apps = ['assessment']

--- a/openassessment/assessment/models/base.py
+++ b/openassessment/assessment/models/base.py
@@ -500,6 +500,7 @@ class AssessmentPart(models.Model):
     MAX_FEEDBACK_SIZE = 1024 * 100
 
     assessment = models.ForeignKey(Assessment, related_name='parts')
+    criterion = models.ForeignKey(Criterion, null=True, related_name="+")
     option = models.ForeignKey(CriterionOption, related_name="+")
 
     # Free-form text feedback for the specific criterion
@@ -537,9 +538,11 @@ class AssessmentPart(models.Model):
             None
 
         """
+        options = CriterionOption.objects.select_related().filter(pk__in=option_ids)
+
         cls.objects.bulk_create([
-            cls(assessment=assessment, option_id=option_id)
-            for option_id in option_ids
+            cls(assessment=assessment, option_id=option.pk, criterion_id=option.criterion.pk)
+            for option in options
         ])
 
         if criterion_feedback is not None:

--- a/openassessment/assessment/test/test_peer.py
+++ b/openassessment/assessment/test/test_peer.py
@@ -150,7 +150,7 @@ class TestPeerApi(CacheResetTest):
     Tests for the peer assessment API functions.
     """
 
-    CREATE_ASSESSMENT_NUM_QUERIES = 60
+    CREATE_ASSESSMENT_NUM_QUERIES = 61
 
     def test_create_assessment_points(self):
         self._create_student_and_submission("Tim", "Tim's answer")


### PR DESCRIPTION
In preparation for the full migration with https://github.com/edx/edx-ora2/pull/463.

This adds a new foreign key field `criterion` to the `AssessmentPart` model and ensures that new `AssessmentPart`s write to this field.

This PR performs the first two steps of the migrations required by #463:
1) Add the field criterion_id to the table assessment_assessmentpart, making it nullable.
2) Deploy code that writes criterion_id for new assessments.

Then, in a future release, #463 will...
3) Run a data migration to back-fill the criterion_id for old assessments.
4) Modify criterion_id to make it NOT NULL.
5) Modify option_id to make it nullable.

This ensures that all `AssessmentPart.criterion` fields will contain valid foreign key values once we deploy code that reads this field.

Unfortunately, this increases the query count for creating new assessments by one -- with the refactoring in #463 this will go back down.  I'm trying to change as little as possible in this PR to minimize risk, and I think the trade-off in query counts is worth it.

@feanil @stephensanchez Please review.  I would like to get this in today's release so #463 can be deployed the following week.
