### PR TITLE
Fix leaderboard PDFs

### DIFF
--- a/openassessment/templates/openassessmentblock/leaderboard/oa_leaderboard_show.html
+++ b/openassessment/templates/openassessmentblock/leaderboard/oa_leaderboard_show.html
@@ -17,11 +17,9 @@
                             </h4>
                             {% endwith %}
                             <div class="leaderboard__answer">
-                                {% if topscore.file %}
-                                <img class="leaderboard__score__image" alt="{% trans "The image associated with your peer's submission." %}" src="{{ topscore.file }}" />
-                                {% endif %}
                                 {% trans "Your peer's response to the question above:" as translated_label %}
                                 {% include "openassessmentblock/oa_submission_answer.html" with answer=topscore.submission.answer answer_text_label=translated_label %}
+                                {% include "openassessmentblock/oa_uploaded_file.html" with file_upload_type=file_upload_type file_url=topscore.file class_prefix="submission__answer"%}
                             </div>
                         </li>
                     {% endfor %}

--- a/openassessment/xblock/leaderboard_mixin.py
+++ b/openassessment/xblock/leaderboard_mixin.py
@@ -86,7 +86,7 @@ class LeaderboardMixin(object):
 
             score.pop('content', None)
 
-        context = {'topscores': scores, 'allow_latex': self.allow_latex,}
+        context = {'topscores': scores, 'allow_latex': self.allow_latex, 'file_upload_type': self.file_upload_type,}
 
         return 'openassessmentblock/leaderboard/oa_leaderboard_show.html', context
 

--- a/openassessment/xblock/test/test_leaderboard.py
+++ b/openassessment/xblock/test/test_leaderboard.py
@@ -242,6 +242,7 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
             {
                 'topscores': scores,
                 'allow_latex': xblock.allow_latex,
+                'file_upload_type': xblock.file_upload_type,
             },
             workflow_status='done'
         )


### PR DESCRIPTION
As Shelby noted on TNL-3115, pdf files do not appear properly on the leaderboard, because the OSPR that added images to the leaderboard used raw `img` tags instead of our existing template.

This is a quick fix that seems to handle things.
Before screenshot:
<img width="571" alt="screen shot 2016-03-01 at 5 12 13 pm" src="https://cloud.githubusercontent.com/assets/7373924/13443800/c7c7ec96-dfd0-11e5-9385-0e6ab05ab5c6.png">

After screenshot:
<img width="668" alt="screen shot 2016-03-01 at 5 12 45 pm" src="https://cloud.githubusercontent.com/assets/7373924/13443817/d85c07a4-dfd0-11e5-841a-d11d9ba2ebb2.png">

You'll notice I also moved the image to be below the response instead of above the prompt; it seems more logical to me that way. If no one else agrees, we can move it back quite easily.

Seen on my sandbox at https://efischer19.sandbox.edx.org/courses/course-v1:edx+ORA203+course/courseware/a4dfec19cf9b4a6fb5b18be6ccd9cecc/8725631f67fa4b1099136f1196782767/

@dianakhuang @cahrens Can you give this a quick review?
