### PR TITLE
Use proper platform details in user facing string

### DIFF
--- a/openassessment/templates/openassessmentblock/oa_uploaded_file.html
+++ b/openassessment/templates/openassessmentblock/oa_uploaded_file.html
@@ -20,7 +20,7 @@
                 {% trans "View the file associated with this submission." %}
             </a>
             {% if show_warning %}
-                <p class="submission_file_warning">{% trans "(Caution: This file was uploaded by another course learner and has not been verified, screened, approved, reviewed, or endorsed by edX. If you decide to access it, you do so at your own risk.)" %}</p>
+                <p class="submission_file_warning">{% trans "(Caution: This file was uploaded by another course learner and has not been verified, screened, approved, reviewed, or endorsed by the site administrator. If you decide to access it, you do so at your own risk.)" %}</p>
             {% endif %}
         {% endif %}
     </div>


### PR DESCRIPTION
While reviewing translations, @ "Natalia Berdnikov" noticed that this string uses `edX`, which may not be correct for all openedx installations.

@nedbat @shaunagm Is there a standard way to refer to "the people running this instance" in code? @sstack22 and @catong may have suggestions as well.