### PR TITLE
[WIP] For running single acceptance test, add an optional argument that wil…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test-js-debug: render-templates
 test-sandbox: test-acceptance test-a11y
 
 test-acceptance:
-	./scripts/test-acceptance.sh tests
+	./scripts/test-acceptance.sh
 
 test-a11y:
 	./scripts/test-acceptance.sh accessibility

--- a/scripts/test-acceptance.sh
+++ b/scripts/test-acceptance.sh
@@ -12,7 +12,7 @@
 #
 #   Usage:
 #
-#       ./test-acceptance.sh {test_file}
+#       ./test-acceptance.sh {test}
 #
 ############################################################
 
@@ -32,6 +32,10 @@ mkdir -p test/logs
 cd test/logs
 
 test_name="${1:-acceptance}"
+
+if [[ -z ${test} ]]; then
+    export test="tests.py"
+fi
 
 
 # The machines that these tests run on in jenkins have an old
@@ -53,4 +57,4 @@ if [[ "${test_name}" = "accessibility" ]]; then
 fi
 
 echo "Running acceptance tests from ${test_name}.py against the sandbox..."
-nosetests ../acceptance/${test_name}.py --with-xunit --xunit-file=../acceptance/xunit-${test_name}.xml
+nosetests ../acceptance/${test} --with-xunit --xunit-file=../acceptance/xunit-${test_name}.xml


### PR DESCRIPTION
…l enable us to supply an argument if we want to just run one single test

Examples:
>  `make test-acceptance tests.py:FullWorkflowOverrideTest.test_staff_override_at_end`
_Runs test_staff_override_at_end test of FullWorkflowOverrideTest class_

>  `make test-acceptance tests.py:FullWorkflowOverrideTest`
_Runs tests for FullWorkflowOverrideTest class_

>  `make test-acceptance tests.py`
_Runs all tests in tests.py_

> `make test-acceptance`
_This would work as it was previously i.e run all the acceptance tests_