### PR TITLE
Allow cancellation of buggy workflow

### DIFF
--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -19,7 +19,7 @@ from django.utils.timezone import now
 from model_utils import Choices
 from model_utils.models import StatusModel, TimeStampedModel
 from submissions import api as sub_api
-from openassessment.assessment.base import AssessmentError
+from openassessment.assessment.errors.base import AssessmentError
 from openassessment.assessment.signals import assessment_complete_signal
 from .errors import AssessmentApiLoadError, AssessmentWorkflowError, AssessmentWorkflowInternalError
 

--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -19,6 +19,7 @@ from django.utils.timezone import now
 from model_utils import Choices
 from model_utils.models import StatusModel, TimeStampedModel
 from submissions import api as sub_api
+from openassessment.assessment.base import AssessmentError
 from openassessment.assessment.signals import assessment_complete_signal
 from .errors import AssessmentApiLoadError, AssessmentWorkflowError, AssessmentWorkflowInternalError
 
@@ -507,7 +508,11 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
             if on_cancel_func is not None:
                 on_cancel_func(self.submission_uuid)
 
-        score = self.get_score(assessment_requirements, step_for_name)
+        try:
+            score = self.get_score(assessment_requirements, step_for_name)
+        except AssessmentError as exc:
+            logger.info("TNL-5799, exception in get_score during cancellation. {}".format(exc))
+            score = None
 
         # Set the points_earned to 0.
         if score is not None:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,7 +7,7 @@ freezegun==0.1.11
 mock==1.0.1
 moto==0.3.1
 pep8==1.7.0
-factory_boy==2.6.1
+factory_boy==2.8.1
 
 git+https://github.com/edx/django-pyfs.git@1.0.3#egg=django-pyfs==1.0.3
 git+https://github.com/edx/i18n-tools.git@56f048af9b6868613c14aeae760548834c495011#egg=i18n_tools


### PR DESCRIPTION
From https://openedx.atlassian.net/browse/TNL-6093 and https://splunk.edx.org/en-US/app/search/search?sid=1481833446.2325572, it's possible to run into errors that prevent delete student state. Stack trace:
```
Dec 15 18:59:22 ip-10-4-11-15 [service_variant=lms][django.request][env:prod-edge-edxapp] ERROR [ip-10-4-11-15  1730] [base.py:256] - Internal Server Error: /courses/course-v1:MITx+uINOV8x+4T2016/instructor/api/reset_student_attempts
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic-2.74.0.54/newrelic/hooks/framework_django.py", line 503, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/views/decorators/http.py", line 45, in inner
    return func(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 110, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/views/decorators/cache.py", line 43, in _cache_controlled
    response = viewfunc(request, *args, **kw)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor/views/api.py", line 202, in wrapped
    return func(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor/views/api.py", line 175, in wrapped
    return func(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor/views/api.py", line 126, in wrapped
    return func(request, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor/views/api.py", line 1975, in reset_student_attempts
    delete_module=delete_module
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor/enrollment.py", line 254, in reset_student_attempts
    requesting_user_id=requesting_user_id
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/openassessment/xblock/staff_area_mixin.py", line 514, in clear_student_state
    self._cancel_workflow(sub['uuid'], "Student state cleared", requesting_user_id=requesting_user_id)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/openassessment/xblock/staff_area_mixin.py", line 567, in _cancel_workflow
    assessment_requirements=assessment_requirements
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/openassessment/workflow/api.py", line 397, in cancel_workflow
    AssessmentWorkflow.cancel_workflow(submission_uuid, comments, cancelled_by_id, assessment_requirements)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/openassessment/workflow/models.py", line 552, in cancel_workflow
    workflow.cancel(assessment_requirements)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/openassessment/workflow/models.py", line 510, in cancel
    score = self.get_score(assessment_requirements, step_for_name)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/openassessment/workflow/models.py", line 261, in get_score
    score = get_score_func(self.submission_uuid, step_requirements)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/openassessment/assessment/api/peer.py", line 160, in get_score
    if not submitter_is_finished(submission_uuid, peer_requirements):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/openassessment/assessment/api/peer.py", line 63, in submitter_is_finished
    raise PeerAssessmentRequestError(u'Requirements dict must contain "must_grade" key')
PeerAssessmentRequestError: Requirements dict must contain "must_grade" key
```

These are just my first ideas of a fix that would allow the delete state to proceed.