### PR TITLE
Fix oa_block release state status

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ Pan Luo <pan.luo@ubc.ca>
 Eric Fischer <efischer@edx.org>
 Andy Armstrong <andya@edx.org>
 Christina Roberts <christina@edx.org>
+Mushtaq Ali <mushtaak@gmail.com>

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -35,7 +35,7 @@ from openassessment.xblock.staff_assessment_mixin import StaffAssessmentMixin
 from openassessment.workflow.errors import AssessmentWorkflowError
 from openassessment.xblock.student_training_mixin import StudentTrainingMixin
 from openassessment.xblock.validation import validator
-from openassessment.xblock.resolve_dates import resolve_dates, DISTANT_PAST, DISTANT_FUTURE
+from openassessment.xblock.resolve_dates import resolve_dates, parse_date_value, DISTANT_PAST, DISTANT_FUTURE
 from openassessment.xblock.data_conversion import create_prompts_list, create_rubric_dict, update_assessments_format
 
 
@@ -834,7 +834,10 @@ class OpenAssessmentBlock(
         else:
             is_published = True
         is_closed, reason, __, __ = self.is_closed(step=step)
-        return is_published and (not is_closed or reason == 'due')
+        is_released = is_published and (not is_closed or reason == 'due')
+        if self.start:
+            is_released = is_released and dt.datetime.now(pytz.UTC) > parse_date_value(self.start, self._)
+        return is_released
 
     def get_assessment_module(self, mixin_name):
         """

--- a/openassessment/xblock/resolve_dates.py
+++ b/openassessment/xblock/resolve_dates.py
@@ -52,6 +52,11 @@ def _parse_date(value, _):
         raise InvalidDateFormat(_("'{date}' must be a date string or datetime").format(date=value))
 
 
+def parse_date_value(date, _):
+    """ Public method for _parse_date """
+    return _parse_date(date, _)
+
+
 def resolve_dates(start, end, date_ranges, _):
     """
     Resolve date strings (including "default" dates) to datetimes.

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -499,6 +499,19 @@ class TestDates(XBlockHandlerTestCase):
         self.assertTrue(xblock.is_released())
 
     @scenario('data/basic_scenario.xml')
+    def test_is_released_published_scheduled(self, xblock):
+        # The scenario doesn't provide a start date, so `is_released()`
+        # should be controlled only by the published state which defaults to True
+        xblock.runtime.modulestore = MagicMock()
+        xblock.runtime.modulestore.has_published_version.return_value = True
+
+        # Set the start date one day ahead in the future (in UTC)
+        xblock.start = dt.datetime.utcnow().replace(tzinfo=pytz.utc) + dt.timedelta(days=1)
+
+        # Check that it is not yet released
+        self.assertFalse(xblock.is_released())
+
+    @scenario('data/basic_scenario.xml')
     def test_is_released_no_ms(self, xblock):
         self.assertTrue(xblock.is_released())
 


### PR DESCRIPTION
While checking for release state of the the ORA block, we are not checking if the XBlock has actually went live or it has release/start date in future thus making it's state to scheduled/ready.

**Fix**
Add a check to calculate XBlock's start date against current time to define if it is live or not.

[TNL-4268](https://openedx.atlassian.net/browse/TNL-4268)