### PR TITLE
Remove unnecessary unicode type conversion

### DIFF
--- a/openassessment/xblock/studio_mixin.py
+++ b/openassessment/xblock/studio_mixin.py
@@ -110,7 +110,7 @@ class StudioMixin(object):
             'submission_start': submission_start,
             'assessments': assessments,
             'criteria': criteria,
-            'feedbackprompt': unicode(self.rubric_feedback_prompt),
+            'feedbackprompt': self.rubric_feedback_prompt,
             'unused_assessments': unused_assessments,
             'used_assessments': used_assessments
         }


### PR DESCRIPTION
`rubric_feedback_prompt` is a `String` XBlock field, which is parsed from JSON and should already be a `unicode` object.  Adding the extra type conversion is unnecessary.

@stephensanchez 
