### PR TITLE
Add maxlength attribute to authoring editor textareas

### DIFF
--- a/openassessment/templates/openassessmentblock/edit/oa_edit.html
+++ b/openassessment/templates/openassessmentblock/edit/oa_edit.html
@@ -14,7 +14,7 @@
         </div>
 
         <div id="oa_prompt_editor_wrapper" class="oa_editor_content_wrapper">
-            <textarea id="openassessment_prompt_editor">{{ prompt }}</textarea>
+            <textarea id="openassessment_prompt_editor" maxlength="10000">{{ prompt }}</textarea>
         </div>
 
         {% include "openassessmentblock/edit/oa_edit_rubric.html"  %}

--- a/openassessment/templates/openassessmentblock/edit/oa_edit_criterion.html
+++ b/openassessment/templates/openassessmentblock/edit/oa_edit_criterion.html
@@ -25,7 +25,7 @@
                 <div class="wrapper-comp-settings">
                     <label class="openassessment_criterion_prompt_label setting-label">
                         {% trans "Criterion Prompt" %}
-                        <textarea class="openassessment_criterion_prompt setting-input">{{ criterion_prompt }}</textarea>
+                        <textarea class="openassessment_criterion_prompt setting-input" maxlength="10000">{{ criterion_prompt }}</textarea>
                     </label>
                 </div>
             </li>

--- a/openassessment/templates/openassessmentblock/edit/oa_edit_option.html
+++ b/openassessment/templates/openassessmentblock/edit/oa_edit_option.html
@@ -40,7 +40,7 @@
                 <div class="wrapper-comp-setting">
                     <label class="openassessment_criterion_option_explanation_label setting-label">
                         {% trans "Option Explanation"%}
-                        <textarea class="openassessment_criterion_option_explanation setting-input">{{ option_explanation }}</textarea>
+                        <textarea class="openassessment_criterion_option_explanation setting-input" maxlength="10000">{{ option_explanation }}</textarea>
                     </label>
                 </div>
             </li>

--- a/openassessment/templates/openassessmentblock/edit/oa_training_example.html
+++ b/openassessment/templates/openassessmentblock/edit/oa_training_example.html
@@ -28,7 +28,7 @@
 
         <div class="openassessment_training_example_essay_wrapper">
             <h2>{% trans "Response" %}</h2>
-            <textarea class="openassessment_training_example_essay">{{ example.answer }}</textarea>
+            <textarea class="openassessment_training_example_essay" maxlength="100000">{{ example.answer }}</textarea>
         </div>
     </div>
 </li>


### PR DESCRIPTION
[ORA-735](https://openedx.atlassian.net/browse/ORA-735): textarea tags should have maxlength attributes.

I chose 10,000 characters arbitrarily, except for:

1) AI examples, which I didn't set a limit for because it may need to be extremely large and won't be visible to most course teams.
2) Student training examples, which use the same size limit as student responses (100,000 chars)

@stephensanchez please review.
