### PR TITLE
Remove part of api test

### DIFF
--- a/openassessment/workflow/test/test_api.py
+++ b/openassessment/workflow/test/test_api.py
@@ -361,16 +361,6 @@ class TestAssessmentWorkflowApi(CacheResetTest):
         with self.assertRaises(AssessmentWorkflowInternalError):
             workflow_api.create_workflow(submission['uuid'], ['self'], ON_INIT_PARAMS)
 
-        AssessmentWorkflow.objects.create(
-            submission_uuid=submission['uuid'],
-            status=AssessmentWorkflow.STATUS.waiting,
-            course_id=ITEM_1['course_id'],
-            item_id=ITEM_1['item_id']
-        )
-
-        with self.assertRaises(AssessmentApiLoadError):
-            workflow_api.update_from_assessments(submission['uuid'], {})
-
     def test_cancel_the_assessment_workflow(self):
         # Create the submission and assessment workflow.
         submission = sub_api.create_submission(ITEM_1, ANSWER_1)


### PR DESCRIPTION
This test is trying to confirm behavior when an api cannot be loaded.
It is no longer possible for an AssessmentWorkflow to have been created
without going through __init__(), so the latter part of this test is
now trying to confirm assumptions about an impossible state.

I recommend we just remove it. @andy-armstrong, thoughts?