### PR TITLE
Full workflow bok choy tests

### DIFF
--- a/openassessment/templates/openassessmentblock/staff_area/oa_student_info.html
+++ b/openassessment/templates/openassessmentblock/staff_area/oa_student_info.html
@@ -46,7 +46,7 @@
     </div>
 
     {% if peer_assessments %}
-        <div class="staff-info__status ui-staff__content__section wrapper--ui--collapse">
+        <div class="staff-info__status ui-staff__content__section wrapper--ui--collapse staff-info__peer__assessments">
             <div class="ui-staff ui-toggle-visibility is--collapsed">
                 <h2 class="staff-info__title ui-staff__subtitle ui-toggle-visibility__control">
                     <i class="icon fa fa-caret-right" aria-hidden="true"></i>
@@ -99,7 +99,7 @@
     {% endif %}
 
     {% if submitted_assessments %}
-        <div class="staff-info__status ui-staff__content__section wrapper--ui--collapse">
+        <div class="staff-info__status ui-staff__content__section wrapper--ui--collapse staff-info__submitted__assessments">
             <div class="ui-staff ui-toggle-visibility is--collapsed">
                 <h2 class="staff-info__title ui-staff__subtitle ui-toggle-visibility__control">
                     <i class="icon fa fa-caret-right" aria-hidden="true"></i>
@@ -152,7 +152,7 @@
     {% endif %}
 
     {% if self_assessment %}
-        <div class="staff-info__status ui-staff__content__section wrapper--ui--collapse">
+        <div class="staff-info__status ui-staff__content__section wrapper--ui--collapse staff-info__self__assessment">
             <div class="ui-staff ui-toggle-visibility is--collapsed">
                 <h2 class="staff-info__title ui-staff__subtitle ui-toggle-visibility__control">
                     <i class="icon fa fa-caret-right" aria-hidden="true"></i>

--- a/test/acceptance/pages.py
+++ b/test/acceptance/pages.py
@@ -548,3 +548,24 @@ class StaffAreaPage(OpenAssessmentPage, AssessmentMixin):
         # Must put a comment to enable the submit button.
         self.q(css=self._bounded_selector("textarea.cancel_submission_comments")).fill("comment")
         self.submit(button_css=".action--submit-cancel-submission")
+
+    def status_text(self, section):
+        """
+        Return the status text (as an array of strings) as shown in the staff area section.
+
+        Args:
+            section: the classname of the section for which text should be returned
+                (for example, 'peer__assessments', 'submitted__assessments', or 'self__assessment'
+
+        Returns: array of strings representing the text(for example, ['Good', u'5', u'5', u'Excellent', u'3', u'3'])
+
+        """
+
+        table_elements = self.q(
+            css=self._bounded_selector(".staff-info__{} .staff-info__status__table .value".format(section))
+        )
+        text = []
+        for value in table_elements:
+            text.append(value.text)
+
+        return text


### PR DESCRIPTION
TNL-3819

Adds 2 new "full workflow" tests-- one with staff assessment at the end of the process, and one with staff assessment at the beginning. These tests cover the following previously-existing bugs: unable to submit a peer assessment after staff override, wrong assessment information shown in staff tools, unable to submit staff override for a problem with training.

@andy-armstrong and @efischer19 please review.