### PR TITLE
Fixes Student Training Labels on Import

### DIFF
--- a/openassessment/xblock/studio_mixin.py
+++ b/openassessment/xblock/studio_mixin.py
@@ -258,7 +258,7 @@ class StudioMixin(object):
         student_training_module = self.get_assessment_module('student-training')
 
         student_training_template = {'answer': ""}
-        criteria_list = copy.deepcopy(self.rubric_criteria)
+        criteria_list = copy.deepcopy(self.rubric_criteria_with_labels)
         for criterion in criteria_list:
             criterion['option_selected'] = ""
         student_training_template['criteria'] = criteria_list
@@ -267,7 +267,7 @@ class StudioMixin(object):
             example_list = []
             # Adds each example to a modified version of the student training module dictionary.
             for example in student_training_module['examples']:
-                criteria_list = copy.deepcopy(self.rubric_criteria)
+                criteria_list = copy.deepcopy(self.rubric_criteria_with_labels)
                 # Equivalent to a Join Query, this adds the selected option to the Criterion's dictionary, so that
                 # it can be easily referenced in the template without searching through the selected options.
                 for criterion in criteria_list:

--- a/openassessment/xblock/test/test_studio.py
+++ b/openassessment/xblock/test/test_studio.py
@@ -311,3 +311,16 @@ class StudioViewTest(XBlockHandlerTestCase):
             self.assertEqual(criterion['label'], criterion['name'])
             for option in criterion['options']:
                 self.assertEqual(option['label'], option['name'])
+
+        # Verify the same thing for the training example template
+        for criterion in context['assessments']['training']['template']['criteria']:
+            self.assertEqual(criterion['label'], criterion['name'])
+            for option in criterion['options']:
+                self.assertEqual(option['label'], option['name'])
+
+        # Verify the same thing for the context for student training examples
+        for example in context['assessments']['training']['examples']:
+            for criterion in example['criteria']:
+                self.assertEqual(criterion['label'], criterion['name'])
+                for option in criterion['options']:
+                    self.assertEqual(option['label'], option['name'])


### PR DESCRIPTION
Fixed ORA-781, verifies passing the label-corrected context to training examples and training-example-template in addition to the rubric. @stephensanchez 
