### PR TITLE
Change exception type

### DIFF
--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -382,7 +382,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
         # A staff step must always be available, to allow for staff overrides
         try:
             self.steps.get(name=self.STATUS.staff)
-        except AttributeError:
+        except AssessmentWorkflowStep.DoesNotExist:
             for step in list(self.steps.all()):
                 step.order_num += 1
             self.steps.add(


### PR DESCRIPTION
I misunderstood what was happening in my cursory investigation earlier -
all that needs to change here is the type of exception being caught.

The work I've done previously to define `self.STEPS.staff` in `__init__()` renders the `AttributeError` check useless; a DNE check is what we need here. Note that the block immediately following will fix the issue by creating a staff AssessmentWorkflowStep and adding in to the model.

@andy-armstrong @cahrens Can you give this a quick look?