### PR TITLE
Staff Assessment section in staff tools

### DIFF
--- a/openassessment/templates/openassessmentblock/staff_area/oa_student_info.html
+++ b/openassessment/templates/openassessmentblock/staff_area/oa_student_info.html
@@ -51,185 +51,28 @@
     </div>
 
     {% if peer_assessments %}
-        <div class="staff-info__status ui-staff__content__section wrapper--ui--collapse staff-info__peer__assessments">
-            <div class="ui-staff ui-toggle-visibility is--collapsed">
-                <h2 class="staff-info__title ui-staff__subtitle ui-toggle-visibility__control">
-                    <i class="icon fa fa-caret-right" aria-hidden="true"></i>
-                    <span>{% trans "Peer Assessments for This Learner" %}</span>
-                </h2>
-                <div class="ui-toggle-visibility__content">
-                    {% for assessment in peer_assessments %}
-                        {% with peer_num=forloop.counter %}
-                            <h4 class="title--sub">
-                                {% blocktrans %}
-                                    Peer {{ peer_num }}:
-                                {% endblocktrans %}
-                            </h4>
-                            <table class="staff-info__status__table" summary="{% trans "Assessment" %}">
-                                <thead>
-                                <tr>
-                                    <th abbr="Criterion" scope="col">{% trans "Criterion" %}</th>
-                                    <th abbr="Selected Option" scope="col">{% trans "Selected Option" %}</th>
-                                    <th abbr="Feedback" scope="col">{% trans "Feedback" %}</th>
-                                    <th abbr="Points" scope="col">{% trans "Points" %}</th>
-                                    <th abbr="Points Possible" scope="col">{% trans "Points Possible" %}</th>
-                                </tr>
-                                </thead>
-
-                                <tbody>
-                                {% for criterion in rubric_criteria %}
-                                    {% for part in assessment.parts %}
-                                        {% if part.option.criterion.name == criterion.name %}
-                                            <tr>
-                                                <td class="label">{{ criterion.label }}</td>
-                                                <td class="value">{{ part.option.label }}</td>
-                                                <td class="value">{{ part.feedback }}</td>
-                                                <td class="value">{{ part.option.points }}</td>
-                                                <td class="value">{{ criterion.total_value }}</td>
-                                            </tr>
-                                        {% endif %}
-                                    {% endfor %}
-                                {% endfor %}
-                                </tbody>
-                            </table>
-                            <h4 class="title--sub">{% trans "Overall Feedback" %}</h4>
-                            <div class="student__answer__display__content">
-                                {{ assessment.feedback|linebreaks }}
-                            </div>
-                        {% endwith %}
-                    {%  endfor %}
-                </div>
-            </div>
-        </div>
+        {% trans "Peer Assessments for This Learner" as translated_title %}
+        {% include "openassessmentblock/staff_area/oa_student_info_assessment_detail.html" with class_type="peer" assessments=peer_assessments %}
     {% endif %}
 
     {% if submitted_assessments %}
-        <div class="staff-info__status ui-staff__content__section wrapper--ui--collapse staff-info__submitted__assessments">
-            <div class="ui-staff ui-toggle-visibility is--collapsed">
-                <h2 class="staff-info__title ui-staff__subtitle ui-toggle-visibility__control">
-                    <i class="icon fa fa-caret-right" aria-hidden="true"></i>
-                    <span>{% trans "Peer Assessments Completed by This Learner" %}</span>
-                </h2>
-                <div class="ui-toggle-visibility__content">
-                    {% for assessment in submitted_assessments %}
-                        {% with peer_num=forloop.counter %}
-                            <h4 class="title--sub">
-                                {% blocktrans %}
-                                    Assessment {{ peer_num }}:
-                                {% endblocktrans %}
-                            </h4>
-                            <table class="staff-info__status__table" summary="{% trans "Assessment" %}">
-                                <thead>
-                                <tr>
-                                    <th abbr="Criterion" scope="col">{% trans "Criterion" %}</th>
-                                    <th abbr="Selected Option" scope="col">{% trans "Selected Option" %}</th>
-                                    <th abbr="Feedback" scope="col">{% trans "Feedback" %}</th>
-                                    <th abbr="Points" scope="col">{% trans "Points" %}</th>
-                                    <th abbr="Points Possible" scope="col">{% trans "Points Possible" %}</th>
-                                </tr>
-                                </thead>
-
-                                <tbody>
-                                {% for criterion in rubric_criteria %}
-                                    {% for part in assessment.parts %}
-                                        {% if part.option.criterion.name == criterion.name %}
-                                            <tr>
-                                                <td class="label">{{ criterion.label }}</td>
-                                                <td class="value">{{ part.option.label }}</td>
-                                                <td class="value">{{ part.feedback }}</td>
-                                                <td class="value">{{ part.option.points }}</td>
-                                                <td class="value">{{ criterion.total_value }}</td>
-                                            </tr>
-                                        {% endif %}
-                                    {% endfor %}
-                                {% endfor %}
-                                </tbody>
-                            </table>
-                            <h4 class="title--sub">{% trans "Overall Feedback" %}</h4>
-                            <div class="student__answer__display__content">
-                                {{ assessment.feedback|linebreaks }}
-                            </div>
-                        {% endwith %}
-                    {%  endfor %}
-                </div>
-            </div>
-        </div>
+        {% trans "Peer Assessments Completed by This Learner" as translated_title %}
+        {% include "openassessmentblock/staff_area/oa_student_info_assessment_detail.html" with class_type="submitted" assessments=submitted_assessments %}
     {% endif %}
 
     {% if self_assessment %}
