### PR TITLE
Staff xblock test additions

### DIFF
--- a/openassessment/xblock/test/test_staff.py
+++ b/openassessment/xblock/test/test_staff.py
@@ -9,6 +9,7 @@ from openassessment.assessment.api import staff as staff_api
 from openassessment.xblock.data_conversion import create_rubric_dict
 from .base import XBlockHandlerTestCase, scenario
 
+#touch
 
 class StaffAssessmentTestBase(XBlockHandlerTestCase):
     maxDiff = None


### PR DESCRIPTION
Continuing from https://github.com/edx/edx-ora2/pull/768, with a goal of increasing test coverage. I won't be changing behavior in any way, just writing some tests based on the following:

| Name | Stmts | Miss | Branch | Branch Misses | Cover | Missing |
|---|---|---|---|---|---|---|
| workflow.models | 257 | 19 | 98 | 14 | 91% | 247-248, 357-361, 442, 474-475, 517-521, 544-549, 711, 718 |

Attack plan:
* get_score and skip over non-existent staff assessment
* staff_score_exists True, somehow
* something about get_score not getting a staff score #248
* backwards-compatible mock None #357-361
* non related, but could get us to 100% coverage:
  * cancel workflow that already has score
  * databaseerrors in workflow cancellation, get by uuid
  * get nonexistent workflow by uuid
  * unicode methods of cancellation object