### PR TITLE
Adding html to black list for custom file types.

### DIFF
--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -44,6 +44,7 @@ class SubmissionMixin(object):
         'msh1xml', 'msh2xml', 'action', 'apk', 'app', 'bin', 'command', 'csh',
         'ins', 'inx', 'ipa', 'isu', 'job', 'mst', 'osx', 'out', 'paf', 'prg',
         'rgs', 'run', 'sct', 'shb', 'shs', 'u3p', 'vbscript', 'vbe', 'workflow',
+        'htm', 'html',
     ]
 
     @XBlock.json_handler


### PR DESCRIPTION
This PR adds `html & htm` extension to the black list for custom type file uploads.

Sandbox: https://html-blacklisted.sandbox.edx.org/