### PR TITLE
Default label value (DB migration)

### DIFF
--- a/openassessment/assessment/migrations/0022__add_label_fields.py
+++ b/openassessment/assessment/migrations/0022__add_label_fields.py
@@ -11,12 +11,12 @@ class Migration(SchemaMigration):
         # Adding field 'Criterion.label'
         db.add_column('assessment_criterion', 'label',
                       self.gf('django.db.models.fields.CharField')(default='', max_length=100, blank=True),
-                      keep_default=False)
+                      keep_default=True)
 
         # Adding field 'CriterionOption.label'
         db.add_column('assessment_criterionoption', 'label',
                       self.gf('django.db.models.fields.CharField')(default='', max_length=100, blank=True),
-                      keep_default=False)
+                      keep_default=True)
 
 
     def backwards(self, orm):


### PR DESCRIPTION
Set a database-level default for criterion.label and criterionoption.label

Without this change, we cannot safely roll-back authoring before running reverse migrations.  (We get `DatabaseErrors` from MySQL when calling the Django model's `save()` method).

@feanil @stephensanchez 
