### PR TITLE
Set ORA display name by default

### DIFF
--- a/openassessment/templates/openassessmentblock/oa_base.html
+++ b/openassessment/templates/openassessmentblock/oa_base.html
@@ -3,7 +3,7 @@
 <div class="wrapper wrapper--xblock wrapper--openassessment theme--basic">
     <div class="openassessment problem" id="openassessment">
         <div class="wrapper--grid">
-            <h2 class="openassessment__title problem__header">{{ title }}</h2>
+            <h2 class="openassessment__title problem__header">{% trans title %}</h2>
 
             <div class="wrapper-openassessment__message">
                 {% block message %}

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -151,7 +151,7 @@ class OpenAssessmentBlock(
     )
 
     title = String(
-        default="",
+        default="Open Response Assessment",
         scope=Scope.content,
         help="A title to display to a student (plain text)."
     )

--- a/openassessment/xblock/test/test_studio.py
+++ b/openassessment/xblock/test/test_studio.py
@@ -111,6 +111,11 @@ class StudioViewTest(XBlockHandlerTestCase):
     }
 
     @scenario('data/basic_scenario.xml')
+    def test_default_fields(self, xblock):
+        # Default value should not be empty
+        self.assertEqual(xblock.fields['title'].default, "Open Response Assessment")
+
+    @scenario('data/basic_scenario.xml')
     def test_render_studio_view(self, xblock):
         frag = self.runtime.render(xblock, 'studio_view')
         self.assertTrue(frag.body_html().find('openassessment-edit'))


### PR DESCRIPTION
### Description
 
[TNL-4687](https://openedx.atlassian.net/browse/TNL-4687)

ORA display name should be set by default, instead of empty. I also added a unit test, and translated the display name in the template. I didn't translate the display name in openassessmentblock.py because it was strangely not being translated, and the quality test failed because the gettext import was unused.

### Sandbox
- [ ] https://studio-ssemenova.sandbox.edx.org/home/

### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit shows 0 violations
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @cahrens 
- [ ] Code review: @clrux 

FYI: @nedbat - could you look at the way the translation is done?

### Post-review
- [ ] Squash commits