### PR TITLE
Use workflow_requirements()

### DIFF
--- a/openassessment/assessment/api/peer.py
+++ b/openassessment/assessment/api/peer.py
@@ -45,7 +45,7 @@ def submitter_is_finished(submission_uuid, requirements):
         bool
 
     """
-    if not requirements:
+    if requirements is None:
         return False
 
     try:
@@ -59,6 +59,8 @@ def submitter_is_finished(submission_uuid, requirements):
         return False
     except PeerWorkflow.DoesNotExist:
         return False
+    except KeyError:
+        raise PeerAssessmentRequestError(u'Requirements dict must contain "must_grade" key')
 
 
 def assessment_is_finished(submission_uuid, requirements):

--- a/openassessment/workflow/api.py
+++ b/openassessment/workflow/api.py
@@ -264,7 +264,7 @@ def update_from_assessments(submission_uuid, assessment_requirements):
             u"Updated workflow for submission UUID {uuid} "
             u"with requirements {reqs}"
         ).format(uuid=submission_uuid, reqs=assessment_requirements))
-        return _serialized_with_details(workflow, assessment_requirements)
+        return _serialized_with_details(workflow)
     except PeerAssessmentError as err:
         err_msg = u"Could not update assessment workflow: {}".format(err)
         logger.exception(err_msg)
@@ -362,13 +362,12 @@ def _get_workflow_model(submission_uuid):
     return workflow
 
 
-def _serialized_with_details(workflow, assessment_requirements):
-    """Given a workflow and assessment requirements, return the serialized
-    version of an `AssessmentWorkflow` and add in the status details. See
-    `update_from_assessments()` for details on params and return values.
+def _serialized_with_details(workflow):
+    """
+    Given a workflow, return its serialized version with added status details.
     """
     data_dict = AssessmentWorkflowSerializer(workflow).data
-    data_dict["status_details"] = workflow.status_details(assessment_requirements)
+    data_dict["status_details"] = workflow.status_details()
     return data_dict
 
 

--- a/openassessment/xblock/staff_assessment_mixin.py
+++ b/openassessment/xblock/staff_assessment_mixin.py
@@ -52,7 +52,7 @@ class StaffAssessmentMixin(object):
                 create_rubric_dict(self.prompts, self.rubric_criteria_with_labels)
             )
             self.publish_assessment_event("openassessmentblock.staff_assessment", assessment)
-            workflow_api.update_from_assessments(assessment["submission_uuid"], {})
+            workflow_api.update_from_assessments(assessment["submission_uuid"], None)
 
         except StaffAssessmentRequestError:
             logger.warning(
@@ -71,7 +71,7 @@ class StaffAssessmentMixin(object):
             return {'success': False, 'msg': msg}
         else:
             return {'success': True, 'msg': u""}
-            
+
     @XBlock.handler
     def render_staff_assessment(self, data, suffix=''):
         """
@@ -85,7 +85,7 @@ class StaffAssessmentMixin(object):
         path, context_dict = self.staff_path_and_context()
 
         return self.render_assessment(path, context_dict)
-        
+
     def staff_path_and_context(self):
         """
         Retrieve the correct template path and template context for the handler to render.


### PR DESCRIPTION
~~@dianakhuang, here's another option for how to handle this situation, if we decide to not use https://github.com/edx/edx-ora2/pull/806. `workflow_requirements()` is defined here, and will ensure we have some value for student_training if that module exists: https://github.com/edx/edx-ora2/blob/ora-staff-grading/openassessment/xblock/workflow_mixin.py#L66~~