### PR TITLE
To package missing modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from setuptools import setup
+from setuptools import setup, find_packages
 
 PACKAGES = [
     'openassessment',
@@ -9,6 +9,7 @@ PACKAGES = [
     'openassessment.management',
     'openassessment.xblock'
 ]
+PACKAGES += find_packages()
 
 def is_requirement(line):
     """


### PR DESCRIPTION
Ticket: [OSPR-268 ](https://openedx.atlassian.net/browse/OSPR-268)

**Background:**
It seems that sometimes setup.py did not package openassessment.assessment.worker and other modules  when install edx by [configuration](https://github.com/edx/configuration) .

so I open this pull  to make sure all modules  be installed

**Studio Updates:**  None.

**LMS Updates:** None

**Test:**

some errors looked like before:  
```shell
2014-12-05 10:10:39,858 ERROR 22467 [gunicorn.error] glogging.py:219 - Error handling request
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 126, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 241, in __call__
    response = self.get_response(request)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 177, in get_response
    response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 222, in handle_uncaught_exception
    if resolver.urlconf_module is None:
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 342, in urlconf_module
    self._urlconf_module = import_module(self.urlconf_name)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/edx/app/edxapp/edx-platform/lms/urls.py", line 11, in <module>
    admin.autodiscover()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/ratelimitbackend/admin.py", line 33, in autodiscover
    django_autodiscover()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/admin/__init__.py", line 29, in autodiscover
    import_module('%s.admin' % app)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/djcelery/admin.py", line 270, in <module>
    class PeriodicTaskAdmin(admin.ModelAdmin):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/djcelery/admin.py", line 272, in PeriodicTaskAdmin
    form = periodic_task_form()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/djcelery/admin.py", line 242, in periodic_task_form
    current_app.loader.import_default_modules()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/djcelery/loaders.py", line 138, in import_default_modules
    self.autodiscover()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/djcelery/loaders.py", line 141, in autodiscover
    self.task_modules.update(mod.__name__ for mod in autodiscover() or ())
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/djcelery/loaders.py", line 176, in autodiscover
    for app in settings.INSTALLED_APPS])
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/djcelery/loaders.py", line 195, in find_related_module
    return importlib.import_module('%s.%s' % (app, related_name))
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/openassessment/assessment/tasks.py", line 6, in <module>
    from .worker.training import train_classifiers, reschedule_training_tasks
ImportError: No module named worker.training
```
now ,work very well