### PR TITLE
Override submitter requirements on staff override assessment

### DIFF
--- a/openassessment/assessment/api/peer.py
+++ b/openassessment/assessment/api/peer.py
@@ -436,6 +436,8 @@ def get_assessment_median_scores(submission_uuid):
         assessments = [item.assessment for item in items]
         scores = Assessment.scores_by_criterion(assessments)
         return Assessment.get_median_score_dict(scores)
+    except PeerWorkflow.DoesNotExist:
+        return {}
     except DatabaseError:
         error_message = (
             u"Error getting assessment median scores for submission {uuid}"

--- a/openassessment/workflow/api.py
+++ b/openassessment/workflow/api.py
@@ -177,7 +177,7 @@ def get_workflow_for_submission(submission_uuid, assessment_requirements):
     return update_from_assessments(submission_uuid, assessment_requirements)
 
 
-def update_from_assessments(submission_uuid, assessment_requirements):
+def update_from_assessments(submission_uuid, assessment_requirements, override_submitter_requirements=False):
     """
     Update our workflow status based on the status of the underlying assessments.
 
@@ -259,7 +259,7 @@ def update_from_assessments(submission_uuid, assessment_requirements):
     workflow = _get_workflow_model(submission_uuid)
 
     try:
-        workflow.update_from_assessments(assessment_requirements)
+        workflow.update_from_assessments(assessment_requirements, override_submitter_requirements)
         logger.info((
             u"Updated workflow for submission UUID {uuid} "
             u"with requirements {reqs}"

--- a/openassessment/workflow/api.py
+++ b/openassessment/workflow/api.py
@@ -204,6 +204,9 @@ def update_from_assessments(submission_uuid, assessment_requirements, override_s
             `must_be_graded_by` to ensure that everyone will get scored.
             The intention is to eventually pass in more assessment sequence
             specific requirements in this dict.
+        override_submitter_requirements (bool): If True, the presence of a new
+            staff score will cause all of the submitter's requirements to be
+            fulfilled, moving the workflow to DONE and exposing their grade.
 
     Returns:
         dict: Assessment workflow information with the following

--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -297,6 +297,9 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
                 can refer to this to decide whether the requirements have been
                 met.  Note that the requirements could change if the author
                 updates the problem definition.
+            override_submitter_requirements (bool): If True, the presence of a new
+                staff score will cause all of the submitter's requirements to be
+                fulfilled, moving the workflow to DONE and exposing their grade.
 
         """
         if self.status == self.STATUS.cancelled:
@@ -326,9 +329,10 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
                 # Update the assessment_completed_at field for all steps
                 # All steps are considered "assessment complete", as the staff score will override all
                 for step in steps:
-                    step.assessment_completed_at = now()
+                    common_now = now()
+                    step.assessment_completed_at = common_now
                     if override_submitter_requirements:
-                        step.submitter_completed_at = now()
+                        step.submitter_completed_at = common_now
                     step.save()
 
         if self.status == self.STATUS.done:

--- a/openassessment/workflow/test/test_api.py
+++ b/openassessment/workflow/test/test_api.py
@@ -15,6 +15,7 @@ from openassessment.assessment.models import StudentTrainingWorkflow
 import submissions.api as sub_api
 from openassessment.assessment.api import peer as peer_api
 from openassessment.assessment.api import self as self_api
+from openassessment.assessment.api import staff as staff_api
 from openassessment.workflow.models import AssessmentWorkflow, AssessmentApiLoadError
 from openassessment.workflow.errors import AssessmentWorkflowInternalError
 
@@ -253,6 +254,39 @@ class TestAssessmentWorkflowApi(CacheResetTest):
         mock_create.side_effect = DatabaseError("Kaboom!")
         submission = sub_api.create_submission(ITEM_1, ANSWER_2)
         workflow_api.create_workflow(submission["uuid"], ["peer", "self"], ON_INIT_PARAMS)
+
+    @patch.object(staff_api, 'get_score')
+    @patch.object(PeerWorkflow.objects, 'get')
+    def test_no_peer_assessment_error_handled(self, mock_get_workflow, mock_get_staff_score):
+        """
+        Tests to verify that, given a problem that requires the peer step and a submission associated with a workflow
+        that has no assessments, an overriding staff score will push the workflow into the done state and not crash
+        when there are no assessments in the "completed" peer step.
+        """
+        mock_get_workflow.return_value = None
+        mock_get_staff_score.return_value = {
+            "points_earned": 10,
+            "points_possible": 10,
+            "contributing_assessments": 123,
+            "staff_id": "staff 1",
+        }
+        _, submission = self._create_workflow_with_status(
+            "user 1",
+            "test/1/1",
+            "peer-problem",
+            "peer",
+            steps=["peer"]
+        )
+        workflow_api.update_from_assessments(
+            submission["uuid"],
+            {
+                "peer": {
+                    "must_grade": 5,
+                    "must_be_graded_by": 3
+                }
+            },
+            override_submitter_requirements=True
+        )
 
     @patch.object(AssessmentWorkflow.objects, 'get')
     @ddt.file_data('data/assessments.json')

--- a/openassessment/workflow/test/test_api.py
+++ b/openassessment/workflow/test/test_api.py
@@ -3,7 +3,6 @@ from django.test.utils import override_settings
 import ddt
 from mock import patch
 from nose.tools import raises
-from openassessment.assessment.models import PeerWorkflow
 
 from openassessment.test_utils import CacheResetTest
 
@@ -11,7 +10,7 @@ from submissions.models import Submission
 import openassessment.workflow.api as workflow_api
 from openassessment.assessment.api import ai as ai_api
 from openassessment.assessment.errors import AIError
-from openassessment.assessment.models import StudentTrainingWorkflow
+from openassessment.assessment.models import PeerWorkflow, StudentTrainingWorkflow
 import submissions.api as sub_api
 from openassessment.assessment.api import peer as peer_api
 from openassessment.assessment.api import self as self_api
@@ -263,7 +262,7 @@ class TestAssessmentWorkflowApi(CacheResetTest):
         that has no assessments, an overriding staff score will push the workflow into the done state and not crash
         when there are no assessments in the "completed" peer step.
         """
-        mock_get_workflow.return_value = None
+        mock_get_workflow.raises = PeerWorkflow.DoesNotExist
         mock_get_staff_score.return_value = {
             "points_earned": 10,
             "points_possible": 10,

--- a/openassessment/xblock/grade_mixin.py
+++ b/openassessment/xblock/grade_mixin.py
@@ -567,15 +567,16 @@ class GradeMixin(object):
         # If criteria/options in the problem definition do NOT have a "label" field
         # (because they were created before this change),
         # we create a new label that has the same value as "name".
-        for part in assessment['parts']:
-            criterion_label_key = part['criterion']['name']
-            part['criterion']['label'] = criterion_labels.get(criterion_label_key, part['criterion']['name'])
+        if assessment is not None:
+            for part in assessment['parts']:
+                criterion_label_key = part['criterion']['name']
+                part['criterion']['label'] = criterion_labels.get(criterion_label_key, part['criterion']['name'])
 
-            # We need to be a little bit careful here: some assessment parts
-            # have only written feedback, so they're not associated with any options.
-            # If that's the case, we don't need to add the label field.
-            if part.get('option') is not None:
-                option_label_key = (part['criterion']['name'], part['option']['name'])
-                part['option']['label'] = option_labels.get(option_label_key, part['option']['name'])
+                # We need to be a little bit careful here: some assessment parts
+                # have only written feedback, so they're not associated with any options.
+                # If that's the case, we don't need to add the label field.
+                if part.get('option') is not None:
+                    option_label_key = (part['criterion']['name'], part['option']['name'])
+                    part['option']['label'] = option_labels.get(option_label_key, part['option']['name'])
 
         return assessment

--- a/openassessment/xblock/staff_assessment_mixin.py
+++ b/openassessment/xblock/staff_assessment_mixin.py
@@ -53,7 +53,11 @@ class StaffAssessmentMixin(object):
             )
             assess_type = data.get('assess_type', 'regrade')
             self.publish_assessment_event("openassessmentblock.staff_assess", assessment, type=assess_type)
-            workflow_api.update_from_assessments(assessment["submission_uuid"], None)
+            workflow_api.update_from_assessments(
+                assessment["submission_uuid"],
+                None,
+                override_submitter_requirements=(assess_type == 'regrade')
+            )
 
         except StaffAssessmentRequestError:
             logger.warning(

--- a/scripts/run-pep8.sh
+++ b/scripts/run-pep8.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-MAX_PEP8_VIOLATIONS=110
+MAX_PEP8_VIOLATIONS=111
 
 mkdir -p test/logs
 PEP8_VIOLATIONS=test/logs/pep8.txt
 touch $PEP8_VIOLATIONS
 
-pep8 --config=.pep8 openassessment > $PEP8_VIOLATIONS
+pep8 --config=.pep8 openassessment test > $PEP8_VIOLATIONS
 NUM_PEP8_VIOLATIONS=$(cat $PEP8_VIOLATIONS | wc -l)
 
 echo "Found" $NUM_PEP8_VIOLATIONS "pep8 violations, threshold is" $MAX_PEP8_VIOLATIONS

--- a/scripts/run-pylint.sh
+++ b/scripts/run-pylint.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-MAX_PYLINT_VIOLATIONS=519
+MAX_PYLINT_VIOLATIONS=504
 
 mkdir -p test/logs
 PYLINT_VIOLATIONS=test/logs/pylint.txt
 touch $PYLINT_VIOLATIONS
 
-pylint --rcfile=pylintrc openassessment --msg-template='"{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"'> $PYLINT_VIOLATIONS
+pylint --rcfile=pylintrc openassessment test --msg-template='"{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"'> $PYLINT_VIOLATIONS
 ./scripts/run-pylint.py $PYLINT_VIOLATIONS $MAX_PYLINT_VIOLATIONS

--- a/test/acceptance/tests.py
+++ b/test/acceptance/tests.py
@@ -1,6 +1,8 @@
 """
 UI-level acceptance tests for OpenAssessment.
 """
+from __future__ import absolute_import
+
 import ddt
 import os
 import unittest
@@ -342,6 +344,8 @@ class StaffAssessmentTest(OpenAssessmentTest):
 
         # Verify staff grade section appears as expected
         self._verify_staff_grade_section("NOT AVAILABLE")
+        message_title = self.staff_asmnt_page.open_step().message_title
+        self.assertEqual("Waiting for a Staff Grade", message_title)
 
         # Perform staff assessment
         self.staff_area_page = StaffAreaPage(self.browser, self.problem_loc)
@@ -532,14 +536,8 @@ class StaffAreaTest(OpenAssessmentTest):
         self.assertEqual(self.staff_area_page.visible_staff_panels, [])
 
         for panel_name, button_label in [
-                (
-                    "staff-tools",
-                    "MANAGE INDIVIDUAL LEARNERS"
-                ),
-                (
-                    "staff-info",
-                    "VIEW ASSIGNMENT STATISTICS"
-                ),
+                ("staff-tools", "MANAGE INDIVIDUAL LEARNERS"),
+                ("staff-info", "VIEW ASSIGNMENT STATISTICS"),
         ]:
             # Click on the button and verify that the panel has opened
             self.staff_area_page.click_staff_toolbar_button(panel_name)

--- a/test/acceptance/tests.py
+++ b/test/acceptance/tests.py
@@ -445,6 +445,8 @@ class StaffOverrideSelfTest(StaffOverrideTest):
         super(StaffOverrideSelfTest, self).__init__(*args, **kwargs)
         self.problem_type = 'self_only'
 
+    @retry()
+    @attr('acceptance')
     def test_staff_override(self):
         super(StaffOverrideSelfTest, self)._test_staff_override()
 
@@ -457,6 +459,8 @@ class StaffOverridePeerTest(StaffOverrideTest):
         super(StaffOverridePeerTest, self).__init__(*args, **kwargs)
         self.problem_type = 'peer_only'
 
+    @retry()
+    @attr('acceptance')
     def test_staff_override(self):
         super(StaffOverridePeerTest, self)._test_staff_override()
 


### PR DESCRIPTION
## [TNL-4696](https://openedx.atlassian.net/browse/TNL-4696)

When a staff override assessment is recorded, we now treat all the submitter's
requirements as being fulfilled. This allows ORA tooling to match the progress
page reported grade for the student by placing the AssessmentWorkflow into a
DONE state.