### PR TITLE
Fix a placeholder's translation

### DIFF
--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -66,7 +66,7 @@
                                     <textarea
                                         id="submission__answer__part__text__{{ forloop.counter }}"
                                         class="submission__answer__part__text__value"
-                                        placeholder="Enter your response to the question above."
+                                        placeholder="{% trans "Enter your response to the question above." %}"
                                         maxlength="100000"
                                     >{{ part.text }}</textarea>
                                 </div>


### PR DESCRIPTION
This is shown when no text is entered in a response textbox.