-        <div class="staff-info__status ui-staff__content__section wrapper--ui--collapse staff-info__self__assessment">
-            <div class="ui-staff ui-toggle-visibility is--collapsed">
-                <h2 class="staff-info__title ui-staff__subtitle ui-toggle-visibility__control">
-                    <i class="icon fa fa-caret-right" aria-hidden="true"></i>
-                    <span>{% trans "Learner's Self Assessment" %}</span>
-                </h2>
-                <div class="ui-toggle-visibility__content">
-                    <table class="staff-info__status__table" summary="{% trans "Self Assessment" %}">
-                        <thead>
-                        <tr>
-                            <th abbr="Criterion" scope="col">{% trans "Criterion" %}</th>
-                            <th abbr="Selected Option" scope="col">{% trans "Selected Option" %}</th>
-                            <th abbr="Points" scope="col">{% trans "Points" %}</th>
-                            <th abbr="Points Possible" scope="col">{% trans "Points Possible" %}</th>
-                        </tr>
-                        </thead>
-
-                        <tbody>
-                        {% for criterion in rubric_criteria %}
-                            {% for part in self_assessment.parts %}
-                                {% if part.option.criterion.name == criterion.name %}
-                                    <tr>
-                                        <td class="label">{{ criterion.label }}</td>
-                                        <td class="value">{{ part.option.label }}</td>
-                                        <td class="value">{{ part.option.points }}</td>
-                                        <td class="value">{{ criterion.total_value }}</td>
-                                    </tr>
-                                {% endif %}
-                            {% endfor %}
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
+        {% trans "Learner's Self Assessment" as translated_title %}
+        {% include "openassessmentblock/staff_area/oa_student_info_assessment_detail.html" with class_type="self" assessments=self_assessment %}
     {% endif %}
 
     {% if example_based_assessment %}
-        <div class="staff-info__status ui-staff__content__section wrapper--ui--collapse">
-            <div class="ui-staff ui-toggle-visibility is--collapsed">
-                <h2 class="staff-info__title ui-staff__subtitle ui-toggle-visibility__control">
-                    <i class="icon fa fa-caret-right" aria-hidden="true"></i>
-                    <span>{% trans "Example-Based Assessment" %}</span>
-                </h2>
-                <div class="ui-toggle-visibility__content">
-                    <table class="staff-info__status__table" summary="{% trans "Example Based Assessment" %}">
-                        <thead>
-                        <tr>
-                            <th abbr="Criterion" scope="col">{% trans "Criterion" %}</th>
-                            <th abbr="Selected Option" scope="col">{% trans "Selected Option" %}</th>
-                            <th abbr="Points" scope="col">{% trans "Points" %}</th>
-                            <th abbr="Points Possible" scope="col">{% trans "Points Possible" %}</th>
-                        </tr>
-                        </thead>
+        {% trans "Example-Based Assessment" as translated_title %}
+        {% include "openassessmentblock/staff_area/oa_student_info_assessment_detail.html" with class_type="example_based" assessments=example_based_assessment %}
+    {% endif %}
 
