### PR TITLE
Staff can view uploaded files

### DIFF
--- a/openassessment/templates/openassessmentblock/staff_area/oa_student_info.html
+++ b/openassessment/templates/openassessmentblock/staff_area/oa_student_info.html
@@ -36,12 +36,8 @@
                         {% trans "The learner's response to the question above:" as translated_label %}
                         {% include "openassessmentblock/oa_submission_answer.html" with answer=submission.answer answer_text_label=translated_label %}
 
-                        {% if submission.file_url %}
-                            <a href="{{ submission.file_url }}" class="submission--file">
-                                {% trans "The file associated with this response." %}
-                            </a>
-                            <span>{%  trans "Caution: This file was uploaded by another course learner and has not been verified, screened, approved, reviewed, or endorsed by edX. If you decide to access it, you do so at your own risk." %}</span>
-                        {% endif %}
+                        {% trans "Associated File" as translated_header %}
+                        {% include "openassessmentblock/oa_uploaded_file.html" with file_upload_type=file_upload_type file_url=staff_file_url header=translated_header class_prefix="staff-assessment" show_warning="true" %}
                     </div>
                 {% endif %}
             </div>

--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -323,25 +323,15 @@ class StaffAreaMixin(object):
         Returns:
             A context dict for rendering a student submission and associated rubric (for staff grading).
         """
-        if submission and 'file_key' in submission.get('answer', {}):
-            file_key = submission['answer']['file_key']
-
-            try:
-                submission['file_url'] = file_api.get_download_url(file_key)
-            except file_exceptions.FileUploadError:
-                # Log the error, but do not prevent the rest of the student info
-                # from being displayed.
-                msg = (
-                    u"Could not retrieve image URL for staff debug page.  "
-                    u"The learner username is '{student_username}', and the file key is {file_key}"
-                ).format(student_username=student_username, file_key=file_key)
-                logger.exception(msg)
-
         context = {
             'submission': create_submission_dict(submission, self.prompts) if submission else None,
             'rubric_criteria': copy.deepcopy(self.rubric_criteria_with_labels),
             'student_username': student_username,
         }
+
+        if submission:
+            context["file_upload_type"] = self.file_upload_type
+            context["staff_file_url"] = self.get_download_url_from_submission(submission)
 
         if self.rubric_feedback_prompt is not None:
             context["rubric_feedback_prompt"] = self.rubric_feedback_prompt

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -317,15 +317,19 @@ class TestCourseStaff(XBlockHandlerTestCase):
         }, ['self'])
 
         # Mock the file upload API to avoid hitting S3
-        with patch("openassessment.xblock.staff_area_mixin.file_api") as file_api:
+        with patch("openassessment.xblock.submission_mixin.file_upload_api") as file_api:
             file_api.get_download_url.return_value = "http://www.example.com/image.jpeg"
+            # also fake a file_upload_type so our patched url gets rendered
+            xblock.file_upload_type_raw = 'image'
+
             __, context = xblock.get_student_info_path_and_context("Bob")
 
             # Check that the right file key was passed to generate the download url
             file_api.get_download_url.assert_called_with("test_key")
 
             # Check the context passed to the template
-            self.assertEquals('http://www.example.com/image.jpeg', context['submission']['file_url'])
+            self.assertEquals('http://www.example.com/image.jpeg', context['staff_file_url'])
+            self.assertEquals('image', context['file_upload_type'])
 
             # Check the fully rendered template
             payload = urllib.urlencode({"student_username": "Bob"})


### PR DESCRIPTION
Not sure if this was a bug or an oversight, but staff were not able to see uploaded files before.

Verified fix on my sandbox. @andy-armstrong @dianakhuang Can I get quick thumbs on this?

<img width="849" alt="screen shot 2016-01-07 at 12 39 04 pm" src="https://cloud.githubusercontent.com/assets/7373924/12177748/c16907dc-b53b-11e5-82af-589fab4ba083.png">
