### PR TITLE
Final Grade section in staff tools

### DIFF
--- a/openassessment/templates/openassessmentblock/staff_area/oa_student_info.html
+++ b/openassessment/templates/openassessmentblock/staff_area/oa_student_info.html
@@ -83,21 +83,61 @@
             </h2>
             <div class="ui-toggle-visibility__content">
                 {% if workflow_status == "done" %}
-                    <p>
+                    <p class="staff-info__final__grade__score">
                     {% with points_earned_string=score.points_earned|stringformat:"s" points_possible_string=score.points_possible|stringformat:"s" %}
                         {% blocktrans with points_earned='<span class="grade__value__earned">'|safe|add:points_earned_string|add:'</span>'|safe points_possible='<span class="grade__value__potential">'|safe|add:points_possible_string|add:'</span>'|safe %}
                             Final grade: {{ points_earned }} out of {{ points_possible }}
                         {% endblocktrans %}
                     {% endwith %}
                     </p>
+                    <table class="staff-info__status__table staff-info__final__grade__table" summary="{% trans "Final Grade Details" %}">
+                        <thead>
+                        <tr>
+                            <th abbr="{% trans 'Criterion' %}" scope="col">{% trans "Criterion" %}</th>
+                            {% with criterion=grade_details.criteria.0 %}
+                                {% for assessment in criterion.assessments %}
+                                    <th abbr="{{ assessment.title }}" scope="col">{{ assessment.title }}</th>
+                                {% endfor %}
+                            {% endwith %}
+                        </tr>
+                        </thead>
+
+                        <tbody>
+                        {% for criterion in grade_details.criteria %}
+                            <tr>
+                                <td class="label">{{ criterion.label }}</td>
+                                {% for assessment in criterion.assessments %}
+                                    <td class="value">
+                                    {% if assessment.points != None %}
+                                        <div>
+                                        {% blocktrans with assessment_label=assessment.option.label count points=assessment.points %}
+                                            {{ assessment_label }} - {{ points }} point
+                                        {% plural %}
+                                            {{ assessment_label }} - {{ points }} points
+                                        {% endblocktrans %}
+                                        </div>
+                                    {% endif %}
+                                    {% if assessment.individual_assessments %}
+                                        {% for individual_assessment in assessment.individual_assessments %}
+                                            <div>{{ individual_assessment.title }} - {{ individual_assessment.option.label}}</div>
+                                        {% endfor %}
+                                    {% elif assessment.points == None %}
+                                        <div>{{ assessment.option.label }}</div>
+                                    {% endif %}
+                                    </td>
+                                {% endfor %}
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
                 {% elif workflow_status == "waiting" %}
-                    <p>{% trans "The submission is waiting for assessments." %}</p>
+                    <p class="staff-info__final__grade__score">{% trans "The submission is waiting for assessments." %}</p>
                 {% elif workflow_status == "cancelled" %}
-                    <p>{% trans "The learner's submission has been removed from peer assessment. The learner receives a grade of zero unless you delete the learner's state for the problem to allow them to resubmit a response." %}</p>
+                    <p class="staff-info__final__grade__score">{% trans "The learner's submission has been removed from peer assessment. The learner receives a grade of zero unless you delete the learner's state for the problem to allow them to resubmit a response." %}</p>
                 {% elif workflow_status == None %}
-                    <p>{% trans "The problem has not been started." %}</p>
+                    <p class="staff-info__final__grade__score">{% trans "The problem has not been started." %}</p>
                 {% else %}
-                    <p>{% trans "The problem has not been completed." %}</p>
+                    <p class="staff-info__final__grade__score">{% trans "The problem has not been completed." %}</p>
                 {% endif %}
             </div>
         </div>

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -208,6 +208,9 @@ class TestCourseStaff(XBlockHandlerTestCase):
         self.assertIsNone(context['staff_assessment'])
         self.assertEquals("openassessmentblock/staff_area/oa_student_info.html", path)
 
+        # Bob still needs to assess other learners
+        self.assertIsNone(context['grade_details'])
+
     @scenario('data/self_only_scenario.xml', user_id='Bob')
     def test_staff_area_student_info_self_only(self, xblock):
         # Simulate that we are course staff
@@ -239,6 +242,10 @@ class TestCourseStaff(XBlockHandlerTestCase):
         self.assertIsNone(context['staff_assessment'])
         self.assertEquals("openassessmentblock/staff_area/oa_student_info.html", path)
 
+        grade_details = context['grade_details']
+        self.assertEquals(1, len(grade_details['criteria'][0]['assessments']))
+        self.assertEquals('Self Assessment Grade', grade_details['criteria'][0]['assessments'][0]['title'])
+
     @scenario('data/staff_grade_scenario.xml', user_id='Bob')
     def test_staff_area_student_info_staff_only(self, xblock):
         # Simulate that we are course staff
