### PR TITLE
Use improved Jasmine results plugin

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,8 @@ module.exports = function(config) {
       'karma-coverage',
       'karma-jasmine',
       'karma-chrome-launcher',
-      'karma-phantomjs-launcher'
+      'karma-phantomjs-launcher',
+      'karma-spec-reporter'
     ],
 
     // frameworks to use
@@ -56,9 +57,7 @@ module.exports = function(config) {
 
 
     // test results reporter to use
-    // possible values: 'dots', 'progress'
-    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
+    reporters: ['spec', 'coverage'],
 
     coverageReporter: {
         type : 'text'

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "devDependencies": {
     "karma": "~0.12",
     "karma-chrome-launcher": "0.1.3",
-    "karma-coverage": "0.2.4",
+    "karma-coverage": "^0.2.6",
     "karma-jasmine": "0.1.5",
     "karma-phantomjs-launcher": "^0.1.4",
+    "karma-spec-reporter": "^0.0.20",
     "uglify-js": "2.3.6"
   },
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start --reporters progress,coverage"
+    "test": "./node_modules/karma/bin/karma start --reporters spec,coverage"
   }
 }


### PR DESCRIPTION
Use a Jasmine test results plugin that shows a clean summary of the tests that were run and shows those that failed. You can see an example (hopefully all passing) by clicking on the Travis details for this PR.

@cahrens @dianakhuang please review.