### PR TITLE
Change package declaration so that templates load.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,5 @@
 #!/usr/bin/env python
-from setuptools import setup
-
-PACKAGES = [
-    'openassessment',
-    'openassessment.assessment',
-    'openassessment.assessment.api',
-    'openassessment.assessment.errors',
-    'openassessment.assessment.models',
-    'openassessment.assessment.serializers',
-    'openassessment.assessment.worker',
-    'openassessment.fileupload',
-    'openassessment.fileupload.backends',
-    'openassessment.workflow',
-    'openassessment.management',
-    'openassessment.xblock'
-]
+from setuptools import setup, find_packages
 
 def is_requirement(line):
     """
@@ -60,7 +45,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
     ],
-    packages=PACKAGES,
+    packages=find_packages(exclude=["test", "tests"]),
     install_requires=load_requirements('requirements/base.txt', 'requirements/wheels.txt'),
     tests_require=load_requirements('requirements/test.txt'),
     entry_points={


### PR DESCRIPTION
Changing to find_packages instead of the explicit listing of packages allows the templates to load (without -e). I tested this with https://github.com/edx/edx-platform/pull/11512, building a sandbox (orae.sandbox.edx.org) with the edx-platform branch and both manually testing and running the ORA acceptance tests against the sandbox.

I also found that I could leave the package listing as it was and include the HTML files via package_data. But given that most of our repos just use find_packages, I decided to go with the simpler approach.

@nedbat and @efischer19 please review.