@@ -269,6 +276,10 @@ class TestCourseStaff(XBlockHandlerTestCase):
         self.assertIsNone(context['self_assessment'])
         self.assertIsNotNone(context['staff_assessment'])
         self.assertEquals("openassessmentblock/staff_area/oa_student_info.html", path)
+
+        grade_details = context['grade_details']
+        self.assertEquals(1, len(grade_details['criteria'][0]['assessments']))
+        self.assertEquals('Staff Grade', grade_details['criteria'][0]['assessments'][0]['title'])
 
     @scenario('data/basic_scenario.xml', user_id='Bob')
     def test_staff_area_student_info_with_cancelled_submission(self, xblock):

--- a/test/acceptance/pages.py
+++ b/test/acceptance/pages.py
@@ -579,7 +579,7 @@ class StaffAreaPage(OpenAssessmentPage, AssessmentMixin):
         """
         Returns the final score displayed in the learner report.
         """
-        score = self.q(css=self._bounded_selector(".staff-info__student__grade .ui-toggle-visibility__content"))
+        score = self.q(css=self._bounded_selector(".staff-info__final__grade__score"))
         if len(score) == 0:
             return None
         return score.text[0]
@@ -592,6 +592,27 @@ class StaffAreaPage(OpenAssessmentPage, AssessmentMixin):
             lambda: self.learner_final_score == expected_score,
             "Learner score is updated"
         ).fulfill()
+
+    @property
+    def learner_final_score_table_headers(self):
+        """
+        Return the final score table headers (as an array of strings) as shown in the staff area section.
+
+        Returns: array of strings representing the headers (for example,
+            ['CRITERION', 'STAFF GRADE', 'PEER MEDIAN GRADE', 'SELF ASSESSMENT GRADE'])
+        """
+        return self._get_table_text(".staff-info__final__grade__table th")
+
+    @property
+    def learner_final_score_table_values(self):
+        """
+        Return the final score table values (as an array of strings) as shown in the staff area section.
+
+        Returns: array of strings representing the text (for example,
+            ['Poor - 0 points', 'Waiting for peer reviews', 'Good',
+             'Fair - 1 point', 'Waiting for peer reviews', 'Excellent'])
+        """
+        return self._get_table_text(".staff-info__final__grade__table .value")
 
     @property
     def learner_response(self):
