### PR TITLE
Fixed criterion name with label which is displayed to the user.

### DIFF
--- a/openassessment/templates/openassessmentblock/staff_debug/student_info.html
+++ b/openassessment/templates/openassessmentblock/staff_debug/student_info.html
@@ -46,7 +46,7 @@
                         {% for part in assessment.parts %}
                             {% if part.option.criterion.name == criterion.name %}
                         <tr>
-                            <td class="label">{{ criterion.name }}</td>
+                            <td class="label">{{ criterion.label }}</td>
                             <td class="value">{{ part.option.name }}</td>
                             <td class="value">{{ part.feedback }}</td>
                             <td class="value">{{ part.option.points }}</td>
@@ -88,7 +88,7 @@
                             {% for part in assessment.parts %}
                                 {% if part.option.criterion.name == criterion.name %}
                                     <tr>
-                                        <td class="label">{{ criterion.name }}</td>
+                                        <td class="label">{{ criterion.label }}</td>
                                         <td class="value">{{ part.option.name }}</td>
                                         <td class="value">{{ part.feedback }}</td>
                                         <td class="value">{{ part.option.points }}</td>
@@ -126,7 +126,7 @@
                     {% for part in self_assessment.parts %}
                         {% if part.option.criterion.name == criterion.name %}
                             <tr>
-                                <td class="label">{{ criterion.name }}</td>
+                                <td class="label">{{ criterion.label }}</td>
                                 <td class="value">{{ part.option.name }}</td>
                                 <td class="value">{{ part.option.points }}</td>
                                 <td class="value">{{ criterion.total_value }}</td>
@@ -157,7 +157,7 @@
                         {% for part in example_based_assessment.parts %}
                             {% if part.option.criterion.name == criterion.name %}
                                 <tr>
-                                    <td class="label">{{ criterion.name }}</td>
+                                    <td class="label">{{ criterion.label }}</td>
                                     <td class="value">{{ part.option.name }}</td>
                                     <td class="value">{{ part.option.points }}</td>
                                     <td class="value">{{ criterion.total_value }}</td>


### PR DESCRIPTION
Ticket: [TNL-768](https://openedx.atlassian.net/browse/TNL-768)

Field "label" added in "Criterion" model but not updated in "staff_debug_info.html" template. It was showing a unique identifier for new criterion and if we change the name of default criterion then it shows its default name but not updated name which is stored in "label" field.