-                        <tbody>
-                        {% for criterion in rubric_criteria %}
-                            {% for part in example_based_assessment.parts %}
-                                {% if part.option.criterion.name == criterion.name %}
-                                    <tr>
-                                        <td class="label">{{ criterion.label }}</td>
-                                        <td class="value">{{ part.option.label }}</td>
-                                        <td class="value">{{ part.option.points }}</td>
-                                        <td class="value">{{ criterion.total_value }}</td>
-                                    </tr>
-                                {% endif %}
-                            {% endfor %}
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
+    {% if staff_assessment %}
+        {% trans "Staff Assessment for This Learner" as translated_title %}
+        {% include "openassessmentblock/staff_area/oa_student_info_assessment_detail.html" with class_type="staff" assessments=staff_assessment %}
     {% endif %}
 
     <div class="staff-info__status ui-staff__content__section wrapper--ui--collapse staff-info__student__grade">

--- a/openassessment/templates/openassessmentblock/staff_area/oa_student_info_assessment_detail.html
+++ b/openassessment/templates/openassessmentblock/staff_area/oa_student_info_assessment_detail.html
@@ -1,0 +1,55 @@
+{% load i18n %}
+<div class="staff-info__status ui-staff__content__section wrapper--ui--collapse staff-info__{{ class_type }}__assessments">
+    <div class="ui-staff ui-toggle-visibility is--collapsed">
+        <h2 class="staff-info__title ui-staff__subtitle ui-toggle-visibility__control">
+            <i class="icon fa fa-caret-right" aria-hidden="true"></i>
+            <span>{{ translated_title }}</span>
+        </h2>
+        <div class="ui-toggle-visibility__content">
+            {% for assessment in assessments %}
+                {% with assessment_num=forloop.counter %}
+                    {% if assessments|length > 1 %}
+                        <h4 class="title--sub">
+                            {% blocktrans %}
+                                Assessment {{ assessment_num }}:
+                            {% endblocktrans %}
+                        </h4>
+                    {% endif %}
+                    <table class="staff-info__status__table" summary="{% trans "Assessment" %}">
+                        <thead>
+                        <tr>
+                            <th abbr="{% trans "Criterion" %}" scope="col">{% trans "Criterion" %}</th>
+                            <th abbr="{% trans "Selected Option" %}" scope="col">{% trans "Selected Option" %}</th>
+                            <th abbr="{% trans "Feedback" %}" scope="col">{% trans "Feedback" %}</th>
+                            <th abbr="{% trans "Points" %}" scope="col">{% trans "Points" %}</th>
+                            <th abbr="{% trans "Points Possible" %}" scope="col">{% trans "Points Possible" %}</th>
+                        </tr>
+                        </thead>
+
+                        <tbody>
+                        {% for criterion in rubric_criteria %}
+                            {% for part in assessment.parts %}
+                                {% if part.option.criterion.name == criterion.name %}
+                                    <tr>
+                                        <td class="label">{{ criterion.label }}</td>
+                                        <td class="value">{{ part.option.label }}</td>
+                                        <td class="value">{{ part.feedback }}</td>
+                                        <td class="value">{{ part.option.points }}</td>
+                                        <td class="value">{{ criterion.total_value }}</td>
+                                    </tr>
+                                {% endif %}
+                            {% endfor %}
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                    {% if assessment.feedback %}
+                        <h4 class="title--sub">{% trans "Overall Feedback" %}</h4>
+                        <div class="student__answer__display__content">
+                            {{ assessment.feedback|linebreaks }}
+                        </div>
+                    {% endif %}
+                {% endwith %}
+            {% endfor %}
+        </div>
+    </div>
+</div>

--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -378,6 +378,7 @@ class StaffAreaMixin(object):
         self_assessment = None
         peer_assessments = None
         submitted_assessments = None
+        staff_assessment = staff_api.get_latest_staff_assessment(submission_uuid)
 
         if "peer-assessment" in assessment_steps:
             peer_assessments = peer_api.get_assessments(submission_uuid)