@@ -637,12 +658,16 @@ class StaffAreaPage(OpenAssessmentPage, AssessmentMixin):
         Returns: array of strings representing the text(for example, ['Good', u'5', u'5', u'Excellent', u'3', u'3'])
 
         """
+        return self._get_table_text(".staff-info__{} .staff-info__status__table .value".format(section))
 
+    def _get_table_text(self, selector):
+        """
+        Helper method for getting text out of a table.
+        """
         table_elements = self.q(
-            css=self._bounded_selector(".staff-info__{} .staff-info__status__table .value".format(section))
+            css=self._bounded_selector(selector)
         )
         text = []
-        for value in table_elements:
-            text.append(value.text)
-
+        for element in table_elements:
+            text.append(element.text)
         return text

--- a/test/acceptance/tests.py
+++ b/test/acceptance/tests.py
@@ -578,13 +578,28 @@ class StaffAreaTest(OpenAssessmentTest):
         # Check the learner's current score.
         self.staff_area_page.expand_learner_report_sections()
         self.staff_area_page.verify_learner_final_score(self.STAFF_AREA_SCORE.format(self.EXPECTED_SCORE))
+        self.assertEquals(
+            ['CRITERION', 'SELF ASSESSMENT GRADE'],
+            self.staff_area_page.learner_final_score_table_headers
+        )
+        self.assertEquals(
+            ['Fair - 3 points', 'Good - 3 points'], self.staff_area_page.learner_final_score_table_values
+        )
 
         # Do staff override and wait for final score to change.
         self.staff_area_page.assess("staff-override", self.STAFF_OVERRIDE_OPTIONS_SELECTED)
 
         # Verify that the new student score is different from the original one.
-        # Unfortunately there is no indication presently that this was a staff override.
         self.staff_area_page.verify_learner_final_score(self.STAFF_AREA_SCORE.format(self.STAFF_OVERRIDE_SCORE))
+        self.assertEquals(
+            ['CRITERION', 'STAFF GRADE', 'SELF ASSESSMENT GRADE'],
+            self.staff_area_page.learner_final_score_table_headers
+        )
+        self.assertEquals(
+            ['Poor - 0 points', 'Fair',
+             'Fair - 1 point', 'Good'],
+            self.staff_area_page.learner_final_score_table_values
+        )
 
     @retry()
     @attr('acceptance')
@@ -906,6 +921,15 @@ class FullWorkflowOverrideTest(OpenAssessmentTest, FullWorkflowMixin):
             learner, self.STAFF_AREA_PEER_ASSESSMENT, self.STAFF_AREA_SUBMITTED, self.STAFF_AREA_SELF_ASSESSMENT
         )
         self.staff_area_page.verify_learner_final_score(self.PEER_ASSESSMENT_STAFF_AREA_SCORE)
+        self.assertEquals(
+            ['CRITERION', 'PEER MEDIAN GRADE', 'SELF ASSESSMENT GRADE'],
+            self.staff_area_page.learner_final_score_table_headers
+        )
+        self.assertEquals(
+            ['Poor - 0 points\nPeer 1 - Poor', 'Good',
+             'Poor - 0 points\nPeer 1 - Poor', 'Excellent'],
+            self.staff_area_page.learner_final_score_table_values
+        )
 
         self.verify_grade_entries([
             [(u"PEER MEDIAN GRADE - 0 POINTS", u"Poor"), (u"PEER MEDIAN GRADE - 0 POINTS", u"Poor")],
@@ -922,6 +946,15 @@ class FullWorkflowOverrideTest(OpenAssessmentTest, FullWorkflowMixin):
             learner, self.STAFF_AREA_PEER_ASSESSMENT, self.STAFF_AREA_SUBMITTED, self.STAFF_AREA_SELF_ASSESSMENT
         )
         self.staff_area_page.verify_learner_final_score(self.STAFF_AREA_SCORE.format(self.STAFF_OVERRIDE_SCORE))
+        self.assertEquals(
+            ['CRITERION', 'STAFF GRADE', 'PEER MEDIAN GRADE', 'SELF ASSESSMENT GRADE'],
+            self.staff_area_page.learner_final_score_table_headers
+        )
+        self.assertEquals(
+            ['Poor - 0 points', 'Peer 1 - Poor', 'Good',
+             'Fair - 1 point', 'Peer 1 - Poor', 'Excellent'],
+            self.staff_area_page.learner_final_score_table_values
+        )
 
         self.verify_grade_entries([
             [(u"STAFF GRADE - 0 POINTS", u"Poor"), (u"STAFF GRADE - 1 POINT", u"Fair")],
@@ -985,9 +1018,19 @@ class FullWorkflowOverrideTest(OpenAssessmentTest, FullWorkflowMixin):
         self.assertEqual(self.STAFF_OVERRIDE_SCORE, self.grade_page.wait_for_page().score)
         self.verify_staff_area_fields(learner, [], self.STAFF_AREA_SUBMITTED, self.STAFF_AREA_SELF_ASSESSMENT)
         self.staff_area_page.verify_learner_final_score(self.STAFF_AREA_SCORE.format(self.STAFF_OVERRIDE_SCORE))
+        self.assertEquals(
+            ['CRITERION', 'STAFF GRADE', 'PEER MEDIAN GRADE', 'SELF ASSESSMENT GRADE'],
+            self.staff_area_page.learner_final_score_table_headers
+        )
+        self.assertEquals(
+            ['Poor - 0 points', 'Waiting for peer reviews', 'Good',
+             'Fair - 1 point', 'Waiting for peer reviews', 'Excellent'],
+            self.staff_area_page.learner_final_score_table_values
+        )
 
         self.verify_grade_entries([
             [(u"STAFF GRADE - 0 POINTS", u"Poor"), (u"STAFF GRADE - 1 POINT", u"Fair")],
+            [(u'PEER MEDIAN GRADE', u'Waiting for peer reviews'), (u'PEER MEDIAN GRADE', u'Waiting for peer reviews')],
             [(u"YOUR SELF ASSESSMENT", u"Good"), (u"YOUR SELF ASSESSMENT", u"Excellent")]
         ])
 
@@ -1043,6 +1086,8 @@ class FullWorkflowRequiredTest(OpenAssessmentTest, FullWorkflowMixin):
         else:
             self.verify_grade_entries([
                 [(u"STAFF GRADE - 0 POINTS", u"Poor"), (u"STAFF GRADE - 1 POINT", u"Fair")],
+                [(u'PEER MEDIAN GRADE', u'Waiting for peer reviews'),
+                 (u'PEER MEDIAN GRADE', u'Waiting for peer reviews')],
                 [(u"YOUR SELF ASSESSMENT", u"Good"), (u"YOUR SELF ASSESSMENT", u"Excellent")],
             ])
 


### PR DESCRIPTION
## [TNL-3761](https://openedx.atlassian.net/browse/TNL-3761)

Adds more details to the "Final Grade" section in instructor tools. See screenshots below for more details.

Also fixes TNL-3930.

### Sandbox
- [x] https://finalgrade.sandbox.edx.org/

### Testing
- [ ] i18n - need to push/pull strings, as I've changed some display values
- [ ] RTL - will verify with i18n
- [x] Unit and acceptance tests added
- [x] Accessibility tests passing

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19  
- [ ] Code review: @dianakhuang 
- [ ] UI strings/error msgs review: @catong 

### Post-review
- [ ] Squash commits