### PR TITLE
Usability improvement for ORA file uploads

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Eric Fischer <efischer@edx.org>
 Andy Armstrong <andya@edx.org>
 Christina Roberts <christina@edx.org>
 Mushtaq Ali <mushtaak@gmail.com>
+Robert Smith <robert.smith@credoreference.com>


### PR DESCRIPTION
Implementation PRs:

* edx/edx-ora2#993

Related PRs:

* edx/edx-ora2#964

---

@jbarciauskas @marcotuts @sstack22 @scottrish - This is something that I would like to contribute in conjunction with the other ORA2 work we've sent over to you. Usability of this feature is important to us, so if there are other known issues that we could fix as a contribution, I'd be welcome to hearing what they are. 

Overview
There are serious usability issues with the Open Response Assessment file upload option. As it is currently built, the file upload seems to be meant as an optional, supplementary feature. A user must input text into the form input either way in order to submit the response. This requires crystal clear "process" instructions in every ORA prompt. Even then, we’ve found some users will ignore the process instructions in the prompt. 

We noticed this issue with an internal test (3/5 users with prior edx experience), where 5/5 users failed to submit a file. After that we ran a test on usertesting.com with the file upload ORA (5 users). 2 users were completely stuck and the other three ended up pasting their response from the word doc into the submission input. 2 of those three users also submitted a file, but the third did not. 

Some of our customers use files for their assessment records, so using file upload is a requirement in this case. 

Some of our use cases involve the file upload as the _primary_ method of submission. We would like to make an optional setting "Require File Upload" under the current Allow File Upload setting. 

We'd also like to make it possible to save and submit the ORA with _either_ a file or text in the input box, rather than always requiring text in the input box. This assumes that file upload and/or require file upload are selected. 

Here is what I would propose: 
1. Add a "Require File Upload" checkbox in the Allow File Upload section of ORA Settings
-  This should not be selectable if "None" (default) is selected for Allow File Upload
- If multiple files are specified, require each one if this box is checked
2. Allow the "Save your progress" button to be selectable if a file is uploaded to the ORA, even if there is no text in the submission form input
3. If "Require File Upload" is checked, allow the "Submit your response and move to the next step" button to be selectable if a file is uploaded to the ORA, even if there is no text in the submission form input

Existing Allow File Upload section:
![allow file upload - settings](https://cloud.githubusercontent.com/assets/9043572/22304872/53e7ad44-e307-11e6-95b2-c36901c1b94f.png)

Unable to submit response as a file only:
![screen shot 2017-01-25 at 2 07 43 pm](https://cloud.githubusercontent.com/assets/9043572/22305023/f80e45fe-e307-11e6-868b-b0540a692574.png)