### PR TITLE
Updated requirements to ranges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,5 @@ before_script:
 script:
   - "make test"
   - "python manage.py makemessages -l eo"
-branches:
-    only:
-      - master
-      - ora-staff-grading
 after_success:
   coveralls

--- a/openassessment/assessment/test/test_assessment_models.py
+++ b/openassessment/assessment/test/test_assessment_models.py
@@ -152,7 +152,7 @@ class AssessmentTest(CacheResetTest):
         return rubric_from_dict(rubric_dict)
 
     @ddt.file_data('data/models_check_criteria_assessed.json')
-    def test_check_all_criteria_assessed(self, data):
+    def test_check_all_criteria_assessed(self, **data):
         student_item = {
             'student_id': u'𝖙𝖊𝖘𝖙 𝖚𝖘𝖊𝖗',
             'item_id': 'test_item',

--- a/openassessment/assessment/test/test_peer.py
+++ b/openassessment/assessment/test/test_peer.py
@@ -309,7 +309,7 @@ class TestPeerApi(CacheResetTest):
             self.assertEqual(len(part.feedback), Assessment.MAX_FEEDBACK_SIZE)
 
     @file_data('data/valid_assessments.json')
-    def test_get_assessments(self, assessment_dict):
+    def test_get_assessments(self, **assessment_dict):
         self._create_student_and_submission("Tim", "Tim's answer")
         bob_sub, bob = self._create_student_and_submission("Bob", "Bob's answer")
         sub = peer_api.get_submission_to_assess(bob_sub['uuid'], 3)
@@ -326,7 +326,7 @@ class TestPeerApi(CacheResetTest):
         self.assertEqual(1, len(assessments))
 
     @file_data('data/valid_assessments.json')
-    def test_get_assessments_with_date(self, assessment_dict):
+    def test_get_assessments_with_date(self, **assessment_dict):
         self._create_student_and_submission("Tim", "Tim's answer")
         bob_sub, bob = self._create_student_and_submission("Bob", "Bob's answer")
         sub = peer_api.get_submission_to_assess(bob_sub['uuid'], 3)

--- a/openassessment/assessment/test/test_staff.py
+++ b/openassessment/assessment/test/test_staff.py
@@ -6,8 +6,7 @@ from datetime import timedelta
 from django.db import DatabaseError
 from django.test.utils import override_settings
 from django.utils.timezone import now
-from ddt import ddt, data, file_data, unpack
-from nose.tools import raises
+from ddt import ddt, data, unpack
 
 from .constants import OPTIONS_SELECTED_DICT, RUBRIC, RUBRIC_OPTIONS, RUBRIC_POSSIBLE_POINTS, STUDENT_ITEM
 from openassessment.assessment.test.test_ai import (
@@ -20,7 +19,7 @@ from openassessment.test_utils import CacheResetTest
 from openassessment.assessment.api import staff as staff_api, ai as ai_api, peer as peer_api
 from openassessment.assessment.api.self import create_assessment as self_assess
 from openassessment.assessment.api.peer import create_assessment as peer_assess
-from openassessment.assessment.models import Assessment, PeerWorkflow, StaffWorkflow
+from openassessment.assessment.models import Assessment, StaffWorkflow
 from openassessment.assessment.errors import StaffAssessmentRequestError, StaffAssessmentInternalError
 from openassessment.workflow import api as workflow_api
 from submissions import api as sub_api

--- a/openassessment/assessment/test/test_student_training_api.py
+++ b/openassessment/assessment/test/test_student_training_api.py
@@ -148,7 +148,7 @@ class StudentTrainingAssessmentTest(CacheResetTest):
             training_api.assess_training_example(self.submission_uuid, EXAMPLES[0]['options_selected'])
 
     @ddt.file_data('data/validate_training_examples.json')
-    def test_validate_training_examples(self, data):
+    def test_validate_training_examples(self, **data):
         errors = training_api.validate_training_examples(
             data['rubric'], data['examples']
         )

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -97,7 +97,7 @@ class CsvWriterTest(TransactionCacheResetTest):
     maxDiff = None
 
     @ddt.file_data('data/write_to_csv.json')
-    def test_write_to_csv(self, data):
+    def test_write_to_csv(self, **data):
         # Create in-memory buffers for the CSV file data
         output_streams = self._output_streams(data['expected_csv'].keys())
 

--- a/openassessment/xblock/test/test_grade.py
+++ b/openassessment/xblock/test/test_grade.py
@@ -381,7 +381,7 @@ class TestGrade(XBlockHandlerTestCase, SubmitAssessmentsMixin):
 
     @ddt.file_data('data/waiting_scenarios.json')
     @scenario('data/grade_waiting_scenario.xml', user_id='Omar')
-    def test_grade_waiting(self, xblock, data):
+    def test_grade_waiting(self, xblock, **data):
         # If AI classifiers are not trained, then we should see a "waiting for AI" display
         if not data["waiting_for_ai"]:
             with mock.patch.object(

--- a/openassessment/xblock/test/test_resolve_dates.py
+++ b/openassessment/xblock/test/test_resolve_dates.py
@@ -31,7 +31,7 @@ class ResolveDatesTest(TestCase):
         self.DATE_STRINGS[None] = None
 
     @ddt.file_data('data/resolve_dates.json')
-    def test_resolve_dates(self, data):
+    def test_resolve_dates(self, **data):
 
         # Test data provides indices into our date dictionaries
         resolved_start, resolved_end, resolved_ranges = resolve_dates(

--- a/openassessment/xblock/test/test_student_training.py
+++ b/openassessment/xblock/test/test_student_training.py
@@ -64,7 +64,7 @@ class StudentTrainingAssessTest(StudentTrainingTest):
 
     @scenario('data/student_training.xml', user_id="Plato")
     @ddt.file_data('data/student_training_mixin.json')
-    def test_correct(self, xblock, data):
+    def test_correct(self, xblock, **data):
         xblock.create_submission(xblock.get_student_item_dict(), self.SUBMISSION)
         data["expected_context"]['time_zone'] = pytz.utc
         self.assert_path_and_context(xblock, data["expected_template"], data["expected_context"])
@@ -85,7 +85,7 @@ class StudentTrainingAssessTest(StudentTrainingTest):
 
     @scenario('data/student_training.xml', user_id="Plato")
     @ddt.file_data('data/student_training_mixin.json')
-    def test_correct_with_error(self, xblock, data):
+    def test_correct_with_error(self, xblock, **data):
         xblock.create_submission(xblock.get_student_item_dict(), self.SUBMISSION)
         data["expected_context"]['time_zone'] = pytz.utc
         self.assert_path_and_context(xblock, data["expected_template"], data["expected_context"])
@@ -109,7 +109,7 @@ class StudentTrainingAssessTest(StudentTrainingTest):
 
     @scenario('data/student_training.xml', user_id="Plato")
     @ddt.file_data('data/student_training_mixin.json')
-    def test_incorrect(self, xblock, data):
+    def test_incorrect(self, xblock, **data):
         xblock.create_submission(xblock.get_student_item_dict(), self.SUBMISSION)
         data["expected_context"]['time_zone'] = pytz.utc
         self.assert_path_and_context(xblock, data["expected_template"], data["expected_context"])
@@ -130,7 +130,7 @@ class StudentTrainingAssessTest(StudentTrainingTest):
 
     @scenario('data/student_training.xml', user_id="Plato")
     @ddt.file_data('data/student_training_mixin.json')
-    def test_updates_workflow(self, xblock, data):
+    def test_updates_workflow(self, xblock, **data):
         expected_context = data["expected_context"].copy()
         expected_template = data["expected_template"]
         xblock.create_submission(xblock.get_student_item_dict(), self.SUBMISSION)
@@ -209,7 +209,7 @@ class StudentTrainingAssessTest(StudentTrainingTest):
 
     @scenario('data/student_training.xml', user_id="Plato")
     @ddt.file_data('data/student_training_mixin.json')
-    def test_request_error(self, xblock, data):
+    def test_request_error(self, xblock, **data):
         xblock.create_submission(xblock.get_student_item_dict(), self.SUBMISSION)
         expected_context = data["expected_context"].copy()
         expected_template = data["expected_template"]
@@ -226,7 +226,7 @@ class StudentTrainingAssessTest(StudentTrainingTest):
 
     @scenario('data/student_training.xml', user_id="Plato")
     @ddt.file_data('data/student_training_mixin.json')
-    def test_invalid_options_dict(self, xblock, data):
+    def test_invalid_options_dict(self, xblock, **data):
         xblock.create_submission(xblock.get_student_item_dict(), self.SUBMISSION)
         expected_context = data["expected_context"].copy()
         expected_template = data["expected_template"]

--- a/openassessment/xblock/test/test_studio.py
+++ b/openassessment/xblock/test/test_studio.py
@@ -132,7 +132,7 @@ class StudioViewTest(XBlockHandlerTestCase):
 
     @file_data('data/update_xblock.json')
     @scenario('data/basic_scenario.xml')
-    def test_update_editor_context(self, xblock, data):
+    def test_update_editor_context(self, xblock, **data):
         xblock.runtime.modulestore = MagicMock()
         xblock.runtime.modulestore.has_published_version.return_value = False
         resp = self.request(xblock, 'update_editor_context', json.dumps(data), response_format='json')
@@ -192,7 +192,7 @@ class StudioViewTest(XBlockHandlerTestCase):
 
     @file_data('data/invalid_update_xblock.json')
     @scenario('data/basic_scenario.xml')
-    def test_update_context_invalid_request_data(self, xblock, data):
+    def test_update_context_invalid_request_data(self, xblock, **data):
         # All schema validation errors have the same error message, so use that as the default
         # Remove the expected error from the dictionary so we don't get an unexpected key error.
         if 'expected_error' in data:
@@ -208,7 +208,7 @@ class StudioViewTest(XBlockHandlerTestCase):
 
     @file_data('data/invalid_rubric.json')
     @scenario('data/basic_scenario.xml')
-    def test_update_rubric_invalid(self, xblock, data):
+    def test_update_rubric_invalid(self, xblock, **data):
         request = json.dumps(data)
 
         # Store old XBlock fields for later verification

--- a/openassessment/xblock/test/test_validation.py
+++ b/openassessment/xblock/test/test_validation.py
@@ -22,7 +22,7 @@ STUB_I18N = lambda x: x
 class AssessmentValidationTest(TestCase):
 
     @ddt.file_data('data/valid_assessments.json')
-    def test_valid_assessment(self, data):
+    def test_valid_assessment(self, **data):
         success, msg = validate_assessments(
             data["assessments"], data["current_assessments"], data["is_released"], STUB_I18N
         )
@@ -30,7 +30,7 @@ class AssessmentValidationTest(TestCase):
         self.assertEqual(msg, u'')
 
     @ddt.file_data('data/invalid_assessments.json')
-    def test_invalid_assessment(self, data):
+    def test_invalid_assessment(self, **data):
         success, msg = validate_assessments(
             data["assessments"], data["current_assessments"], data["is_released"], STUB_I18N
         )
@@ -44,14 +44,14 @@ class AssessmentValidationTest(TestCase):
 
     # Make sure only legal assessment combinations are allowed.
     @ddt.file_data('data/assessment_combo.json')
-    def test_enforce_assessment_combo_restrictions(self, data):
+    def test_enforce_assessment_combo_restrictions(self, **data):
         self._assert_validation(
             data["assessments"], data["current_assessments"],
             data["is_released"], data['valid']
         )
 
     @ddt.file_data('data/student_training_combo.json')
-    def test_student_training_combos(self, data):
+    def test_student_training_combos(self, **data):
         self._assert_validation(
             data["assessments"], data["current_assessments"],
             data["is_released"], data['valid']
@@ -86,7 +86,7 @@ class AssessmentValidationTest(TestCase):
 class RubricValidationTest(TestCase):
 
     @ddt.file_data('data/valid_rubrics.json')
-    def test_valid_rubric(self, data):
+    def test_valid_rubric(self, **data):
         current_rubric = data.get('current_rubric')
         is_released = data.get('is_released', False)
         is_example_based = data.get('is_example_based', False)
@@ -101,7 +101,7 @@ class RubricValidationTest(TestCase):
         self.assertEqual(msg, u'')
 
     @ddt.file_data('data/invalid_rubrics.json')
-    def test_invalid_rubric(self, data):
+    def test_invalid_rubric(self, **data):
         current_rubric = data.get('current_rubric')
         is_released = data.get('is_released', False)
         is_example_based = data.get('is_example_based', False)
@@ -116,13 +116,13 @@ class RubricValidationTest(TestCase):
 class AssessmentExamplesValidationTest(TestCase):
 
     @ddt.file_data('data/valid_assessment_examples.json')
-    def test_valid_assessment_examples(self, data):
+    def test_valid_assessment_examples(self, **data):
         success, msg = validate_assessment_examples(data['rubric'], data['assessments'], STUB_I18N)
         self.assertTrue(success)
         self.assertEqual(msg, u'')
 
     @ddt.file_data('data/invalid_assessment_examples.json')
-    def test_invalid_assessment_examples(self, data):
+    def test_invalid_assessment_examples(self, **data):
         success, msg = validate_assessment_examples(data['rubric'], data['assessments'], STUB_I18N)
         self.assertFalse(success)
         self.assertGreater(len(msg), 0)
@@ -148,7 +148,7 @@ class DateValidationTest(TestCase):
     # from the LMS, thus bypassing our validation rules.
     # See the docstring for `resolve_dates` for a more detailed justification.
     @ddt.file_data('data/valid_dates.json')
-    def test_valid_dates(self, data):
+    def test_valid_dates(self, **data):
 
         # Input data dict specifies the index for each date
         date = lambda key: self.DATES[data[key]]
@@ -170,7 +170,7 @@ class DateValidationTest(TestCase):
         self.assertEqual(msg, u'')
 
     @ddt.file_data('data/invalid_dates.json')
-    def test_invalid_dates(self, data):
+    def test_invalid_dates(self, **data):
         # Input data dict specifies the index for each date
         date = lambda key: self.DATES[data[key]]
 

--- a/openassessment/xblock/test/test_xml.py
+++ b/openassessment/xblock/test/test_xml.py
@@ -132,7 +132,7 @@ class TestSerializeContent(TestCase):
         self.oa_block.leaderboard_show = data.get('leaderboard_show', 0)
 
     @ddt.file_data('data/serialize.json')
-    def test_serialize(self, data):
+    def test_serialize(self, **data):
         self._configure_xblock(data)
         xml = serialize_content(self.oa_block)
 
@@ -176,7 +176,7 @@ class TestSerializeContent(TestCase):
             )
 
     @ddt.file_data('data/serialize.json')
-    def test_serialize_rubric(self, data):
+    def test_serialize_rubric(self, **data):
         self._configure_xblock(data)
         xml_str = serialize_rubric_to_xml_str(self.oa_block)
         self.assertIn("<rubric>", xml_str)
@@ -184,7 +184,7 @@ class TestSerializeContent(TestCase):
             self.assertNotIn(data['prompt'], xml_str)
 
     @ddt.file_data('data/serialize.json')
-    def test_serialize_examples(self, data):
+    def test_serialize_examples(self, **data):
         self._configure_xblock(data)
         for assessment in data['assessments']:
             if 'student-training' == assessment['name'] and assessment['examples']:
@@ -193,7 +193,7 @@ class TestSerializeContent(TestCase):
                     self.assertIn(part['text'], xml_str)
 
     @ddt.file_data('data/serialize.json')
-    def test_serialize_assessments(self, data):
+    def test_serialize_assessments(self, **data):
         self._configure_xblock(data)
         xml_str = serialize_assessments_to_xml_str(self.oa_block)
         self.assertIn(data['assessments'][0]['name'], xml_str)
@@ -440,7 +440,7 @@ class TestSerializeContent(TestCase):
 class TestParsePromptsFromXml(TestCase):
 
     @ddt.file_data("data/parse_prompts_xml.json")
-    def test_parse_prompts_from_xml(self, data):
+    def test_parse_prompts_from_xml(self, **data):
         xml = etree.fromstring("".join(data['xml']))
         prompts = _parse_prompts_xml(xml)
 
@@ -451,7 +451,7 @@ class TestParsePromptsFromXml(TestCase):
 class TestParseRubricFromXml(TestCase):
 
     @ddt.file_data("data/parse_rubric_xml.json")
-    def test_parse_rubric_from_xml(self, data):
+    def test_parse_rubric_from_xml(self, **data):
         xml = etree.fromstring("".join(data['xml']))
         rubric = parse_rubric_xml(xml)
 
@@ -463,7 +463,7 @@ class TestParseRubricFromXml(TestCase):
 class TestParseExamplesFromXml(TestCase):
 
     @ddt.file_data("data/parse_examples_xml.json")
-    def test_parse_examples_from_xml(self, data):
+    def test_parse_examples_from_xml(self, **data):
         xml = etree.fromstring("".join(data['xml']))
         examples = parse_examples_xml(xml)
         self.assertEqual(examples, data['examples'])
@@ -473,7 +473,7 @@ class TestParseExamplesFromXml(TestCase):
 class TestParseAssessmentsFromXml(TestCase):
 
     @ddt.file_data("data/parse_assessments_xml.json")
-    def test_parse_assessments_from_xml(self, data):
+    def test_parse_assessments_from_xml(self, **data):
         xml = etree.fromstring("".join(data['xml']))
         assessments = parse_assessments_xml(xml)
         self.assertEqual(assessments, data['assessments'])
@@ -487,7 +487,7 @@ class TestParseFromXml(TestCase):
     maxDiff = None
 
     @ddt.file_data('data/update_from_xml.json')
-    def test_parse_from_xml(self, data):
+    def test_parse_from_xml(self, **data):
 
         # Update the block based on the fixture XML definition
         config = parse_from_xml_str("".join(data['xml']))
@@ -525,6 +525,6 @@ class TestParseFromXml(TestCase):
                 )
 
     @ddt.file_data('data/update_from_xml_error.json')
-    def test_parse_from_xml_error(self, data):
+    def test_parse_from_xml_error(self, **data):
         with self.assertRaises(UpdateFromXmlError):
             parse_from_xml_str("".join(data['xml']))

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,21 +10,21 @@ git+https://github.com/edx/edx-submissions.git@1.1.2#egg=edx-submissions==1.1.2
 
 # Third Party Requirements
 boto>=2.32.1,<3.0.0
-celery==3.1.18
-defusedxml==0.4.1
+celery>=3.1.18,<4.0.0
+defusedxml>=0.4.1,<1.0.0
 django>=1.8.14,<1.9
-django-extensions==1.5.9
-django-model-utils==2.3.1
-djangorestframework>=3.1,<3.3
-dogapi==1.2.1
-jsonfield==1.0.3
-lazy==1.1
-libsass==0.10.0
-loremipsum==1.0.5
-python-dateutil==2.1
-python-memcached==1.48
-pytz==2015.2
-voluptuous==0.8.5
+django-extensions>=1.5.9,<2.0.0
+django-model-utils>=2.3.1,<3.0.0
+djangorestframework>=3.1
+dogapi>=1.2.1,<2.0.0
+jsonfield>=1.0.3,<2.0.0
+lazy>=1.1
+libsass>=0.10.0,<1.0.0
+loremipsum>=1.0.5,<2.0.0
+python-dateutil>=2.1
+python-memcached>=1.48
+pytz>=2015.2
+voluptuous>=0.8.5,<1.0.0
 
 # AI grading
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -1,5 +1,5 @@
-bok-choy==0.5.3
-ddt==1.0.0
-nose==1.3.7
-pyinstrument==0.13.1
-selenium==2.53.1
+bok-choy>=0.5.3,<1.0.0
+ddt>=1.0.0,<2.0.0
+nose>=1.3.7,<2.0.0
+pyinstrument>=0.13.1,<1.0.0
+selenium>=2.53.1,<3.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,14 +1,16 @@
 -r base.txt
 -r test-acceptance.txt
 
-coverage==4.0.2
+coverage>=4.0.2,<5.0.0
+# We are stuck with this version until our dependent libraries are updated to use a dependency range.
+# Use pipdeptree to identify conflicting dependencies
 django-nose==1.4.1
-freezegun==0.1.11
-mock==1.0.1
-moto==0.3.1
-pep8==1.7.0
-factory_boy==2.6.1
+edx-i18n-tools>=0.3.4,<1.0.0
+edx-lint>=0.5.1,<1.0.0
+freezegun>=0.1.11,<1.0.0
+mock>=1.0.1,<2.0.0
+moto>=0.3.1,<1.0.0
+pep8>=1.7.0,<2.0.0
+factory_boy>=2.6.1,<3.0.0
 
 git+https://github.com/edx/django-pyfs.git@1.0.3#egg=django-pyfs==1.0.3
-git+https://github.com/edx/i18n-tools.git@56f048af9b6868613c14aeae760548834c495011#egg=i18n_tools
-git+https://github.com/edx/edx-lint.git@v0.4.1#egg=edx_lint==0.4.1

--- a/requirements/wheels.txt
+++ b/requirements/wheels.txt
@@ -2,7 +2,7 @@
 # To speed up the test builds, we create binary "wheel" archives.
 # http://pip.readthedocs.org/en/latest/reference/pip_wheel.html
 
-lxml==3.4.4
-numpy==1.6.2
-scikit-learn==0.12.1
-scipy==0.14.0
+lxml>=3.4.4,<4.0.0
+numpy>=1.6.2,<2.0.0
+scikit-learn>=0.12.1,<1.0.0
+scipy>=0.14.0,<1.0.0


### PR DESCRIPTION
If we are going to read setup.py requirements from files, the files need to use ranges. Otherwise, we will end up with requirement conflicts when the main project wants to upgrade requirements.