### PR TITLE
Any boto version will do

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ git+https://github.com/edx/xblock-sdk.git@643900aadcb18aaeb7fe67271ca9dbf36e463e
 edx-submissions==0.0.5
 
 # Third Party Requirements
-boto==2.30.0
+boto>=2.30.0,<3.0.0
 celery==3.0.19
 defusedxml==0.4.1
 dogapi==1.2.1


### PR DESCRIPTION
This is for https://github.com/edx/edx-platform/pull/4697 -- a new version of `boto` came out since the last upgrade that was applied to edx-ora2. I've adjusted the requirements to be more flexible. Once this goes in, we'll need to make a new release and update https://github.com/edx/edx-platform/pull/4697 to point to it.