@@ -394,17 +395,18 @@ class StaffAreaMixin(object):
         workflow_cancellation = self.get_workflow_cancellation_info(submission_uuid)
 
         context.update({
+            'expanded_view': expanded_view,
+            'example_based_assessment': [example_based_assessment] if example_based_assessment else None,
+            'self_assessment': [self_assessment] if self_assessment else None,
+            'peer_assessments': peer_assessments,
+            'submitted_assessments': submitted_assessments,
+            'staff_assessment': [staff_assessment] if staff_assessment else None,
             'score': workflow.get('score'),
             'workflow_status': workflow.get('status'),
             'workflow_cancellation': workflow_cancellation,
-            'peer_assessments': peer_assessments,
-            'submitted_assessments': submitted_assessments,
-            'self_assessment': self_assessment,
-            'example_based_assessment': example_based_assessment,
-            'expanded_view': expanded_view,
         })
 
-        if peer_assessments or self_assessment or example_based_assessment:
+        if peer_assessments or self_assessment or example_based_assessment or staff_assessment:
             max_scores = peer_api.get_rubric_max_scores(submission_uuid)
             for criterion in context["rubric_criteria"]:
                 criterion["total_value"] = max_scores[criterion["name"]]

--- a/openassessment/xblock/test/data/staff_grade_scenario.xml
+++ b/openassessment/xblock/test/data/staff_grade_scenario.xml
@@ -87,6 +87,6 @@
         </criterion>
     </rubric>
     <assessments>
-        <assessment name="staff-assessment" />
+        <assessment name="staff-assessment" required="true"/>
     </assessments>
 </openassessment>

--- a/test/acceptance/tests.py
+++ b/test/acceptance/tests.py
@@ -519,17 +519,19 @@ class StaffAreaTest(OpenAssessmentTest):
         Given I am viewing the staff area of an ORA problem
         When I search for a learner in staff tools
         And the learner has submitted a response to an ORA problem with self-assessment
+        And I've made a staff override assessment of the learner
         Then I see the correct learner information sections
         """
         username = self.do_self_assessment()
+        self.do_staff_override(username)
 
         self.staff_area_page.visit()
 
         # Click on staff tools and search for user
         self.staff_area_page.show_learner(username)
         self.assertEqual(
-            [u"Learner's Response", u"Learner's Self Assessment", u"Learner's Final Grade",
-             u"Submit Assessment Grade Override", u"Remove Submission From Peer Grading"],
+            [u"Learner's Response", u"Learner's Self Assessment", u"Staff Assessment for This Learner",
+             u"Learner's Final Grade", u"Submit Assessment Grade Override", u"Remove Submission From Peer Grading"],
             self.staff_area_page.learner_report_sections
         )
 
@@ -742,7 +744,7 @@ class FullWorkflowMixin(object):
     PEER_ASSESSMENT_STAFF_AREA_SCORE = "Final grade: 0 out of 8"
 
     SELF_ASSESSMENT = [2, 3]
-    STAFF_AREA_SELF_ASSESSMENT = ['Good', u'5', u'5', u'Excellent', u'3', u'3']
+    STAFF_AREA_SELF_ASSESSMENT = ['Good', u'', u'5', u'5', u'Excellent', u'', u'3', u'3']
 
     SUBMITTED_ASSESSMENT = [0, 3]
     STAFF_AREA_SUBMITTED = ['Poor', u'', u'0', u'5', u'Excellent', u'', u'3', u'3']
@@ -829,7 +831,7 @@ class FullWorkflowMixin(object):
         self.staff_area_page.expand_learner_report_sections()
         self.assertEqual(peer_assessments, self.staff_area_page.status_text('peer__assessments'))
         self.assertEqual(submitted_assessments, self.staff_area_page.status_text('submitted__assessments'))
-        self.assertEqual(self_assessment, self.staff_area_page.status_text('self__assessment'))
+        self.assertEqual(self_assessment, self.staff_area_page.status_text('self__assessments'))
 
     def verify_submission_has_peer_grade(self, learner, max_attempts=5):
         """


### PR DESCRIPTION
## [TNL-3808](https://openedx.atlassian.net/browse/TNL-3808)

Standardizes all assessment types inside staff area to use new `oa_student_info_assessment_detail.html` template, and adds staff assessment to that view.

As a part of this, self assessment view now displays feedback, which has always existed but was previously hidden.

### Sandbox
- [x] https://efischer19.sandbox.edx.org/

### Testing
- [ ] i18n - need to push/pull strings, as I've changed some display values
- [ ] RTL - will verify with i18n
- [x] Unit test added
- [x] Acceptance tests fixed up to pass again given new template
- [x] Accessibility tests passing

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @dianakhuang 
- [x] UI strings/error msgs review: @catong 

### Post-review
- [x] Squash commits