### PR TITLE
Take care to avoid default behavior of get_workflow_info.

### DIFF
--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -402,7 +402,7 @@ class TestCourseStaff(XBlockHandlerTestCase):
         }, ['self'])
 
         # Mock the file upload API to simulate an error
-        with patch("openassessment.xblock.staff_area_mixin.file_api.get_download_url") as file_api_call:
+        with patch("openassessment.fileupload.api.get_download_url") as file_api_call:
             file_api_call.side_effect = FileUploadInternalError("Error!")
             __, context = xblock.get_student_info_path_and_context("Bob")
 

--- a/scripts/run-pylint.sh
+++ b/scripts/run-pylint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-MAX_PYLINT_VIOLATIONS=522
+MAX_PYLINT_VIOLATIONS=519
 
 mkdir -p test/logs
 PYLINT_VIOLATIONS=test/logs/pylint.txt

--- a/test/acceptance/tests.py
+++ b/test/acceptance/tests.py
@@ -544,12 +544,18 @@ class StaffAreaTest(OpenAssessmentTest):
         Scenario: staff tools indicates if no submission has been received for a given learner
 
         Given I am viewing the staff area of an ORA problem
+        And I myself have submitted a response with self-assessment
         When I search for a learner in staff tools
         And the learner has not submitted a response to the ORA problem
         Then I see a message indicating that the learner has not submitted a response
         And there are no student information sections displayed
         """
         self.auto_auth_page.visit()
+
+        # This is to catch a bug that existed when the user viewing staff tools had submitted an assessment,
+        # and had a grade stored (TNL-4060).
+        self.do_self_assessment()
+
         self.staff_area_page.visit()
 
         # Click on staff tools and search for user


### PR DESCRIPTION
## [TNL-4060](https://openedx.atlassian.net/browse/TNL-4060)

This fixes a bug I introduced this sprint, with the story to show additional information in the "Final Grade" section in staff tools.

### Sandbox
- [x] https://nolearner.sandbox.edx.org/courses/course-v1:edx+ORA203+course/courseware/a4dfec19cf9b4a6fb5b18be6ccd9cecc/338a4affb58a45459629e0566291381e/

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [x] Code review: @dianakhuang 

### Post-review
- [x] Squash commits