### PR TITLE
Django 1.8 modernizations

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -16,6 +16,7 @@ if __name__ == "__main__":
         import logging
         logging.captureWarnings(True)
         sys.argv.append('--noinput')
+        sys.argv.append('--logging-clear-handlers')
 
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -356,8 +356,7 @@ class OpenAssessmentBlock(
             "show_staff_area": self.is_course_staff and not self.in_studio_preview,
         }
         template = get_template("openassessmentblock/oa_base.html")
-        context = Context(context_dict)
-        fragment = Fragment(template.render(context))
+        fragment = Fragment(template.render(context_dict))
 
         i18n_service = self.runtime.service(self, 'i18n')
         if hasattr(i18n_service, 'get_language_bidi') and i18n_service.get_language_bidi():

--- a/openassessment/xblock/studio_mixin.py
+++ b/openassessment/xblock/studio_mixin.py
@@ -64,7 +64,7 @@ class StudioMixin(object):
         """
         rendered_template = get_template(
             'openassessmentblock/edit/oa_edit.html'
-        ).render(Context(self.editor_context()))
+        ).render(self.editor_context())
         fragment = Fragment(rendered_template)
         if settings.DEBUG:
             self.add_javascript_files(fragment, "static/js/src/oa_shared.js")

--- a/scripts/render_templates.py
+++ b/scripts/render_templates.py
@@ -30,8 +30,8 @@ import dateutil.parser
 import pytz
 
 # This is a bit of a hack to ensure that the root repo directory
-# is in the Python path, so Django can find the settings module.
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+# is in the front of the Python path, so Django can find the settings module.
+sys.path.insert(1,os.path.dirname(os.path.dirname(__file__)))
 import django
 from django.template.context import Context
 from django.template.loader import get_template
@@ -99,7 +99,7 @@ def render_templates(root_dir, template_json):
     for template_dict in template_json:
         template = get_template(template_dict['template'])
         context = parse_dates(template_dict['context'])
-        rendered = template.render(Context(context))
+        rendered = template.render(context)
         output_path = os.path.join(root_dir, template_dict['output'])
 
         try:

--- a/scripts/test-python.sh
+++ b/scripts/test-python.sh
@@ -6,5 +6,5 @@ cd `dirname $BASH_SOURCE` && cd ..
 git clean -xfd "./storage/test/"
 
 echo "Running Python tests..."
-export DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-"settings.test"}
+export DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-"settings.test_with_coverage"}
 python manage.py test $1

--- a/settings/base.py
+++ b/settings/base.py
@@ -6,7 +6,6 @@ import os
 from celery import Celery
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     ('admin', 'admin'),
@@ -89,10 +88,24 @@ STATICFILES_FINDERS = (
 SECRET_KEY = ')68&amp;-c!+og)cy$o9pju_$c707+fett&amp;ph%t%gqgu-@5)!cl$cr'
 
 # List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
According to https://docs.djangoproject.com/en/1.9/ref/templates/upgrading/,
there have been some changes made to TEMPLATES in settings files that we
should be using. This commit contains those, along with a few minor fixes
to allow tests to be run as expected (without cluttering stdout via logging,
with coverage on python tests) that aren't yet in master.