### PR TITLE
Show peer scores in full grade problem

### DIFF
--- a/openassessment/assessment/api/peer.py
+++ b/openassessment/assessment/api/peer.py
@@ -483,7 +483,7 @@ def has_finished_required_evaluating(submission_uuid, required_assessments):
     return done, peers_graded
 
 
-def get_assessments(submission_uuid, scored_only=True, limit=None):
+def get_assessments(submission_uuid, limit=None):
     """Retrieve the assessments for a submission.
 
     Retrieves all the assessments for a submissions. This API returns related
@@ -495,9 +495,6 @@ def get_assessments(submission_uuid, scored_only=True, limit=None):
             associated with. Required.
 
     Keyword Arguments:
-        scored (boolean): Only retrieve the assessments used to generate a score
-            for this submission.
-
         limit (int): Limit the returned assessments. If None, returns all.
 
 
@@ -513,7 +510,7 @@ def get_assessments(submission_uuid, scored_only=True, limit=None):
             while retrieving the assessments associated with this submission.
 
     Examples:
-        >>> get_assessments("1", scored_only=True, limit=2)
+        >>> get_assessments("1", limit=2)
         [
             {
                 'points_earned': 6,
@@ -533,15 +530,10 @@ def get_assessments(submission_uuid, scored_only=True, limit=None):
 
     """
     try:
