### PR TITLE
Updating reponse_submitted wording

### DIFF
--- a/openassessment/templates/openassessmentblock/response/oa_response_submitted.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response_submitted.html
@@ -22,19 +22,7 @@
         <div class="step__message message message--complete">
             <h3 class="message__title">{% trans "Your Response Has Been Submitted" %}</h3>
             <div class="message__content">
-                {% if has_peer and has_self %}
-                    {% blocktrans with peer_start_tag='<a data-behavior="ui-scroll" href="#openassessment__peer-assessment">'|safe self_start_tag='<a data-behavior="ui-scroll" href="#openassessment__self-assessment">'|safe end_tag='</a>'|safe %}
-                        You'll receive your grade after some of your peers have assessed your response and you complete the {{ peer_start_tag }}peer assessment{{ end_tag }} and {{ self_start_tag }}self assessment{{ end_tag }} steps.
-                    {% endblocktrans %}
-                {% elif has_peer %}
-                    {% blocktrans with start_tag='<a data-behavior="ui-scroll" href="#openassessment__peer-assessment">'|safe end_tag='</a>'|safe %}
-                        You'll receive your grade after some of your peers have assessed your response and you complete the {{ start_tag }}peer assessment{{ end_tag }} step.
-                    {% endblocktrans %}
-                {% elif has_self %}
-                    {% blocktrans with start_tag='<a data-behavior="ui-scroll" href="#openassessment__self-assessment">'|safe end_tag='</a>'|safe %}
-                        You'll receive your grade after you complete the {{ start_tag }}self assessment{{ end_tag }} step.
-                    {% endblocktrans %}
-                {% endif %}
+                {%trans You'll receive your grade after all assessment steps have been completed. %}
             </div>
         </div>
 


### PR DESCRIPTION
I wish I could think of an easy way to simplify this and keep the links present, but easily sorting through a step being present vs. user-completed vs. graded by others gets hairy very quickly, so I just went with the string below. Thoughts @cahrens @catong?

Here's how it looked before, note that the staff step would never impact the message so it still looked like this after peer grades were made and all user requirements were met.
<img width="1227" alt="screen shot 2016-01-07 at 1 08 29 pm" src="https://cloud.githubusercontent.com/assets/7373924/12178500/c729a0f6-b53f-11e5-8072-d5cc212869db.png">
