### PR TITLE
Allow openassessment xblock to clear state

### DIFF
--- a/openassessment/assessment/api/ai.py
+++ b/openassessment/assessment/api/ai.py
@@ -15,7 +15,7 @@ from openassessment.assessment.errors import (
 from openassessment.assessment.models import (
     Assessment, AITrainingWorkflow, AIGradingWorkflow,
     InvalidRubricSelection, NoTrainingExamples,
-    AI_ASSESSMENT_TYPE, AIClassifierSet
+    AI_ASSESSMENT_TYPE, AIClassifierSet, soft_delete
 )
 from openassessment.assessment.worker import training as training_tasks
 from openassessment.assessment.worker import grading as grading_tasks
@@ -394,3 +394,10 @@ def get_classifier_set_info(rubric_dict, algorithm_id, course_id, item_id):
         msg = u"An unexpected error occurred while retrieving classifier set info: {ex}".format(ex=ex)
         logger.exception(msg)
         raise AIGradingInternalError(msg)
+
+def reset_state(submission_uuid):
+    """
+    If student state is being reset, soft-delete everything related to the given uuid in ai grading.
+    """
+    soft_delete(submission_uuid, AIGradingWorkflow)
+    soft_delete(submission_uuid, Assessment)

--- a/openassessment/assessment/api/peer.py
+++ b/openassessment/assessment/api/peer.py
@@ -12,6 +12,7 @@ from dogapi import dog_stats_api
 from openassessment.assessment.models import (
     Assessment, AssessmentFeedback, AssessmentPart,
     InvalidRubricSelection, PeerWorkflow, PeerWorkflowItem,
+    soft_delete
 )
 from openassessment.assessment.serializers import (
     AssessmentFeedbackSerializer, RubricSerializer,
@@ -990,3 +991,12 @@ def on_cancel(submission_uuid):
         )
         logger.exception(error_message)
         raise PeerAssessmentInternalError(error_message)
+
+def reset_state(submission_uuid):
+    """
+    If student state is being reset, soft-delete everything related to the given uuid in peer grading.
+    """
+    soft_delete(submission_uuid, AssessmentFeedback)
+    soft_delete(submission_uuid, PeerWorkflow)
+    soft_delete(submission_uuid, PeerWorkflowItem)
+    soft_delete(submission_uuid, Assessment)

--- a/openassessment/assessment/api/self.py
+++ b/openassessment/assessment/api/self.py
@@ -10,7 +10,7 @@ from openassessment.assessment.serializers import (
     InvalidRubric, full_assessment_dict, rubric_from_dict, serialize_assessments
 )
 from openassessment.assessment.models import (
-    Assessment, AssessmentPart, InvalidRubricSelection
+    Assessment, AssessmentPart, InvalidRubricSelection, soft_delete
 )
 from openassessment.assessment.errors import (
     SelfAssessmentRequestError, SelfAssessmentInternalError
@@ -341,3 +341,9 @@ def _log_assessment(assessment, submission):
         dog_stats_api.histogram('openassessment.assessment.score_percentage', score_percentage, tags=tags)
 
     dog_stats_api.increment('openassessment.assessment.count', tags=tags)
+
+def reset_state(submission_uuid):
+    """
+    If student state is being reset, soft-delete everything related to the given uuid in self grading.
+    """
+    soft_delete(submission_uuid, Assessment)

--- a/openassessment/assessment/api/staff.py
+++ b/openassessment/assessment/api/staff.py
@@ -10,7 +10,7 @@ from submissions import api as submissions_api
 
 from openassessment.assessment.models import (
     Assessment, AssessmentFeedback, AssessmentPart,
-    InvalidRubricSelection, StaffWorkflow,
+    InvalidRubricSelection, StaffWorkflow, soft_delete
 )
 from openassessment.assessment.serializers import (
     AssessmentFeedbackSerializer, RubricSerializer,
@@ -451,3 +451,10 @@ def _complete_assessment(
     if scorer_workflow is not None:
         scorer_workflow.close_active_assessment(assessment, scorer_id)
     return assessment
+
+def reset_state(submission_uuid):
+    """
+    If student state is being reset, soft-delete everything related to the given uuid in staff grading.
+    """
+    soft_delete(submission_uuid, StaffWorkflow)
+    soft_delete(submission_uuid, Assessment)

--- a/openassessment/assessment/migrations/0003_reset_state.py
+++ b/openassessment/assessment/migrations/0003_reset_state.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assessment', '0002_staffworkflow'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='aigradingworkflow',
+            name='deleted',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='assessment',
+            name='deleted',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='assessmentfeedback',
+            name='deleted',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='peerworkflow',
+            name='deleted',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='peerworkflowitem',
+            name='deleted',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='staffworkflow',
+            name='deleted',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='studenttrainingworkflow',
+            name='deleted',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='studenttrainingworkflowitem',
+            name='deleted',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/openassessment/assessment/models/staff.py
+++ b/openassessment/assessment/models/staff.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from django.db import models, DatabaseError
 from django.utils.timezone import now
 
-from openassessment.assessment.models.base import Assessment
+from openassessment.assessment.models.base import Assessment, SoftDeletedManager
 from openassessment.assessment.errors import StaffAssessmentInternalError
 
 
@@ -35,6 +35,13 @@ class StaffWorkflow(models.Model):
     grading_started_at = models.DateTimeField(null=True, db_index=True)
     cancelled_at = models.DateTimeField(null=True, db_index=True)
     assessment = models.CharField(max_length=128, db_index=True, null=True)
+
+    # Has this workflow been soft-deleted? This allows instructors to reset student
+    # state on an item, while preserving the previous value for potential analytics use.
+    deleted = models.BooleanField(default=False)
+
+    # Override the default Manager with our custom one to filter out soft-deleted items
+    objects = SoftDeletedManager()
 
     class Meta:
         ordering = ["created_at", "id"]

--- a/openassessment/assessment/models/student_training.py
+++ b/openassessment/assessment/models/student_training.py
@@ -5,6 +5,7 @@ from django.db import models, IntegrityError
 from django.utils import timezone
 from submissions import api as sub_api
 from .training import TrainingExample
+from openassessment.assessment.models.base import SoftDeletedManager
 
 
 class StudentTrainingWorkflow(models.Model):
@@ -22,6 +23,13 @@ class StudentTrainingWorkflow(models.Model):
     student_id = models.CharField(max_length=40, db_index=True)
     item_id = models.CharField(max_length=128, db_index=True)
     course_id = models.CharField(max_length=40, db_index=True)
+
+    # Has this workflow been soft-deleted? This allows instructors to reset student
+    # state on an item, while preserving the previous value for potential analytics use.
+    deleted = models.BooleanField(default=False)
+
+    # Override the default Manager with our custom one to filter out soft-deleted items
+    objects = SoftDeletedManager()
 
     class Meta:
         app_label = "assessment"
@@ -185,6 +193,13 @@ class StudentTrainingWorkflowItem(models.Model):
     started_at = models.DateTimeField(auto_now_add=True)
     completed_at = models.DateTimeField(default=None, null=True)
     training_example = models.ForeignKey(TrainingExample)
+
+    # Has this workflow item been soft-deleted? This allows instructors to reset student
+    # state on an item, while preserving the previous value for potential analytics use.
+    deleted = models.BooleanField(default=False)
+
+    # Override the default Manager with our custom one to filter out soft-deleted items
+    objects = SoftDeletedManager()
 
     class Meta:
         app_label = "assessment"

--- a/openassessment/workflow/api.py
+++ b/openassessment/workflow/api.py
@@ -425,3 +425,6 @@ def is_workflow_cancelled(submission_uuid):
         return workflow.is_cancelled if workflow else False
     except AssessmentWorkflowError:
         return False
+
+def soft_delete(submission_uuid):
+    AssessmentWorkflow.delete_workflow_and_assessments(submission_uuid)

--- a/openassessment/workflow/migrations/0002_reset_state.py
+++ b/openassessment/workflow/migrations/0002_reset_state.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workflow', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='assessmentworkflow',
+            name='deleted',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -220,6 +220,22 @@ class OpenAssessmentBlock(
         help="Indicates whether or not there are peers to grade."
     )
 
+    def clear_state(self, user_id, course_id, item_id, delete=True):
+        """
+        Clear the state of this openassessment problem for the given (anonoymous) user_id.
+
+        For openassessment this operation makes no sense if delete is False, so we return immediately in that case.
+        """
+        if not delete:
+            return
+
+        # passthrough to sub_api.reset_student_item(), and look up all submissions for this user,course,item triplet
+        sub_uuids = self.clear_submission(user_id, course_id, item_id)
+
+        # soft-delete Workflow and any Assessments
+        for uuid in sub_uuids:
+            self.clear_workflow(uuid)
+
     @property
     def course_id(self):
         return self._serialize_opaque_key(self.xmodule_runtime.course_id)  # pylint:disable=E1101

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -211,6 +211,9 @@ class SubmissionMixin(object):
 
         return submission
 
+    def clear_submission(self, user_id, course_id, item_id):
+        return api.reset_student_item(user_id, course_id, item_id)
+
     @XBlock.json_handler
     def upload_url(self, data, suffix=''):
         """

--- a/openassessment/xblock/workflow_mixin.py
+++ b/openassessment/xblock/workflow_mixin.py
@@ -210,3 +210,7 @@ class WorkflowMixin(object):
             cancellation_info['cancelled_at'] = cancellation_model.created_at
 
         return cancellation_info
+
+
+    def clear_workflow(self, submission_uuid):
+        workflow_api.soft_delete(submission_uuid)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 git+https://github.com/edx/XBlock.git@xblock-0.4.1#egg=XBlock==0.4.1
 
 # edx-submissions
-git+https://github.com/edx/edx-submissions.git@0.1.3#egg=edx-submissions==0.1.3
+git+https://github.com/edx/edx-submissions.git@efischer/soft_delete_sub#egg=edx-submissions
 
 # Third Party Requirements
 boto>=2.32.1,<3.0.0


### PR DESCRIPTION
All the changes here are in support of one goal - openassessmentblock
should be able to provide a clear_state method which will:
* soft-delete any models that refer to a submission_uuid
* passthrough to the submissions api to delete the submission as well

Doing this will allow staff the ability to reset student state on ORA problems,
which is otherwise impossible. The changes in this commit are an entry point
in openassessmentblock, helpers in workflow_ and submission_mixin, and changes to
the workflow and assessment models and apis to allow them to be soft deleted.

Migrations are needed as a part of this change, they too are included.

Sibling change to https://github.com/edx/edx-platform/pull/11371 and https://github.com/edx/edx-submissions/pull/33