### PR TITLE
Fix test settings so all non-acceptance tests run

### DIFF
--- a/settings/test.py
+++ b/settings/test.py
@@ -14,7 +14,7 @@ TEST_APPS = (
 
 # Configure nose
 NOSE_ARGS = [
-    "-a '!acceptance'",
+    "-a !acceptance",
     '--with-coverage',
     '--cover-package=' + ",".join(TEST_APPS),
     '--cover-branches',


### PR DESCRIPTION
Too many layers of indirection :(  This was causing all tests to be skipped, including non-selenium tests.
