### PR TITLE
fix naive datetimes

### DIFF
--- a/openassessment/templates/openassessmentblock/peer/oa_peer_assessment.html
+++ b/openassessment/templates/openassessmentblock/peer/oa_peer_assessment.html
@@ -21,14 +21,14 @@
                     {% if peer_start %}
                     <span class="step__deadline">
                         {# Translators: This string displays a date to the user, then tells them the time until that date.  Example: "available August 13th, 2014 00:00 UTC (in 5 days and 45 minutes)" #}
-                        {% blocktrans with start_date=peer_start|date:"Y-m-d H:i" time_until=peer_start|timeuntil %}
+                        {% blocktrans with start_date=peer_start|timezone:"UTC"|date:"c" time_until=peer_start|timeuntil %}
                         <span class="date ora-datetime" data-datetime="{{ start_date }}" data-string="available {date} (in {{ time_until }})" data-timezone="{{ user_timezone }}" data-language="{{ user_language }}"></span>
                         {% endblocktrans %}
                     </span>
                     {% elif peer_due %}
                     <span class="step__deadline">
                         {# Translators: This string displays a date to the user, then tells them the time until that date.  Example: "due August 13th, 2014 00:00 UTC (in 5 days and 45 minutes)" #}
-                        {% blocktrans with due_date=peer_due|date:"Y-m-d H:i" time_until=peer_due|timeuntil %}
+                        {% blocktrans with due_date=peer_due|timezone:"UTC"|date:"c" time_until=peer_due|timeuntil %}
                         <span class="date ora-datetime" data-datetime="{{ due_date }}" data-string="due {date} (in {{ time_until }})" data-timezone="{{ user_timezone }}" data-language="{{ user_language }}"></span>
                         {% endblocktrans %}
                     </span>

--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -17,14 +17,14 @@
                     {% if submission_start %}
                     <span class="step__deadline">
                         {# Translators: This string displays a date to the user, then tells them the time until that date.  Example: "available August 13th, 2014 (in 5 days and 45 minutes)" #}
-                        {% blocktrans with start_date=submission_start|date:"Y-m-d H:i" time_until=submission_start|timeuntil %}
+                        {% blocktrans with start_date=submission_start|timezone:"UTC"|date:"c" time_until=submission_start|timeuntil %}
                         <span class="date ora-datetime" data-datetime="{{ start_date }}" data-string="available {date} (in {{ time_until }})" data-timezone="{{ user_timezone }}" data-language="{{ user_language }}"></span>
                         {% endblocktrans %}
                     </span>
                     {% elif submission_due %}
                     <span class="step__deadline">
                         {# Translators: This string displays a date to the user, then tells them the time until that date.  Example: "due August 13th, 2014 (in 5 days and 45 minutes)" #}
-                        {% blocktrans with due_date=submission_due|date:"Y-m-d H:i" time_until=submission_due|timeuntil %}
+                        {% blocktrans with due_date=submission_due|timezone:"UTC"|date:"c" time_until=submission_due|timeuntil %}
                         <span class="date ora-datetime" data-datetime="{{ due_date }}" data-string="due {date} (in {{ time_until }})" data-timezone="{{ user_timezone }}" data-language="{{ user_language }}"></span>
                         {% endblocktrans %}
                     </span>
@@ -50,7 +50,7 @@
                     {% if submission_due %}
                     {% trans "You can save your progress and return to complete your response at any time before the due date" %}
                     (<span class="step__deadline">
-                        <span class="date ora-datetime" data-datetime="{{ submission_due|date:'Y-m-d H:i' }}" data-timezone="{{ user_timezone }}" data-format="longDateTime" data-language="{{ user_language }}"></span>
+                        <span class="date ora-datetime" data-datetime="{{ submission_due|timezone:'UTC'|date:'c' }}" data-timezone="{{ user_timezone }}" data-format="longDateTime" data-language="{{ user_language }}"></span>
                     </span>).
                     {% else %}
                     {% trans "You can save your progress and return to complete your response at any time." %}

--- a/openassessment/templates/openassessmentblock/self/oa_self_assessment.html
+++ b/openassessment/templates/openassessmentblock/self/oa_self_assessment.html
@@ -18,14 +18,14 @@
                     {% if self_start %}
                     <span class="step__deadline">
                         {# Translators: This string displays a date to the user, then tells them the time until that date.  Example: "available August 13th, 2014 (in 5 days and 45 minutes)" #}
-                        {% blocktrans with start_date=self_start|date:"Y-m-d H:i" time_until=self_start|timeuntil %}
+                        {% blocktrans with start_date=self_start|timezone:"UTC"|date:"c" time_until=self_start|timeuntil %}
                             <span class="date ora-datetime" data-datetime="{{ start_date }}" data-string="available {date} (in {{ time_until }})" data-timezone="{{ user_timezone }}" data-language="{{ user_language }}"></span>
                         {% endblocktrans %}
                     </span>
                     {% elif self_due %}
                     <span class="step__deadline">
                         {# Translators: This string displays a date to the user, then tells them the time until that date.  Example: "due August 13th, 2014 (in 5 days and 45 minutes)" #}
-                        {% blocktrans with due_date=self_due|date:"Y-m-d H:i" time_until=self_due|timeuntil %}
+                        {% blocktrans with due_date=self_due|timezone:"UTC"|date:"c" time_until=self_due|timeuntil %}
                             <span class="date ora-datetime" data-datetime="{{ due_date }}" data-string="due {date} (in {{ time_until }})" data-timezone="{{ user_timezone }}" data-language="{{ user_language }}"></span>
                         {% endblocktrans %}
                     </span>

--- a/openassessment/templates/openassessmentblock/student_training/student_training.html
+++ b/openassessment/templates/openassessmentblock/student_training/student_training.html
@@ -17,14 +17,14 @@
                 {% if training_start %}
                     <span class="step__deadline">
                         {# Translators: This string displays a date to the user, then tells them the time until that date.  Example: "available August 13th, 2014 (in 5 days and 45 minutes)" #}
-                        {% blocktrans with start_date=training_start|date:"Y-m-d H:i" time_until=training_start|timeuntil %}
+                        {% blocktrans with start_date=training_start|timezone:"UTC"|date:"c" time_until=training_start|timeuntil %}
                         <span class="date ora-datetime" data-datetime="{{ start_date }}" data-string="available {date} (in {{ time_until }})" data-timezone="{{ user_timezone }}" data-language="{{ user_language }}"></span>
                         {% endblocktrans %}
                     </span>
                 {% elif training_due %}
                     <span class="step__deadline">
                         {# Translators: This string displays a date to the user, then tells them the time until that date.  Example: "due August 13th, 2014 (in 5 days and 45 minutes)" #}
-                        {% blocktrans with due_date=training_due|date:"Y-m-d H:i" time_until=training_due|timeuntil %}
+                        {% blocktrans with due_date=training_due|timezone:"UTC"|date:"c" time_until=training_due|timeuntil %}
                         <span class="date ora-datetime" data-datetime="{{ due_date }}" data-string="due {date} (in {{ time_until }})" data-timezone="{{ user_timezone }}" data-language="{{ user_language }}"></span>
                         {% endblocktrans %}
                     </span>

--- a/openassessment/xblock/static/js/spec/lms/oa_datefactory.js
+++ b/openassessment/xblock/static/js/spec/lms/oa_datefactory.js
@@ -16,7 +16,7 @@ describe('OpenAssessment.DateTimeFactory', function() {
             datetimeFactory.apply();
             $('.ora-datetime', timeElement).each(function() {
                 var self = this;
-                expect($(self).data('datetime')).toBe('2019-12-31 19:00');
+                expect($(self).data('datetime')).toBe('2020-01-01T00:00:00+00:00');
                 expect($(self).data('string')).toContain('due {date}');
             });
         });
@@ -36,7 +36,7 @@ describe('OpenAssessment.DateTimeFactory', function() {
             $('.ora-datetime', timeElement).each(function() {
                 var el = this;
                 var testContext = datetimeFactory.determineContext($(el));
-                expect(testContext['datetime']).toBe('2019-12-31 19:00');
+                expect(testContext['datetime']).toBe('2020-01-01T00:00:00+00:00');
                 expect(testContext['timezone']).toBe('America/Los_Angeles');
                 expect(testContext['language']).toBe('en');
                 expect(testContext['format']).toBe('');

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -100,8 +100,8 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         # Expect that the page renders even if the update fails
         self.assertIn("OpenAssessmentBlock", xblock_fragment.body_html())
 
-    @ddt.data(('utc', '2014-03-31 20:00'),
-              ('America/Los_Angeles', '2014-03-31 20:00'))
+    @ddt.data(('utc', '2014-04-01T00:00:00+00:00'),
+              ('America/Los_Angeles', '2014-04-01T00:00:00+00:00'))
     @ddt.unpack
     def test_load_student_view_with_dates(self, time_zone, expected_date):
         """OA XBlock returns some HTML to the user.
@@ -159,8 +159,8 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         request.params = {}
         return xblock.render_peer_assessment(request)
 
-    @ddt.data(('utc', '2014-03-31 21:01'),
-              ('America/Los_Angeles', '2014-03-31 21:01'))
+    @ddt.data(('utc', '2014-04-01T01:01:01+00:00'),
+              ('America/Los_Angeles', '2014-04-01T01:01:01+00:00'))
     @ddt.unpack
     @freeze_time("2014-01-01")
     def test_formatted_start_dates(self, time_zone, expected_start_date):
@@ -172,8 +172,8 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             resp = self._render_xblock(xblock)
             self.assertIn(expected_start_date, resp.body)
 
-    @ddt.data(('utc', '2014-04-30 20:00'),
-              ('America/Los_Angeles', '2014-04-30 20:00'))
+    @ddt.data(('utc', '2014-05-01T00:00:00+00:00'),
+              ('America/Los_Angeles', '2014-05-01T00:00:00+00:00'))
     @ddt.unpack
     def test_formatted_end_dates(self, time_zone, expected_end_date):
         """Test end dates correctly formatted"""
@@ -185,8 +185,8 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             resp = self._render_xblock(xblock)
             self.assertIn(expected_end_date, resp.body)
 
-    @ddt.data(('utc', '2014-03-31 21:01'),
-              ('America/Los_Angeles', '2014-03-31 21:01'))
+    @ddt.data(('utc', '2014-04-01T01:01:01+00:00'),
+              ('America/Los_Angeles', '2014-04-01T01:01:01+00:00'))
     @ddt.unpack
     @freeze_time("2014-01-01")
     def test_formatted_start_dates_for_beta_tester_with_days_early(self, time_zone, expected_start_date):
@@ -202,8 +202,8 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             resp = self._render_xblock(xblock)
             self.assertIn(expected_start_date, resp.body)
 
-    @ddt.data(('utc', '2014-04-30 20:00'),
-              ('America/Los_Angeles', '2014-04-30 20:00'))
+    @ddt.data(('utc', '2014-05-01T00:00:00+00:00'),
+              ('America/Los_Angeles', '2014-05-01T00:00:00+00:00'))
     @ddt.unpack
     def test_formatted_end_dates_for_beta_tester_with_days_early(self, time_zone, expected_end_date):
         """Test end dates for beta tester with days early"""
@@ -218,8 +218,8 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             resp = self._render_xblock(xblock)
             self.assertIn(expected_end_date, resp.body)
 
-    @ddt.data(('utc', '2014-04-05 21:01'),
-              ('America/Los_Angeles', '2014-04-05 21:01'))
+    @ddt.data(('utc', '2014-04-06T01:01:01+00:00'),
+              ('America/Los_Angeles', '2014-04-06T01:01:01+00:00'))
     @ddt.unpack
     @freeze_time("2014-01-01")
     @patch.object(openassessmentblock.OpenAssessmentBlock, 'is_beta_tester', new_callable=PropertyMock)
@@ -239,8 +239,8 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             resp = self._render_xblock(xblock)
             self.assertIn(expected_start_date, resp.body)
 
-    @ddt.data(('utc', '2014-04-30 20:00'),
-              ('America/Los_Angeles', '2014-04-30 20:00'))
+    @ddt.data(('utc', '2014-05-01T00:00:00+00:00'),
+              ('America/Los_Angeles', '2014-05-01T00:00:00+00:00'))
     @ddt.unpack
     @patch.object(openassessmentblock.OpenAssessmentBlock, 'is_beta_tester', new_callable=PropertyMock)
     def test_formatted_end_dates_for_beta_tester_without_days_early(
@@ -259,8 +259,8 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             resp = self._render_xblock(xblock)
             self.assertIn(expected_end_date, resp.body)
 
-    @ddt.data(('utc', '2014-04-05 21:01'),
-              ('America/Los_Angeles', '2014-04-05 21:01'))
+    @ddt.data(('utc', '2014-04-06T01:01:01+00:00'),
+              ('America/Los_Angeles', '2014-04-06T01:01:01+00:00'))
     @ddt.unpack
     @freeze_time("2014-01-01")
     def test_formatted_start_dates_for_beta_tester_with_nonetype_days_early(self, time_zone, expected_start_date):
@@ -276,8 +276,8 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             resp = self._render_xblock(xblock)
             self.assertIn(expected_start_date, resp.body)
 
-    @ddt.data(('utc', '2014-04-30 20:00'),
-              ('America/Los_Angeles', '2014-04-30 20:00'))
+    @ddt.data(('utc', '2014-05-01T00:00:00+00:00'),
+              ('America/Los_Angeles', '2014-05-01T00:00:00+00:00'))
     @ddt.unpack
     def test_formatted_end_dates_for_beta_tester_with_nonetype_days_early(self, time_zone, expected_end_date):
         """Test end dates for beta tester with NoneType days early"""

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -470,7 +470,7 @@ class SubmissionRenderTest(XBlockHandlerTestCase):
         # Expect that the response step is open and displays the deadline
         resp = self.request(xblock, 'render_submission', json.dumps(dict()))
         self.assertIn('Enter your response to the question', resp)
-        self.assertIn('2999-05-05 19:00', resp)
+        self.assertIn('2999-05-06T00:00:00+00:00', resp)
 
         # Create a submission for the user
         xblock.create_submission(


### PR DESCRIPTION
## [TNL-6501](https://openedx.atlassian.net/browse/TNL-6501)

### Description
Fixes occasional naive datetime objects being rendered in ORA, causing confusion in certain browsers as to deadline accuracy. Renders timezone (UTC) aware datestamps more completely, and eliminates ambiguity.

### Testing
- [x] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [ ] Code review: @sanfordstudent, @jcdyer, or @nasthagiri 

FYI: 

### Post-review
- [x] Rebase and squash commits

