### PR TITLE
1.1.11 version bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='1.1.10',
+    version='1.1.11',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
@yro broke it!

The code in https://github.com/edx/edx-ora2/pull/948 was included in the new `1.1.11` release tag, but the actual version in setup.py was never bumped, causing my devstack installation of edx-platform to get hella confused and overwrite my perfectly good locally edited code with the `1.1.11` tagged code from github.

FYI @cahrens @staubina I'm planning to merge this quickly and get the release tag fixed, can you thumb this when you see it?