### PR TITLE
Increase the comment textarea size to 1000

### DIFF
--- a/openassessment/templates/openassessmentblock/oa_rubric.html
+++ b/openassessment/templates/openassessmentblock/oa_rubric.html
@@ -44,7 +44,7 @@
                                 class="answer__value"
                                 value="{{ criterion.name }}"
                                 name="{{ criterion.name }}"
-                                maxlength="300"
+                                maxlength="1000"
                                 {% if criterion.feedback == 'required' %}required{% endif %}
                                 >
                             </textarea>

--- a/openassessment/templates/openassessmentblock/peer/oa_peer_turbo_mode.html
+++ b/openassessment/templates/openassessmentblock/peer/oa_peer_turbo_mode.html
@@ -100,7 +100,7 @@
                                                             class="answer__value"
                                                             value="{{ criterion.name }}"
                                                             name="{{ criterion.name }}"
-                                                            maxlength="300"
+                                                            maxlength="1000"
                                                             {% if criterion.feedback == 'required' %}required{% endif %}
                                                             >
                                                         </textarea>


### PR DESCRIPTION
The current comment textarea size is limited to 300 in the UI. We have a use case for larger size comment. Here is the rationale from our instructor:

> Our class involves the development of a research proposal, which is run through the peer assessment module. Both the TA and myself ran into the word limit, as did many of our students (I got several forum messages and emails about this). Given that the feedback is vital for the development of the proposals in a professional development setting, a higher character limit would be quite helpful.

As some poking around the code and chat on Slack, the backend is supporting much larger size of comment. And this PR is increasing the UI from 300 to 1000 to support larger comment.