### PR TITLE
Link tip to input fields.

### DIFF
--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -70,6 +70,7 @@
                                     <textarea
                                         id="submission__answer__part__text__{{ forloop.counter }}__{{ xblock_id }}"
                                         class="submission__answer__part__text__value"
+                                        aria-describedby="submission__answer__tip__{{ xblock_id }}"
                                         placeholder="{% trans "Enter your response to the question above." %}"
                                         maxlength="100000"
                                     >{{ part.text }}</textarea>
@@ -93,7 +94,7 @@
                         {% include "openassessmentblock/oa_uploaded_file.html" with file_upload_type=file_upload_type file_url=file_url class_prefix="submission__answer"%}
                     </ol>
 
-                    <span class="tip">{% trans "You may continue to work on your response until you submit it." %}</span>
+                    <span class="tip" id="submission__answer__tip__{{ xblock_id }}">{% trans "You may continue to work on your response until you submit it." %}</span>
 
                     <div class="response__submission__actions">
                         <div class="message message--inline message--error message--error-server" tabindex="-1">


### PR DESCRIPTION
[TNL-5195](https://openedx.atlassian.net/browse/TNL-5195)

Links "You may continue to work on your response until you submit it" tip to input field(s).

@cptvitamin can you take a quick look and verify this is what you wanted? Here is an ORA problem with 2 different input fields for the question. They are both linked to the "tip" text via aria-describedby.

https://tip.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/2?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40a5817b2473a040d1a6cb4f32d169d864