### PR TITLE
Update bok choy and selenium versions

### DIFF
--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -1,4 +1,5 @@
-bok-choy==0.4.10
+bok-choy==0.5.3
 ddt==1.0.0
 nose==1.3.7
 pyinstrument==0.13.1
+selenium==2.53.1


### PR DESCRIPTION
Pin the versions of `bok-choy` and `selenium` used in this project to be the versions specified by [edx-platform](https://github.com/edx/edx-platform/blob/master/requirements/edx/base.txt#L171).

This had been causing issues on my fresh devstack, as `selenium==3.0.1` was installed by default. Now, after a `pip install -r requirements/test-acceptance.txt`, I am able to run acceptance tests locally against the sandbox.

@jzoldak @cahrens to review when they have a chance.

## [TE-1824](https://openedx.atlassian.net/browse/TE-1824)