### PR TITLE
Version 1.0.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='0.2.9',
+    version='1.0.0',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
Seeing as ora2 is reasonably stable at this point, having been in
production for some time, I move that we transition our versioning
scheme from "arbitrarily increment the last digit in 0.2.x" to
semantic versioning as recommended by GitHub.

This is arbitrarily being declared the 1.0.0 release, all subsequent
releases should follow the guidlines described at http://semver.org/

Looping in the entire team to weigh in on this one: @cahrens @dianakhuang @robrap @andy-armstrong 