### PR TITLE
Staff assessments and workflow status

### DIFF
--- a/openassessment/assessment/models/base.py
+++ b/openassessment/assessment/models/base.py
@@ -573,7 +573,7 @@ class Assessment(models.Model):
         """
         assessments = list(assessments)  # Force us to read it all
         if not assessments:
-            return []
+            return {}
 
         # Generate a cache key that represents all the assessments we're being
         # asked to grab scores from (comma separated list of assessment IDs)


### PR DESCRIPTION
Staff assessments can now mark workflow as being done, with proper handling to hide a score if the submitter has not yet fulfilled their obligations. Includes tests.

Also contains a tiny bugfix for a previously unexecuted codepath.

This PR supersedes https://github.com/edx/edx-ora2/pull/787, which was pointing at the wrong branch. I'll get this newly-django-1.8-compliant code up on a sandbox shortly.

FYI @cahrens @dianakhuang @andy-armstrong 