### PR TITLE
Fix broken/flaky sandbox tests

### DIFF
--- a/test/acceptance/accessibility.py
+++ b/test/acceptance/accessibility.py
@@ -160,7 +160,7 @@ class StaffAreaA11yTest(OpenAssessmentA11yTest):
 
         # Refresh the page, then verify accessibility of the Staff Grade section (marked Complete).
         self.browser.refresh()
-        self._verify_staff_grade_section(self.STAFF_GRADE_EXISTS, None)
+        self._verify_staff_grade_section(self.STAFF_GRADE_EXISTS)
 
         self._check_a11y(self.staff_asmnt_page)
 

--- a/test/acceptance/tests.py
+++ b/test/acceptance/tests.py
@@ -427,7 +427,7 @@ class StaffOverrideTest(OpenAssessmentTest):
         self.assertFalse(self.staff_asmnt_page.is_browser_on_page())
 
         # Submit a staff override.
-        self.do_staff_override(username, self.STAFF_OVERRIDE_STAFF_AREA_NOT_COMPLETE)
+        self.do_staff_override(username)
 
         # Refresh the page so the learner sees the Staff Grade section.
         self.refresh_page()
@@ -1045,7 +1045,7 @@ class FullWorkflowOverrideTest(OpenAssessmentTest, FullWorkflowMixin):
         self.staff_area_page.verify_learner_final_score(self.STAFF_OVERRIDE_STAFF_AREA_NOT_COMPLETE)
 
         # Do staff override
-        self.do_staff_override(learner, self.STAFF_OVERRIDE_STAFF_AREA_NOT_COMPLETE)
+        self.do_staff_override(learner)
 
         # Refresh the page so the learner sees the Staff Grade section.
         self.refresh_page()


### PR DESCRIPTION
These tests were broken on master as part of my latest PR.

- a11y tests were not updated, breaking a usage of the common `_verify_staff_grade_section` method.
- `verify_learner_final_score` runs ~~too quickly~~ differently on jenkins, ~~and needs a wait to succeed there~~ revealing some test method calls that were never properly updated to use a new default parameter. These should not have been passing locally

I'm going to have jenkins use this branch to run the tests; once they pass I'll go about updating the 1.1.9 release tag.