-        if scored_only:
-            assessments = PeerWorkflowItem.get_scored_assessments(
-                submission_uuid
-            )[:limit]
-        else:
-            assessments = Assessment.objects.filter(
-                submission_uuid=submission_uuid,
-                score_type=PEER_TYPE
-            )[:limit]
+        assessments = Assessment.objects.filter(
+            submission_uuid=submission_uuid,
+            score_type=PEER_TYPE
+        )[:limit]
         return serialize_assessments(assessments)
     except DatabaseError:
         error_message = (
@@ -551,7 +543,7 @@ def get_assessments(submission_uuid, scored_only=True, limit=None):
         raise PeerAssessmentInternalError(error_message)
 
 
-def get_submitted_assessments(submission_uuid, scored_only=True, limit=None):
+def get_submitted_assessments(submission_uuid, limit=None):
     """Retrieve the assessments created by the given submission's author.
 
     Retrieves all the assessments created by the given submission's author. This
@@ -564,8 +556,6 @@ def get_submitted_assessments(submission_uuid, scored_only=True, limit=None):
         we are requesting. Required.
 
     Keyword Arguments:
-        scored (boolean): Only retrieve the assessments used to generate a score
-            for this submission.
         limit (int): Limit the returned assessments. If None, returns all.
 
     Returns:
@@ -581,7 +571,7 @@ def get_submitted_assessments(submission_uuid, scored_only=True, limit=None):
             while retrieving the assessments associated with this submission.
 
     Examples:
-        >>> get_submitted_assessments("1", scored_only=True, limit=2)
+        >>> get_submitted_assessments("1", limit=2)
         [
             {
                 'points_earned': 6,
@@ -608,8 +598,6 @@ def get_submitted_assessments(submission_uuid, scored_only=True, limit=None):
             scorer=workflow,
             assessment__isnull=False
         )
-        if scored_only:
-            items = items.exclude(scored=False)
         assessments = Assessment.objects.filter(
             pk__in=[item.assessment.pk for item in items])[:limit]
         return serialize_assessments(assessments)

--- a/openassessment/management/tests/test_create_oa_submissions.py
+++ b/openassessment/management/tests/test_create_oa_submissions.py
@@ -32,7 +32,7 @@ class CreateSubmissionsTest(TestCase):
             self.assertGreater(len(answer_dict['text']), 0)
 
             # Check that peer and self assessments were created
-            assessments = peer_api.get_assessments(submissions[0]['uuid'], scored_only=False)
+            assessments = peer_api.get_assessments(submissions[0]['uuid'])
 
             # Verify that the assessments exist and have content
             self.assertEqual(len(assessments), cmd.NUM_PEER_ASSESSMENTS)

--- a/openassessment/templates/openassessmentblock/grade/oa_grade_waiting.html
+++ b/openassessment/templates/openassessmentblock/grade/oa_grade_waiting.html
@@ -16,13 +16,7 @@
         <div class="wrapper--step__content">
             <div class="step__content">
                 <div class="grade__value__description">
-                    {% if waiting == 'peer' %}
-                        <p>{% trans "Your response is still undergoing peer assessment. After your peers have assessed your response, you'll see their comments and receive your final grade." %}</p>
-                    {% elif waiting == 'example-based' %}
-                        <p>{% trans "Your response is still undergoing example-based assessment. After your response has been assessed, you'll see the comments and receive your final grade." %}</p>
-                    {% elif waiting == 'all' %}
-                        <p>{% trans "Your response is still undergoing peer assessment and example-based assessment. After your peers have assessed your response and example-based assessment is complete, you'll see your peers' comments and receive your final grade." %}</p>
-                    {% endif %}
+                    <p>{% trans "Not all assessment steps have been completed for your response. After all assessment steps are complete, you will see feedback from everyone who assessed your response, and you will receive your final grade." %}</p>
                 </div>
             </div>
         </div>

--- a/openassessment/templates/openassessmentblock/message/oa_message_complete.html
+++ b/openassessment/templates/openassessmentblock/message/oa_message_complete.html
@@ -4,12 +4,8 @@
     <h3 class="message__title">{% trans "You Have Completed This Assignment" %} </h3>
     <div class="message__content">
         <p>
-            {% if waiting == 'peer' %}
-                <p>{% trans "Your grade will be available when your peers have completed their assessments of your response." %}</p>
-            {% elif waiting == 'example-based' %}
-                <p>{% trans "Your grade will be available when the example-based assessment of your response is complete." %}</p>
-            {% elif waiting == 'all' %}
-                <p>{% trans "Your grade will be available when your peers have completed their assessments of your response and the example-based assessment of your response is complete." %}</p>
+            {% if waiting %}
+                <p>{% trans "Your final grade will be available when all assessment steps for your response have been completed." %}</p>
             {% else %}
                 <a data-behavior="ui-scroll" href="#openassessment__grade">{% trans "Review your grade and your assessment details." %}</a>
             {% endif %}

--- a/openassessment/xblock/grade_mixin.py
+++ b/openassessment/xblock/grade_mixin.py
@@ -60,7 +60,7 @@ class GradeMixin(object):
             elif status == "done":
                 path, context = self.render_grade_complete(workflow)
             elif status == "waiting":
-                path, context = self.render_grade_waiting(workflow)
+                path, context = 'openassessmentblock/grade/oa_grade_waiting.html', {}
             elif status is None:
                 path = 'openassessmentblock/grade/oa_grade_not_started.html'
             else:  # status is 'self' or 'peer', which implies that the workflow is incomplete
@@ -69,22 +69,6 @@ class GradeMixin(object):
             return self.render_error(self._(u"An unexpected error occurred."))
         else:
             return self.render_assessment(path, context)
-
-    def render_grade_waiting(self, workflow):
-        """
-        Render the grade waiting state.
-
-        Args:
-            workflow (dict): The serialized Workflow model.
-
-        Returns:
-            tuple of context (dict) and template_path (string)
-
-        """
-        context = {
-            "waiting": self.get_waiting_details(workflow["status_details"])
-        }
-        return 'openassessmentblock/grade/oa_grade_waiting.html', context
 
     def render_grade_complete(self, workflow):
         """
@@ -108,6 +92,7 @@ class GradeMixin(object):
         has_submitted_feedback = False
 
         if "peer-assessment" in assessment_steps:
+            peer_api.get_score(submission_uuid, self.workflow_requirements()["peer"])
             feedback = peer_api.get_assessment_feedback(submission_uuid)
             peer_assessments = [
                 self._assessment_grade_context(peer_assessment)

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -777,22 +777,17 @@ class OpenAssessmentBlock(
 
     def get_waiting_details(self, status_details):
         """
-        Returns the specific waiting status based on the given status_details.
-        This status can currently be peer, example-based, or both. This is
-        determined by checking that status details to see if all assessment
-        modules have been graded.
+        Returns waiting status (boolean value) based on the given status_details.
 
         Args:
             status_details (dict): A dictionary containing the details of each
                 assessment module status. This will contain keys such as
-                "peer" and "ai", referring to dictionaries, which in turn will
-                have the key "graded". If this key has a value set, these
-                assessment modules have been graded.
+                "peer", "ai", and "staff", referring to dictionaries, which in
+                turn will have the key "graded". If this key has a value set,
+                these assessment modules have been graded.
 
         Returns:
-            A string of "peer", "exampled-based", or "all" to indicate which
-            assessment modules in the workflow are waiting on assessments.
-            Returns None if no module is waiting on an assessment.
+            True if waiting for a grade from peer, ai, or staff assessment, else False.
 
         Examples:
             >>> now = dt.datetime.utcnow().replace(tzinfo=pytz.utc)
@@ -807,18 +802,13 @@ class OpenAssessmentBlock(
             >>>     }
             >>> }
             >>> self.get_waiting_details(status_details)
-            "peer"
+            True
         """
-        waiting = None
-        peer_waiting = "peer" in status_details and not status_details["peer"]["graded"]
-        ai_waiting = "ai" in status_details and not status_details["ai"]["graded"]
-        if peer_waiting and ai_waiting:
-            waiting = "all"
-        elif peer_waiting:
-            waiting = "peer"
-        elif ai_waiting:
-            waiting = "example-based"
-        return waiting
+        steps = ["peer", "ai", "staff"]  # These are the steps that can be submitter-complete, but lack a grade
+        for step in steps:
+            if step in status_details and not status_details[step]["graded"]:
+                return True
+        return False
 
     def is_released(self, step=None):
         """

--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -391,7 +391,7 @@ class StaffAreaMixin(object):
 
         if "peer-assessment" in assessment_steps:
             peer_assessments = peer_api.get_assessments(submission_uuid)
-            submitted_assessments = peer_api.get_submitted_assessments(submission_uuid, scored_only=False)
+            submitted_assessments = peer_api.get_submitted_assessments(submission_uuid)
 
         if "self-assessment" in assessment_steps:
             self_assessment = self_api.get_assessment(submission_uuid)

--- a/openassessment/xblock/test/data/waiting_scenarios.json
+++ b/openassessment/xblock/test/data/waiting_scenarios.json
@@ -2,17 +2,17 @@
     "waiting_for_peer": {
         "waiting_for_peer": true,
         "waiting_for_ai": false,
-        "expected_response": "peer assessment"
+        "expected_response": "not all assessment steps have been completed"
     },
     "waiting_for_ai": {
         "waiting_for_peer": false,
         "waiting_for_ai": true,
-        "expected_response": "example-based assessment"
+        "expected_response": "not all assessment steps have been completed"
     },
     "waiting_for_both": {
         "waiting_for_peer": true,
         "waiting_for_ai": true,
-        "expected_response": "peer assessment and example-based assessment"
+        "expected_response": "not all assessment steps have been completed"
     },
     "not_waiting": {
         "waiting_for_peer": false,

--- a/openassessment/xblock/test/test_message.py
+++ b/openassessment/xblock/test/test_message.py
@@ -7,12 +7,14 @@ import copy
 
 import mock
 import pytz
+import ddt
 
 import datetime as dt
 from openassessment.xblock.openassessmentblock import OpenAssessmentBlock
 from .base import XBlockHandlerTestCase, scenario
 
 
+@ddt.ddt
 class TestMessageRender(XBlockHandlerTestCase):
     """
     Tests for the Message XBlock Handler
@@ -35,6 +37,10 @@ class TestMessageRender(XBlockHandlerTestCase):
             'graded': TODAY,
         },
         'ai': {
+            'completed': TODAY,
+            'graded': TODAY,
+        },
+        'staff': {
             'completed': TODAY,
             'graded': TODAY,
         },
@@ -717,7 +723,7 @@ class TestMessageRender(XBlockHandlerTestCase):
         expected_path = 'openassessmentblock/message/oa_message_complete.html'
 
         expected_context = {
-            "waiting": "peer"
+            "waiting": True
         }
 
         self._assert_path_and_context(
@@ -744,7 +750,7 @@ class TestMessageRender(XBlockHandlerTestCase):
         expected_path = 'openassessmentblock/message/oa_message_complete.html'
 
         expected_context = {
-            "waiting": "peer"
+            "waiting": True
         }
 
         self._assert_path_and_context(
@@ -752,12 +758,18 @@ class TestMessageRender(XBlockHandlerTestCase):
             status, deadline_information, has_peers_to_grade, status_details
         )
 
+    @ddt.data("peer", "ai", "staff", "all")
     @scenario('data/message_scenario.xml', user_id="Linda")
-    def test_waiting_on_ai(self, xblock):
+    def test_waiting_on_steps(self, xblock, step):
 
         status = 'waiting'
         status_details = copy.deepcopy(self.DEFAULT_STATUS_DETAILS)
-        status_details["ai"]["graded"] = None
+        if step == "all":
+            status_details["peer"]["graded"] = None
+            status_details["ai"]["graded"] = None
+            status_details["staff"]["graded"] = None
+        else:
+            status_details[step]["graded"] = None
 
         deadline_information = {
             'submission': (True, 'due', self.FAR_PAST, self.YESTERDAY),
@@ -771,35 +783,7 @@ class TestMessageRender(XBlockHandlerTestCase):
         expected_path = 'openassessmentblock/message/oa_message_complete.html'
 
         expected_context = {
-            "waiting": "example-based"
-        }
-
-        self._assert_path_and_context(
-            xblock, expected_path, expected_context,
-            status, deadline_information, has_peers_to_grade, status_details
-        )
-
-    @scenario('data/message_scenario.xml', user_id="Linda")
-    def test_waiting_on_all(self, xblock):
-
-        status = 'waiting'
-        status_details = copy.deepcopy(self.DEFAULT_STATUS_DETAILS)
-        status_details["ai"]["graded"] = None
-        status_details["peer"]["graded"] = None
-
-        deadline_information = {
-            'submission': (True, 'due', self.FAR_PAST, self.YESTERDAY),
-            'peer-assessment': (True, 'due', self.YESTERDAY, self.TODAY),
-            'self-assessment': (True, 'due', self.YESTERDAY, self.TODAY),
-            'over-all': (True, 'due', self.FAR_PAST, self.TODAY)
-        }
-
-        has_peers_to_grade = False
-
-        expected_path = 'openassessmentblock/message/oa_message_complete.html'
-
-        expected_context = {
-            "waiting": "all"
+            "waiting": True
         }
 
         self._assert_path_and_context(
@@ -824,7 +808,7 @@ class TestMessageRender(XBlockHandlerTestCase):
         expected_path = 'openassessmentblock/message/oa_message_complete.html'
 
         expected_context = {
-            "waiting": None
+            "waiting": False
         }
 
         self._assert_path_and_context(
@@ -849,7 +833,7 @@ class TestMessageRender(XBlockHandlerTestCase):
         expected_path = 'openassessmentblock/message/oa_message_complete.html'
 
         expected_context = {
-            "waiting": None
+            "waiting": False
         }
 
         self._assert_path_and_context(

--- a/openassessment/xblock/test/test_peer.py
+++ b/openassessment/xblock/test/test_peer.py
@@ -823,5 +823,5 @@ class TestPeerAssessHandler(XBlockHandlerTestCase):
             self.assertTrue(resp['success'])
 
             # Retrieve the peer assessment
-            retrieved_assessment = peer_api.get_assessments(submission['uuid'], scored_only=False)[0]
+            retrieved_assessment = peer_api.get_assessments(submission['uuid'])[0]
             return submission['uuid'], retrieved_assessment

--- a/test/acceptance/tests.py
+++ b/test/acceptance/tests.py
@@ -1001,8 +1001,8 @@ class FullWorkflowRequiredTest(OpenAssessmentTest, FullWorkflowMixin):
 
     @retry()
     @attr('acceptance')
-    @ddt.data(False)
-    def test_train_self_peer_staff(self, peer_grades_me):  # TODO: can't run with "True" due to TNL-3957
+    @ddt.data(True, False)
+    def test_train_self_peer_staff(self, peer_grades_me):
         """
         Scenario: complete workflow that included staff required step.
 
@@ -1032,12 +1032,17 @@ class FullWorkflowRequiredTest(OpenAssessmentTest, FullWorkflowMixin):
         self._verify_staff_grade_section(self.STAFF_GRADE_EXISTS, None)
         self.assertEqual(self.STAFF_OVERRIDE_SCORE, self.grade_page.wait_for_page().score)
 
-        # Note that PEER ASSESSMENT isn't shown here - it gets cut off the page in this case
-        # See TNL-3930 for details and possible fix.
-        self.verify_grade_entries([
-            [(u"STAFF GRADE - 0 POINTS", u"Poor"), (u"STAFF GRADE - 1 POINT", u"Fair")],
-            [(u"YOUR SELF ASSESSMENT", u"Good"), (u"YOUR SELF ASSESSMENT", u"Excellent")],
-        ])
+        if peer_grades_me:
+            self.verify_grade_entries([
+                [(u"STAFF GRADE - 0 POINTS", u"Poor"), (u"STAFF GRADE - 1 POINT", u"Fair")],
+                [(u"PEER MEDIAN GRADE", u"Poor"), (u"PEER MEDIAN GRADE", u"Poor")],
+                [(u"YOUR SELF ASSESSMENT", u"Good"), (u"YOUR SELF ASSESSMENT", u"Excellent")],
+            ])
+        else:
+            self.verify_grade_entries([
+                [(u"STAFF GRADE - 0 POINTS", u"Poor"), (u"STAFF GRADE - 1 POINT", u"Fair")],
+                [(u"YOUR SELF ASSESSMENT", u"Good"), (u"YOUR SELF ASSESSMENT", u"Excellent")],
+            ])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## [TNL-3957](https://openedx.atlassian.net/browse/TNL-3957)

There are 2 main issues being fixed here:
First, the peer scores that are not used to calculate score are always hidden.
This is because the peer api tries to hide these values by default.
Within the peer api, `scored_only` seems to only be used in a handful of tests, 
and is never expected implicitly by the ORA2 frontend. Because of this I've
changed the default to be `False`, and updated the tests that expected
the old default behavior to explicitly use `True`.

Secondly, the display strings for waiting values are not yet updated.
I've replayed the changes initially proposed in https://github.com/edx/edx-ora2/pull/764,
with a simplification made (thanks @catong for the suggestion - https://github.com/edx/edx-ora2/pull/764#discussion_r45105717). @explorerleslie, is this an okay simplification to
make, or is it important that the display string explicitly list each step requirement? I'll
add a screenshot below.

### Sandbox
- [x] https://efischer19.sandbox.edx.org/

### Testing
- [x] Unit tests passing locally
- [x] Acceptance tests passing locally

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @andy-armstrong 
- [x] Display strings review: @catong 
- [ ] Product review: @explorerleslie 