### PR TITLE
Update mathjax test

### DIFF
--- a/test/acceptance/pages.py
+++ b/test/acceptance/pages.py
@@ -102,7 +102,7 @@ class SubmissionPage(OpenAssessmentPage):
     def preview_latex(self):
         # Click 'Preview in LaTeX' button on the page.
         self.q(css="button#submission__preview").click()
-        self.wait_for_element_visibility("#preview_content .MathJax", "Verify Preview LaTeX expression")
+        self.wait_for_element_visibility("#preview_content .MathJax_CHTML", "Verify Preview LaTeX expression")
 
     def select_file(self, file_path_name):
         """

--- a/test/acceptance/tests.py
+++ b/test/acceptance/tests.py
@@ -78,7 +78,7 @@ class OpenAssessmentTest(WebAppTest):
     }
 
     SUBMISSION = u"This is a test submission."
-    LATEX_SUBMISSION = u"[mathjaxinline]( \int_{0}^{1}xdx \)[/mathjaxinline]"
+    LATEX_SUBMISSION = u"[mathjaxinline]( \int_{0}^{1}xdx )[/mathjaxinline]"
     OPTIONS_SELECTED = [1, 2]
     STAFF_OVERRIDE_OPTIONS_SELECTED = [0, 1]
     STAFF_OVERRIDE_SCORE = 1


### PR DESCRIPTION
The `test_latex` test started failing last week. After investigating, it turns out that the class we're searching for has changed as part of the MathJax upgrade that went out last week. Updating that; already confirmed working locally.

Will wait for http://jenkins.edx.org:8080/view/ora2/job/ora2-acceptance-tests/746/ to pass as well before merging.

@dianakhuang @cahrens Very small change, would you mind reviewing?