### PR TITLE
Fix falsy check for requirements

### DIFF
--- a/openassessment/assessment/api/student_training.py
+++ b/openassessment/assessment/api/student_training.py
@@ -41,7 +41,7 @@ def submitter_is_finished(submission_uuid, requirements):   # pylint:disable=W06
         StudentTrainingRequestError
 
     """
-    if requirements is None:
+    if not requirements:
         return False
 
     try:

--- a/openassessment/assessment/test/test_student_training_api.py
+++ b/openassessment/assessment/test/test_student_training_api.py
@@ -229,7 +229,7 @@ class StudentTrainingAssessmentTest(CacheResetTest):
             with self.assertRaises(StudentTrainingInternalError):
                 training_api.assess_training_example(self.submission_uuid, EXAMPLES[0]['options_selected'])
 
-    @ddt.data({}, {'num_required': 'not an integer!'})
+    @ddt.data({'some_other_field': 0}, {'num_required': 'not an integer!'})
     def test_submitter_is_finished_invalid_requirements(self, requirements):
         with self.assertRaises(StudentTrainingRequestError):
             training_api.submitter_is_finished(self.submission_uuid, requirements)


### PR DESCRIPTION
This makes `student_training.py` match what we did for `peer.py` back in https://github.com/edx/edx-ora2/pull/759. It seems silly that passing `None` returns false, while an empty dict causes errors.

For further discussion - is it the correct decision to always return `False` if there are no requirements? In my mind, no requirements means "nothing needs to be done" so the answer to the question "is the submitter finished?" is then `True`.

That doesn't make sense for what we're doing with staff grading though, in these cases it's more "we don't know the requirements so we can't rightly make any decision about whether the submitter is finished".

@dianakhuang - Let's discuss this further in the morning. This seems cleaner than https://github.com/edx/edx-ora2/pull/805, but we could also choose to have `None` be passed here(https://github.com/edx/edx-ora2/blob/ora-staff-grading/openassessment/xblock/staff_assessment_mixin.py#L55), or some other solution involving requirements.