### PR TITLE
Better handling of duplicate training essays

### DIFF
--- a/openassessment/templates/openassessmentblock/student_training/student_training_error.html
+++ b/openassessment/templates/openassessmentblock/student_training/student_training_error.html
@@ -1,0 +1,17 @@
+{% extends "openassessmentblock/student_training/student_training.html" %}
+{% load i18n %}
+
+{% block body %}
+    <div class="ui-toggle-visibility__content">
+        <div class="wrapper--step__content">
+
+            <div class="step__message message message--incomplete">
+                <h3 class="message__title">{% trans "Error Loading Student Training Examples" %}</h3>
+
+                <div class="message__content">
+                    <p>{% trans "We couldn't load the student training step of this assignment." %}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/openassessment/xblock/student_training_mixin.py
+++ b/openassessment/xblock/student_training_mixin.py
@@ -6,7 +6,6 @@ from django.utils.translation import ugettext as _
 from webob import Response
 from xblock.core import XBlock
 from openassessment.assessment.api import student_training
-import openassessment.workflow.api as workflow_api
 from openassessment.workflow.errors import AssessmentWorkflowError
 from openassessment.xblock.data_conversion import convert_training_examples_list_to_dict
 from .resolve_dates import DISTANT_FUTURE
@@ -119,9 +118,17 @@ class StudentTrainingMixin(object):
                 },
                 examples
             )
-            context['training_essay'] = example['answer']
-            context['training_rubric'] = example['rubric']
-            template = 'openassessmentblock/student_training/student_training.html'
+
+            if example:
+                context['training_essay'] = example['answer']
+                context['training_rubric'] = example['rubric']
+                template = 'openassessmentblock/student_training/student_training.html'
+            else:
+                logger.error(
+                    "No training example was returned from the API for student "
+                    "with Submission UUID {}".format(self.submission_uuid)
+                )
+                template = "openassessmentblock/student_training/student_training_error.html"
 
         return template, context
 

--- a/openassessment/xblock/test/data/assessment_combo.json
+++ b/openassessment/xblock/test/data/assessment_combo.json
@@ -55,7 +55,15 @@
         "valid": true,
         "assessments": [
             {
-                "name": "student-training"
+                "name": "student-training",
+                "examples": [
+                    {
+                        "answer": "foo"
+                    },
+                    {
+                        "answer": "bar"
+                    }
+                ]
             },
             {
                 "name": "self-assessment"

--- a/openassessment/xblock/test/data/student_training_combo.json
+++ b/openassessment/xblock/test/data/student_training_combo.json
@@ -46,6 +46,72 @@
         "is_released": false
     },
 
+    "training_no_examples": {
+        "valid": false,
+        "assessments": [
+            {
+                "name": "student-training"
+            },
+            {
+                "name": "peer-assessment",
+                "must_grade": 5,
+                "must_be_graded_by": 3
+            },
+            {
+                "name": "self-assessment"
+            }
+        ],
+        "current_assessments": null,
+        "is_released": false
+    },
+
+    "training_duplicate_examples": {
+        "valid": false,
+        "assessments": [
+            {
+                "name": "student-training",
+                "examples": [
+                    {
+                        "answer": "тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    },
+                    {
+                        "answer": "тєѕт αηѕωєя",
+                        "options_selected": [
+                            {
+                                "criterion": "vocabulary",
+                                "option": "poor"
+                            },
+                            {
+                                "criterion": "grammar",
+                                "option": "good"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "peer-assessment",
+                "must_grade": 5,
+                "must_be_graded_by": 3
+            },
+            {
+                "name": "self-assessment"
+            }
+        ],
+        "current_assessments": null,
+        "is_released": false
+    },
+
     "training_peer": {
         "valid": true,
         "assessments": [

--- a/openassessment/xblock/validation.py
+++ b/openassessment/xblock/validation.py
@@ -131,6 +131,18 @@ def validate_assessments(assessments, current_assessments, is_released):
             if must_grade < must_be_graded_by:
                 return (False, _('The "must_grade" value must be greater than or equal to the "must_be_graded_by" value.'))
 
+        # Student Training must have at least one example, and all
+        # examples must have unique answers.
+        if assessment_dict.get('name') == 'student-training':
+            answers = []
+            examples = assessment_dict.get('examples')
+            if not examples:
+                return False, _('You must provide at least one example response for student training.')
+            for example in examples:
+                if example.get('answer') in answers:
+                    return False, _('Each example response for student training must be unique.')
+                answers.append(example.get('answer'))
+
         # Example-based assessment MUST specify 'ease' or 'fake' as the algorithm ID,
         # at least for now.  Later, we may make this more flexible.
         if assessment_dict.get('name') == 'example-based-assessment':


### PR DESCRIPTION
RE: ORA-640  We need to better handle duplicate essays in student training. The current design creates a unique hash of all training examples via
- answer
- rubric
- selected options.

The validation I am proposing on edit is even more strict than that: do not allow the same "answer" for two training examples. If an author attempts to save two examples with the same answer, it will now fail validation.

Client-side, the mixin is slightly more flexible (it will not bomb out). This should not be a state that will occur any longer, but I'm willing to add some type of "Error while loading" messaging to the template if we want to be safe.

@wedaly @gradyward for code review
@Lyla-Fischer @lou-wang for proposed solution, error handling, validation choices, etc. 
