### PR TITLE
Enable the preview button if the submit button is enabled.

### DIFF
--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -115,7 +115,8 @@
                             </li>
                             {% if allow_latex %}
                                 <li class="list--actions__item">
-                                    <button type="submit" class="submission__preview  action action--save" aria-describedby="response__preview_explanation__{{ xblock_id }}">
+                                    <button type="submit" class="submission__preview  action action--save" aria-describedby="response__preview_explanation__{{ xblock_id }}"
+                                        {{submit_enabled|yesno:",disabled" }}>
                                         {% trans "Preview in LaTeX"%}
                                     </button>
                                     <div id="response__preview_explanation__{{ xblock_id }}" class="response__submission__label">

--- a/test/acceptance/pages.py
+++ b/test/acceptance/pages.py
@@ -85,7 +85,7 @@ class OpenAssessmentPage(BaseAssessmentPage):
         """
         submit_button_selector = self._bounded_selector(button_css)
         EmptyPromise(
-            lambda: 'is--disabled' not in " ".join(self.q(css=submit_button_selector).attrs('class')),
+            lambda: False == any(self.q(css=submit_button_selector).attrs('disabled')),
             "Submit button is enabled."
         ).fulfill()
 
@@ -165,8 +165,7 @@ class SubmissionPage(OpenAssessmentPage):
         Returns:
             bool
         """
-        preview_latex_button_class = self.q(css="button.submission__preview").attrs('class')[0]
-        return 'is--disabled' in preview_latex_button_class
+        return self.q(css="button.submission__preview").attrs('disabled') == ['true']
 
     @property
     def has_submitted(self):


### PR DESCRIPTION
Really, the preview button should be enabled whenever there
is something to render. Since the submit button will only be
disabled upon initial rendering if there is nothing to submit,
it seems like a reasonable proxy.

@andy-armstrong and @staubina can you please review? The code is on https://tip.sandbox.edx.org/courses/course-v1:edx+ORA203+course/courseware/a4dfec19cf9b4a6fb5b18be6ccd9cecc/338a4affb58a45459629e0566291381e/ (link to a problem with LaTeX preview enabled).

I have run both acceptance and a11y tests with these changes, and they all passed.