### PR TITLE
ORA-61: Answer too long error message

### DIFF
--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -9,7 +9,6 @@ import pytz
 from mock import patch, Mock
 from submissions import api as sub_api
 from submissions.api import SubmissionRequestError, SubmissionInternalError
-from openassessment.xblock.submission_mixin import SubmissionMixin
 from .base import XBlockHandlerTestCase, scenario
 
 
@@ -23,6 +22,17 @@ class SubmissionTest(XBlockHandlerTestCase):
         self.assertTrue(resp[0])
 
     @scenario('data/basic_scenario.xml', user_id='Bob')
+    def test_submit_answer_too_long(self, xblock):
+        # Maximum answer length is 100K, once the answer has been JSON-encoded
+        long_submission = json.dumps({
+            'submission': 'longcat is long ' * 100000
+        })
+        resp = self.request(xblock, 'submit', long_submission, response_format='json')
+        self.assertFalse(resp[0])
+        self.assertEqual(resp[1], "EANSWERLENGTH")
+        self.assertEqual(resp[2], xblock.SUBMIT_ERRORS["EANSWERLENGTH"])
+
+    @scenario('data/basic_scenario.xml', user_id='Bob')
     def test_submission_multisubmit_failure(self, xblock):
         # We don't care about return value of first one
         self.request(xblock, 'submit', self.SUBMISSION, response_format='json')
@@ -31,7 +41,7 @@ class SubmissionTest(XBlockHandlerTestCase):
         resp = self.request(xblock, 'submit', self.SUBMISSION, response_format='json')
         self.assertFalse(resp[0])
         self.assertEqual(resp[1], "ENOMULTI")
-        self.assertEqual(resp[2], xblock.submit_errors["ENOMULTI"])
+        self.assertEqual(resp[2], xblock.SUBMIT_ERRORS["ENOMULTI"])
 
     @scenario('data/basic_scenario.xml', user_id='Bob')
     @patch.object(sub_api, 'create_submission')
@@ -40,15 +50,16 @@ class SubmissionTest(XBlockHandlerTestCase):
         resp = self.request(xblock, 'submit', self.SUBMISSION, response_format='json')
         self.assertFalse(resp[0])
         self.assertEqual(resp[1], "EUNKNOWN")
-        self.assertEqual(resp[2], SubmissionMixin().submit_errors["EUNKNOWN"])
+        self.assertEqual(resp[2], xblock.SUBMIT_ERRORS["EUNKNOWN"])
 
     @scenario('data/basic_scenario.xml', user_id='Bob')
     @patch.object(sub_api, 'create_submission')
     def test_submission_API_failure(self, xblock, mock_submit):
-        mock_submit.side_effect = SubmissionRequestError("Cat on fire.")
+        mock_submit.side_effect = SubmissionRequestError(msg="Cat on fire.")
         resp = self.request(xblock, 'submit', self.SUBMISSION, response_format='json')
         self.assertFalse(resp[0])
         self.assertEqual(resp[1], "EBADFORM")
+        self.assertEqual(resp[2], xblock.SUBMIT_ERRORS["EBADFORM"])
 
     # In Studio preview mode, the runtime sets the user ID to None
     @scenario('data/basic_scenario.xml', user_id=None)
@@ -65,7 +76,7 @@ class SubmissionTest(XBlockHandlerTestCase):
         resp = self.request(xblock, 'submit', self.SUBMISSION, response_format='json')
         self.assertFalse(resp[0])
         self.assertEqual(resp[1], "ENOPREVIEW")
-        self.assertEqual(resp[2], "To submit a response, view this component in Preview or Live mode.")
+        self.assertEqual(resp[2], xblock.SUBMIT_ERRORS["ENOPREVIEW"])
 
     @scenario('data/over_grade_scenario.xml', user_id='Alice')
     def test_closed_submissions(self, xblock):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 git+https://github.com/edx/XBlock.git@fc5fea25c973ec66d8db63cf69a817ce624f5ef5#egg=XBlock
 git+https://github.com/edx/xblock-sdk.git@643900aadcb18aaeb7fe67271ca9dbf36e463ee6#egg=xblock-sdk
 
-edx-submissions==0.0.3
+edx-submissions==0.0.5
 
 # Third Party Requirements
 boto==2.13.3


### PR DESCRIPTION
[ORA-61](https://openedx.atlassian.net/browse/ORA-61)

It turns out that we were restricting _character_ length on the client side (using the textarea's `maxlength` attribute), but checking JSON-encoded _byte_ length on the server side (in the submissions API).  Depending on which characters were being encoded, a user could exceed the byte length limit without exceeding the character limit (for example, double-escaped newline chars, non-ASCII unicode, and JSON keys).

This PR addresses the issue in two ways:

1) It suppresses the "field errors" returned by the submissions API, which (a) weren't localized and (b) were a scary `repr` or a dictionary, which users should never have to see.

2) It intercepts "answer too long" request errors from the submissions API and displays the more specific error message: "Your answer is too long."  This is somewhat vague (it doesn't tell the user _how_ long), but I think it's clearer than saying something more specific like "JSON encoded byte length > 100K", which the user doesn't have any control over.

There's a related PR in edx-submissions: https://github.com/edx/edx-submissions/pull/7
Once that is reviewed, merged, and released, I'll update the requirements to point to the new version in PyPi.

@srpearce Please review the messaging changes (all in `SUBMIT_ERRORS` on line 29 of `submission_mixin.py`)

@stephensanchez and @gradyward please review the code changes.
