### PR TITLE
Editor Assessments Order improvements

### DIFF
--- a/openassessment/xblock/test/test_studio.py
+++ b/openassessment/xblock/test/test_studio.py
@@ -106,7 +106,8 @@ class StudioViewTest(XBlockHandlerTestCase):
         "example-based-assessment": "oa_ai_assessment_editor",
         "peer-assessment": "oa_peer_assessment_editor",
         "self-assessment": "oa_self_assessment_editor",
-        "student-training": "oa_student_training_editor"
+        "student-training": "oa_student_training_editor",
+        "staff-assessment": "oa_staff_assessment_editor",
     }
 
     @scenario('data/basic_scenario.xml')
@@ -246,22 +247,17 @@ class StudioViewTest(XBlockHandlerTestCase):
 
     @scenario('data/self_then_peer.xml')
     def test_render_editor_assessment_order(self, xblock):
-        # Initially, the editor assessment order should be the default
-        # (because we haven't set it yet by saving in Studio)
-        # However, the assessment order IS set when we import the problem from XML,
-        # and it differs from the default order (self->peer instead of peer->self)
         # Expect that the editor uses the order defined by the problem.
         self._assert_rendered_editor_order(xblock, [
-            'example-based-assessment',
             'student-training',
             'self-assessment',
             'peer-assessment',
+            'staff-assessment'
         ])
 
         # Change the order (simulates what would happen when the author saves).
         xblock.editor_assessments_order = [
             'student-training',
-            'example-based-assessment',
             'peer-assessment',
             'self-assessment',
         ]
@@ -273,9 +269,9 @@ class StudioViewTest(XBlockHandlerTestCase):
         # Expect that the rendered view reflects the new order
         self._assert_rendered_editor_order(xblock, [
             'student-training',
-            'example-based-assessment',
             'peer-assessment',
             'self-assessment',
+            'staff-assessment',
         ])
 
     def _assert_rendered_editor_order(self, xblock, expected_assessment_order):
@@ -304,6 +300,7 @@ class StudioViewTest(XBlockHandlerTestCase):
         actual_assessment_order = [
             index_dict['name']
             for index_dict in sorted(assessment_indices, key=lambda d: d['index'])
+            if index_dict['index'] > 0
         ]
         self.assertEqual(actual_assessment_order, expected_assessment_order)
 


### PR DESCRIPTION
## [TNL-4005](https://openedx.atlassian.net/browse/TNL-4005)

Moves `editor_assessments_order` to a property in `studio_mixin`, allowing for validation on every get and set, ensuring invalid orders are never viewed by the user.