### PR TITLE
Fixed training example answer format for old submissions.

### DIFF
--- a/openassessment/assessment/data_conversion.py
+++ b/openassessment/assessment/data_conversion.py
@@ -1,0 +1,24 @@
+"""
+Data Conversion utility methods for handling assessment data transformations.
+
+"""
+import json
+
+
+def update_training_example_answer_format(answer):
+    """
+    For each training example update 'answer' to newer format.
+
+    Args:
+        answer unicode string or dict
+    Returns:
+        dict
+    """
+    if isinstance(answer, unicode) or isinstance(answer, str):
+        return {
+            'parts': [
+                {'text': answer}
+            ]
+        }
+
+    return answer

--- a/openassessment/assessment/serializers/training.py
+++ b/openassessment/assessment/serializers/training.py
@@ -4,6 +4,7 @@ Serializers for the training assessment type.
 from django.core.cache import cache
 from django.db import transaction, IntegrityError
 from openassessment.assessment.models import TrainingExample
+from openassessment.assessment.data_conversion import update_training_example_answer_format
 from .base import rubric_from_dict, RubricSerializer
 
 
@@ -58,7 +59,7 @@ def serialize_training_example(example):
     example_dict = cache.get(cache_key)
     if example_dict is None:
         example_dict = {
-            'answer': example.answer,
+            'answer': update_training_example_answer_format(example.answer),
             'options_selected': example.options_selected_dict,
             'rubric': RubricSerializer.serialized_from_cache(example.rubric),
         }


### PR DESCRIPTION
[TNL-1758] (https://openedx.atlassian.net/browse/TNL-1758)

In ```TrainingExample``` table there is a field ```raw_answer```, after last release of ora it has a dict object
but for the student which submitted there answers before ora release they have a unicode string in it.

Fixed it by formatting this string into new format (dict format).