### PR TITLE
Dispaly rubric-option label instead of name

### DIFF
--- a/openassessment/templates/openassessmentblock/staff_debug/student_info.html
+++ b/openassessment/templates/openassessmentblock/staff_debug/student_info.html
@@ -112,7 +112,7 @@
                             {% if part.option.criterion.name == criterion.name %}
                         <tr>
                             <td class="label">{{ criterion.label }}</td>
-                            <td class="value">{{ part.option.name }}</td>
+                            <td class="value">{{ part.option.label }}</td>
                             <td class="value">{{ part.feedback }}</td>
                             <td class="value">{{ part.option.points }}</td>
                             <td class="value">{{ criterion.total_value }}</td>
@@ -154,7 +154,7 @@
                                 {% if part.option.criterion.name == criterion.name %}
                                     <tr>
                                         <td class="label">{{ criterion.label }}</td>
-                                        <td class="value">{{ part.option.name }}</td>
+                                        <td class="value">{{ part.option.label }}</td>
                                         <td class="value">{{ part.feedback }}</td>
                                         <td class="value">{{ part.option.points }}</td>
                                         <td class="value">{{ criterion.total_value }}</td>
@@ -192,7 +192,7 @@
                         {% if part.option.criterion.name == criterion.name %}
                             <tr>
                                 <td class="label">{{ criterion.label }}</td>
-                                <td class="value">{{ part.option.name }}</td>
+                                <td class="value">{{ part.option.label }}</td>
                                 <td class="value">{{ part.option.points }}</td>
                                 <td class="value">{{ criterion.total_value }}</td>
                             </tr>
@@ -223,7 +223,7 @@
                             {% if part.option.criterion.name == criterion.name %}
                                 <tr>
                                     <td class="label">{{ criterion.label }}</td>
-                                    <td class="value">{{ part.option.name }}</td>
+                                    <td class="value">{{ part.option.label }}</td>
                                     <td class="value">{{ part.option.points }}</td>
                                     <td class="value">{{ criterion.total_value }}</td>
                                 </tr>


### PR DESCRIPTION
[TNL-1638](https://openedx.atlassian.net/browse/TNL-1638)

The staff debug panel is displaying the internal "name" field for the rubric options instead of the "label" field that the course team entered