### PR TITLE
Unpin pytz version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ libsass==0.10.0
 loremipsum==1.0.5
 python-dateutil==2.1
 python-memcached==1.48
-pytz==2015.2
+pytz
 voluptuous==0.8.5
 
 # AI grading


### PR DESCRIPTION
## [TNL-5813](https://openedx.atlassian.net/browse/TNL-5813)

### Description

This unpins the pytz version, to allow it to update freely, as Uruguay is not (as of Summer 2016-2017) recognizing DST. This is on a year-by-year basis, and will take it out of conflict with the needed version for edx-platform.
 
### Testing
- [x] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 

### Post-review
- [x] Rebase and squash commits

 (TNL-5813) 