### PR TITLE
Django version change

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,16 +3,16 @@
 -r wheels.txt
 
 # edX Internal Requirements
-git+https://github.com/edx/XBlock.git@xblock-0.4.10#egg=XBlock==0.4.10
+git+https://github.com/edx/XBlock.git@xblock-0.4.12#egg=XBlock==0.4.12
 
 # edx-submissions
-git+https://github.com/edx/edx-submissions.git@1.1.1#egg=edx-submissions==1.1.1
+git+https://github.com/edx/edx-submissions.git@1.1.2#egg=edx-submissions==1.1.2
 
 # Third Party Requirements
 boto>=2.32.1,<3.0.0
 celery==3.1.18
 defusedxml==0.4.1
-django==1.8.13
+django>=1.8.14,<1.9
 django-extensions==1.5.9
 django-model-utils==2.3.1
 djangorestframework>=3.1,<3.3


### PR DESCRIPTION
@macdiesel I began seeing this error on my devstack after rebasing on master, I suspect it's related to your work on https://github.com/edx/edx-platform/commit/7278102871b10b3681d492e369f3de3b9bf656a7.

Is this safe/a good idea to silence the warnings?

FYI @cahrens 

```
2016-07-20 12:09:51,550 WARNING 24908 [xblock.plugin] plugin.py:147 - Unable to load XBlock 'openassessment'
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/plugin.py", line 144, in load_classes
    yield (class_.name, cls._load_class_entry_point(class_))
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/plugin.py", line 73, in _load_class_entry_point
    class_ = entry_point.load()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2354, in load
    self.require(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2371, in require
    items = working_set.resolve(reqs, env, installer)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 844, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
VersionConflict: (Django 1.8.14 (/edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages), Requirement.parse('django==1.8.13'))
2016-07-20 12:09:52,022 WARNING 24908 [xblock.plugin] plugin.py:147 - Unable to load XBlock 'openassessment'
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/plugin.py", line 144, in load_classes
    yield (class_.name, cls._load_class_entry_point(class_))
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/plugin.py", line 73, in _load_class_entry_point
    class_ = entry_point.load()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2354, in load
    self.require(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2371, in require
    items = working_set.resolve(reqs, env, installer)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 844, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
VersionConflict: (Django 1.8.14 (/edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages), Requirement.parse('django==1.8.13'))
2016-07-20 12:09:52,112 WARNING 24908 [xblock.plugin] plugin.py:147 - Unable to load XBlock 'openassessment'
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/plugin.py", line 144, in load_classes
    yield (class_.name, cls._load_class_entry_point(class_))
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/plugin.py", line 73, in _load_class_entry_point
    class_ = entry_point.load()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2354, in load
    self.require(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2371, in require
    items = working_set.resolve(reqs, env, installer)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 844, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
VersionConflict: (Django 1.8.14 (/edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages), Requirement.parse('django==1.8.13'))
/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/require/helpers.py:4: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
  from django.utils.importlib import import_module
```