### PR TITLE
Update student training messaging in authoring.

### DIFF
--- a/openassessment/assessment/api/student_training.py
+++ b/openassessment/assessment/api/student_training.py
@@ -189,9 +189,9 @@ def validate_training_examples(rubric, examples):
     ]
     if len(set(criteria_options) - set(criteria_without_options)) == 0:
         return [_(
-            u"When you include a student training assessment, "
-            u"the rubric for the assessment must contain at least one criterion, "
-            u"and each criterion must contain at least two options."
+            "If your assignment includes a student training step, "
+            "the rubric must have at least one criterion, "
+            "and that criterion must have at least one option."
         )]
 
     # Check each example

--- a/openassessment/assessment/test/data/validate_training_examples.json
+++ b/openassessment/assessment/test/data/validate_training_examples.json
@@ -577,7 +577,7 @@
                 "options_selected": {}
             }
         ],
-        "errors": ["When you include a student training assessment, the rubric for the assessment must contain at least one criterion, and each criterion must contain at least two options."]
+        "errors": ["If your assignment includes a student training step, the rubric must have at least one criterion, and that criterion must have at least one option."]
     }
 
 }

--- a/openassessment/xblock/test/data/invalid_update_xblock.json
+++ b/openassessment/xblock/test/data/invalid_update_xblock.json
@@ -975,7 +975,7 @@
             }
         ],
         "editor_assessments_order": ["student-training", "peer-assessment", "self-assessment"],
-        "expected_error": "student training example option does not match the rubric"
+        "expected_error": "example 1 has an extra option for \"not a criterion!\"; example 1 is missing an option for \"0\""
     },
 
     "missing_editor_assessments_order": {

--- a/openassessment/xblock/test/test_validation.py
+++ b/openassessment/xblock/test/test_validation.py
@@ -303,7 +303,10 @@ class ValidationIntegrationTest(TestCase):
         # Expect a validation error
         is_valid, msg = self.validator(self.RUBRIC, mutated_assessments)
         self.assertFalse(is_valid)
-        self.assertEqual(msg, u'Student training example option does not match the rubric.')
+        self.assertEqual(msg, (
+            u'Example 1 has an extra option for \"Invalid criterion!"; '
+            u'Example 1 is missing an option for "vocabulary"'
+        ))
 
     def test_student_training_examples_invalid_option(self):
         # Mutate the assessment training examples so the option names don't match the rubric
@@ -313,7 +316,7 @@ class ValidationIntegrationTest(TestCase):
         # Expect a validation error
         is_valid, msg = self.validator(self.RUBRIC, mutated_assessments)
         self.assertFalse(is_valid)
-        self.assertEqual(msg, u'Student training example option does not match the rubric.')
+        self.assertEqual(msg, u'Example 1 has an invalid option for "vocabulary": "Invalid option!"')
 
     def test_example_based_assessment_duplicate_point_values(self):
         # Mutate the rubric so that two options have the same point value

--- a/openassessment/xblock/validation.py
+++ b/openassessment/xblock/validation.py
@@ -295,7 +295,7 @@ def validate_assessment_examples(rubric_dict, assessments, _):
             # examples against the rubric.
             errors = validate_training_examples(rubric_dict, examples)
             if errors:
-                return False, _(u"Student training example option does not match the rubric.")
+                return False, "; ".join(errors)
 
     return True, u''
 


### PR DESCRIPTION
[ORA-731](https://openedx.atlassian.net/browse/ORA-731)

This reverts the change I made earlier this week to wrap all server-side student training errors as "Student training example option does not match the rubric."  This message is confusing when validation fails because a criterion has 0 options.

@stephensanchez 
