### PR TITLE
Fix jQuery Ajax contentType issue. When sending an ajax request, jque…

### DIFF
--- a/openassessment/xblock/static/js/spec/oa_server.js
+++ b/openassessment/xblock/static/js/spec/oa_server.js
@@ -11,6 +11,8 @@ describe("OpenAssessment.Server", function() {
 
     var server = null;
 
+    var jsonContentType = "application/json; charset=utf-8";
+
     /**
     Stub AJAX requests.
 
@@ -126,7 +128,8 @@ describe("OpenAssessment.Server", function() {
         expect($.ajax).toHaveBeenCalledWith({
             url: '/submit',
             type: "POST",
-            data: JSON.stringify({submission: "This is only a test"})
+            data: JSON.stringify({submission: "This is only a test"}),
+            contentType : jsonContentType
         });
     });
 
@@ -146,7 +149,8 @@ describe("OpenAssessment.Server", function() {
         expect($.ajax).toHaveBeenCalledWith({
             url: '/cancel_submission',
             type: "POST",
-            data: JSON.stringify({submission_uuid: submissionUUID, comments: comments})
+            data: JSON.stringify({submission_uuid: submissionUUID, comments: comments}),
+            contentType : jsonContentType
         });
     });
 
@@ -158,7 +162,8 @@ describe("OpenAssessment.Server", function() {
         expect($.ajax).toHaveBeenCalledWith({
             url: "/save_submission",
             type: "POST",
-            data: JSON.stringify({submission: "Test"})
+            data: JSON.stringify({submission: "Test"}),
+            contentType : jsonContentType
         });
     });
 
@@ -180,7 +185,8 @@ describe("OpenAssessment.Server", function() {
                 options_selected: options,
                 criterion_feedback: criterionFeedback,
                 overall_feedback: "Excellent job!"
-            })
+            }),
+            contentType : jsonContentType
         });
     });
 
@@ -202,7 +208,8 @@ describe("OpenAssessment.Server", function() {
                 options_selected: options,
                 criterion_feedback: criterionFeedback,
                 overall_feedback: "Excellent job!"
-            })
+            }),
+            contentType : jsonContentType
         });
 
     });
@@ -226,7 +233,8 @@ describe("OpenAssessment.Server", function() {
             type: "POST",
             data: JSON.stringify({
                 options_selected: options
-            })
+            }),
+            contentType : jsonContentType
         });
     });
 
@@ -246,7 +254,8 @@ describe("OpenAssessment.Server", function() {
             data: JSON.stringify({
                 feedback_text: "test feedback",
                 feedback_options: options,
-            })
+            }),
+            contentType : jsonContentType
         });
     });
 
@@ -279,7 +288,8 @@ describe("OpenAssessment.Server", function() {
                 editor_assessments_order: EDITOR_ASSESSMENTS_ORDER,
                 allow_file_upload: true,
                 leaderboard_show: 15
-            })
+            }),
+            contentType : jsonContentType
         });
     });
 
@@ -293,7 +303,8 @@ describe("OpenAssessment.Server", function() {
 
         expect(receivedIsReleased).toBe(true);
         expect($.ajax).toHaveBeenCalledWith({
-            url: '/check_released', type: "POST", data: "\"\""
+            url: '/check_released', type: "POST", data: "\"\"",
+            contentType : jsonContentType
         });
     });
 

--- a/openassessment/xblock/static/js/src/oa_server.js
+++ b/openassessment/xblock/static/js/src/oa_server.js
@@ -21,6 +21,7 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
         this.element = element;
     };
 
+    var jsonContentType = "application/json; charset=utf-8";
 
     OpenAssessment.Server.prototype = {
 
@@ -149,7 +150,8 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
                 $.ajax({
                     type: "POST",
                     url: url,
-                    data: JSON.stringify({submission: submission})
+                    data: JSON.stringify({submission: submission}),
+                    contentType: jsonContentType
                 }).done(function(data) {
                     var success = data[0];
                     if (success) {
@@ -184,7 +186,8 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
                 $.ajax({
                     type: "POST",
                     url: url,
-                    data: JSON.stringify({submission: submission})
+                    data: JSON.stringify({submission: submission}),
+                    contentType: jsonContentType
                 }).done(function(data) {
                     if (data.success) { defer.resolve(); }
                     else { defer.rejectWith(this, [data.msg]); }
@@ -220,7 +223,7 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
                 'feedback_options': options
             });
             return $.Deferred(function(defer) {
-                $.ajax({ type: "POST", url: url, data: payload }).done(
+                $.ajax({ type: "POST", url: url, data: payload, contentType: jsonContentType }).done(
                     function(data) {
                         if (data.success) { defer.resolve(); }
                         else { defer.rejectWith(this, [data.msg]); }
@@ -263,7 +266,7 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
                 submission_uuid: uuid
             });
             return $.Deferred(function(defer) {
-                $.ajax({ type: "POST", url: url, data: payload }).done(
+                $.ajax({ type: "POST", url: url, data: payload, contentType: jsonContentType }).done(
                     function(data) {
                         if (data.success) {
                             defer.resolve();
@@ -307,7 +310,7 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
                 overall_feedback: overallFeedback
             });
             return $.Deferred(function(defer) {
-                $.ajax({ type: "POST", url: url, data: payload }).done(
+                $.ajax({ type: "POST", url: url, data: payload, contentType: jsonContentType }).done(
                     function(data) {
                         if (data.success) {
                             defer.resolve();
@@ -348,7 +351,7 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
                 options_selected: optionsSelected
             });
             return $.Deferred(function(defer) {
-                $.ajax({ type: "POST", url: url, data: payload }).done(
+                $.ajax({ type: "POST", url: url, data: payload, contentType: jsonContentType }).done(
                     function(data) {
                         if (data.success) {
                             defer.resolveWith(this, [data.corrections]);
@@ -382,7 +385,7 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
         scheduleTraining: function() {
             var url = this.url('schedule_training');
             return $.Deferred(function(defer) {
-                $.ajax({ type: "POST", url: url, data: "\"\""}).done(
+                $.ajax({ type: "POST", url: url, data: "\"\"", contentType: jsonContentType}).done(
                     function(data) {
                         if (data.success) {
                             defer.resolveWith(this, [data.msg]);
@@ -406,7 +409,7 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
         rescheduleUnfinishedTasks: function() {
             var url = this.url('reschedule_unfinished_tasks');
             return $.Deferred(function(defer) {
-                $.ajax({ type: "POST", url: url, data: "\"\""}).done(
+                $.ajax({ type: "POST", url: url, data: "\"\"", contentType: jsonContentType}).done(
                     function(data) {
                         if (data.success) {
                             defer.resolveWith(this, [data.msg]);
@@ -460,7 +463,7 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
             });
             return $.Deferred(function(defer) {
                 $.ajax({
-                    type: "POST", url: url, data: payload
+                    type: "POST", url: url, data: payload, contentType: jsonContentType
                 }).done(function(data) {
                     if (data.success) { defer.resolve(); }
                     else { defer.rejectWith(this, [data.msg]); }
@@ -490,7 +493,7 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
             var payload = "\"\"";
             return $.Deferred(function(defer) {
                 $.ajax({
-                    type: "POST", url: url, data: payload
+                    type: "POST", url: url, data: payload, contentType: jsonContentType
                 }).done(function(data) {
                     if (data.success) { defer.resolveWith(this, [data.is_released]); }
                     else { defer.rejectWith(this, [data.msg]); }
@@ -516,7 +519,7 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
             var url = this.url('upload_url');
             return $.Deferred(function(defer) {
                 $.ajax({
-                    type: "POST", url: url, data: JSON.stringify({contentType: contentType})
+                    type: "POST", url: url, data: JSON.stringify({contentType: contentType}), contentType: jsonContentType
                 }).done(function(data) {
                         if (data.success) { defer.resolve(data.url); }
                         else { defer.rejectWith(this, [data.msg]); }
@@ -537,7 +540,7 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
             var url = this.url('download_url');
             return $.Deferred(function(defer) {
                 $.ajax({
-                    type: "POST", url: url, data: JSON.stringify({})
+                    type: "POST", url: url, data: JSON.stringify({}), contentType: jsonContentType
                 }).done(function(data) {
                         if (data.success) { defer.resolve(data.url); }
                         else { defer.rejectWith(this, [data.msg]); }
@@ -560,7 +563,7 @@ if (typeof OpenAssessment.Server == "undefined" || !OpenAssessment.Server) {
                 comments: comments
             });
             return $.Deferred(function (defer) {
-                $.ajax({ type: "POST", url: url, data: payload }).done(
+                $.ajax({ type: "POST", url: url, data: payload, contentType: jsonContentType }).done(
                     function(data) {
                         if (data.success) {
                             defer.resolveWith(this, [data.msg]);


### PR DESCRIPTION
…ry default contenttype is application/x-www-form-urlencoded; charset=UTF-8. So here sending ?? in the ajax request, it gets encoded in strange manner. So add content-Type to application/json; charset=UTF-8 when sending a json ajax request.

Mentioned in [ORA2 breaks when encountering multiple question marks](https://openedx.atlassian.net/browse/TNL-3437)

**Issue**: `$.ajax` method's default content-type is `application/x-www-form-urlencoded; charset=UTF-8` , which also encodes `?` when sending a ajax request.

**Solution** : explicitly specify `Content-Type` to `application/json; charset=UTF-8` when sending a json request.

@waheedahmed @muzaffaryousaf @symbolist Please review.

@adampalay FYI