### PR TITLE
ORA-688

### DIFF
--- a/openassessment/xblock/grade_mixin.py
+++ b/openassessment/xblock/grade_mixin.py
@@ -147,8 +147,15 @@ class GradeMixin(object):
 
         if median_scores is not None and max_scores is not None:
             for criterion in context["rubric_criteria"]:
-                criterion["median_score"] = median_scores[criterion["name"]]
-                criterion["total_value"] = max_scores[criterion["name"]]
+                # Although we prevent course authors from modifying criteria post-release,
+                # it's still possible for assessments created by course staff to
+                # have criteria that differ from the current problem definition.
+                # It's also possible to circumvent the post-release restriction
+                # if course authors directly import a course into Studio.
+                # If this happens, we simply leave the score blank so that the grade
+                # section can render without error.
+                criterion["median_score"] = median_scores.get(criterion["name"], '')
+                criterion["total_value"] = max_scores.get(criterion["name"], '')
 
         return ('openassessmentblock/grade/oa_grade_complete.html', context)
 

--- a/openassessment/xblock/test/test_grade.py
+++ b/openassessment/xblock/test/test_grade.py
@@ -202,6 +202,28 @@ class TestGrade(XBlockHandlerTestCase):
         self.assertIn(u'Peer 2: ฝﻉɭɭ ɗѻกﻉ!', resp.decode('utf-8'))
         self.assertIn(u'Peer 2: ƒαιя נσв', resp.decode('utf-8'))
 
+    @scenario('data/grade_scenario.xml', user_id='Bob')
+    def test_assessment_does_not_match_rubric(self, xblock):
+         # Get to the grade complete section
+        self._create_submission_and_assessments(
+            xblock, self.SUBMISSION, self.PEERS, self.ASSESSMENTS, self.ASSESSMENTS[0]
+        )
+
+        # Change the problem definition so it no longer
+        # matches the assessments.  This should never happen
+        # for a student (since we prevent authors from doing this post-release),
+        # but it may happen if a course author has submitted
+        # an assessment for a problem before it was published,
+        # or if course authors mess around with course import.
+        xblock.rubric_criteria[0]["name"] = "CHANGED NAME!"
+
+        # Expect that the page renders without an error
+        # It won't show the assessment criterion that changed
+        # (since it's not part of the original assessment),
+        # but at least it won't display an error.
+        resp = self.request(xblock, 'render_grade', json.dumps({}))
+        self.assertGreater(resp, 0)
+
     @ddt.file_data('data/waiting_scenarios.json')
     @scenario('data/grade_waiting_scenario.xml', user_id='Omar')
     def test_grade_waiting(self, xblock, data):


### PR DESCRIPTION
[ORA-688](https://openedx.atlassian.net/browse/ORA-688): Student receiving "Unable to Load" error message

Given the Splunk logs at the time of the error, I believe that the "unable to load" message is due to a KeyError in the grade section.  The only way for this to occur is when the rubric is modified after an assessment is created.  We prevent course authors from doing this post-release, but it's possible for authors to circumvent this using course import.

This is not ideal, since the students won't see a score for criteria that are no longer part of the problem definition, but I don't know another way to handle this reasonably.  We need to ensure that all the assessments have the same criteria (or else the layout could break), and we need to allow course authors to fix typos post-release.

@stephensanchez thoughts?
