### PR TITLE
Be less restrictive about the version of edx-submissions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 git+https://github.com/edx/XBlock.git@fc5fea25c973ec66d8db63cf69a817ce624f5ef5#egg=XBlock
 git+https://github.com/edx/xblock-sdk.git@643900aadcb18aaeb7fe67271ca9dbf36e463ee6#egg=xblock-sdk
 
-edx-submissions==0.0.6
+edx-submissions>=0.0.6,<0.1.0
 
 # Third Party Requirements
 boto>=2.13.0,<3.0.0


### PR DESCRIPTION
In case other projects need to upgrade.  Hopefully folks will bump the major version number if they make backwards-incompatible changes.

@stephensanchez 
