### PR TITLE
Increase the final comment textarea size

### DIFF
--- a/openassessment/templates/openassessmentblock/oa_rubric.html
+++ b/openassessment/templates/openassessmentblock/oa_rubric.html
@@ -69,7 +69,7 @@
                     id="{{ rubric_type }}__assessment__rubric__question--feedback__value"
                     class="assessment__rubric__question--feedback__value"
                     placeholder="{{ rubric_feedback_default_text }}"
-                    maxlength="500"
+                    maxlength="1000"
                 >
                 </textarea>
             </div>


### PR DESCRIPTION
The comment textarea size has been increase to 1000 in this PR(https://github.com/edx/edx-ora2/pull/811) and the final comment size is smaller now. Increases to 1000 to match the comment textarea size.