### PR TITLE
Handle IntegrityError according to 1.8 conventions.

### DIFF
--- a/openassessment/assessment/api/peer.py
+++ b/openassessment/assessment/api/peer.py
@@ -115,14 +115,15 @@ def on_start(submission_uuid):
 
     """
     try:
-        submission = sub_api.get_submission_and_student(submission_uuid)
-        workflow, __ = PeerWorkflow.objects.get_or_create(
-            student_id=submission['student_item']['student_id'],
-            course_id=submission['student_item']['course_id'],
-            item_id=submission['student_item']['item_id'],
-            submission_uuid=submission_uuid
-        )
-        workflow.save()
+        with transaction.atomic():
+            submission = sub_api.get_submission_and_student(submission_uuid)
+            workflow, __ = PeerWorkflow.objects.get_or_create(
+                student_id=submission['student_item']['student_id'],
+                course_id=submission['student_item']['course_id'],
+                item_id=submission['student_item']['item_id'],
+                submission_uuid=submission_uuid
+            )
+            workflow.save()
     except IntegrityError:
         # If we get an integrity error, it means someone else has already
         # created a workflow for this submission, so we don't need to do anything.
@@ -721,14 +722,15 @@ def create_peer_workflow(submission_uuid):
 
     """
     try:
-        submission = sub_api.get_submission_and_student(submission_uuid)
-        workflow, __ = PeerWorkflow.objects.get_or_create(
-            student_id=submission['student_item']['student_id'],
-            course_id=submission['student_item']['course_id'],
-            item_id=submission['student_item']['item_id'],
-            submission_uuid=submission_uuid
-        )
-        workflow.save()
+        with transaction.atomic():
+            submission = sub_api.get_submission_and_student(submission_uuid)
+            workflow, __ = PeerWorkflow.objects.get_or_create(
+                student_id=submission['student_item']['student_id'],
+                course_id=submission['student_item']['course_id'],
+                item_id=submission['student_item']['item_id'],
+                submission_uuid=submission_uuid
+            )
+            workflow.save()
     except IntegrityError:
         # If we get an integrity error, it means someone else has already
         # created a workflow for this submission, so we don't need to do anything.

--- a/openassessment/assessment/api/staff.py
+++ b/openassessment/assessment/api/staff.py
@@ -2,7 +2,7 @@
 Public interface for staff grading, used by students/course staff.
 """
 import logging
-from django.db import DatabaseError, IntegrityError, transaction
+from django.db import DatabaseError, transaction
 from django.utils.timezone import now
 from dogapi import dog_stats_api
 

--- a/openassessment/assessment/models/student_training.py
+++ b/openassessment/assessment/models/student_training.py
@@ -1,7 +1,7 @@
 """
 Django models specific to the student training assessment type.
 """
-from django.db import models, IntegrityError
+from django.db import models, transaction, IntegrityError
 from django.utils import timezone
 from submissions import api as sub_api
 from .training import TrainingExample
@@ -137,11 +137,12 @@ class StudentTrainingWorkflow(models.Model):
             next_example = available_examples[0]
 
             try:
-                StudentTrainingWorkflowItem.objects.create(
-                    workflow=self,
-                    order_num=order_num,
-                    training_example=next_example
-                )
+                with transaction.atomic():
+                    StudentTrainingWorkflowItem.objects.create(
+                        workflow=self,
+                        order_num=order_num,
+                        training_example=next_example
+                    )
             # If we get an integrity error, it means we've violated a uniqueness constraint
             # (someone has created this object after we checked if it existed)
             # Since the object already exists, we don't need to do anything

--- a/openassessment/assessment/serializers/training.py
+++ b/openassessment/assessment/serializers/training.py
@@ -181,9 +181,10 @@ def deserialize_training_examples(examples, rubric_dict):
                 example = TrainingExample.objects.get(content_hash=content_hash)
             except TrainingExample.DoesNotExist:
                 try:
-                    example = TrainingExample.create_example(
-                        example_dict['answer'], example_dict['options_selected'], rubric
-                    )
+                    with transaction.atomic():
+                        example = TrainingExample.create_example(
+                            example_dict['answer'], example_dict['options_selected'], rubric
+                        )
                 except IntegrityError:
                     example = TrainingExample.objects.get(content_hash=content_hash)
 

--- a/openassessment/assessment/test/test_student_training_api.py
+++ b/openassessment/assessment/test/test_student_training_api.py
@@ -103,7 +103,7 @@ class StudentTrainingAssessmentTest(CacheResetTest):
         # This will need to create the student training workflow and the first item
         # NOTE: we *could* cache the rubric model to reduce the number of queries here,
         # but we're selecting it by content hash, which is indexed and should be plenty fast.
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(8):
             training_api.get_training_example(self.submission_uuid, RUBRIC, EXAMPLES)
 
         # Without assessing the first training example, try to retrieve a training example.
@@ -117,7 +117,7 @@ class StudentTrainingAssessmentTest(CacheResetTest):
 
         # Retrieve the next training example, which requires us to create
         # a new workflow item (but not a new workflow).
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(8):
             training_api.get_training_example(self.submission_uuid, RUBRIC, EXAMPLES)
 
     def test_submitter_is_finished_num_queries(self):


### PR DESCRIPTION
@cahrens @efischer19 

This is a small fix that does not have any tests, but the acceptance tests do catch this error. I've verified them locally by running the acceptance tests against a sandbox that uses this branch.

Here's the relevant Django documentation page that explains why this fixes this: https://docs.djangoproject.com/en/1.8/topics/db/transactions/#controlling-transactions-explicitly

TNL-4342