### PR TITLE
Fix broken acceptance tests

### DIFF
--- a/test/acceptance/auto_auth.py
+++ b/test/acceptance/auto_auth.py
@@ -85,7 +85,7 @@ class AutoAuthPage(PageObject):
         Finds and returns the username and email address of the current user.
         """
         message = self.q(css='BODY').text[0].strip()
-        match = re.search(r'Logged in user (\S+) \(.*\) with password (\S+)', message)
+        match = re.search(r'Logged in user (\S+) \((.*)\).*', message)
         if not match:
             return None
         return match.group(1), match.group(2)


### PR DESCRIPTION
A recent change to edx-platform (see [the ECOM ticket](https://openedx.atlassian.net/browse/ECOM-7041) for background, [the git commit](https://github.com/edx/edx-platform/commit/d141eb15b1687a1c493666c7cbec566b4f7c5c91) for the actual change) has revealed a bug in our testing code.

Basically, the method `get_username_and_email` had a poorly-written regex that was actually extracting the username and *password* from the auto auth page. In all tests that were using the `FullWorkflowMixin` class, we'd try to "log back in" as a previous user with the correct username and this buggy "email". [A quick peek at the auto auth code](https://github.com/edx/edx-platform/blob/master/common/djangoapps/student/views.py#L2079-L2094) will show that the username is used to lookup the user then the new password is updated, so our tests were still functionally correct with the added side-effect of updating a bunch of emails to be identical.

The fix is to just make the regex do what the method name is claiming it does.

## tl;dr:
- recent edx-platform change forced unique email for all users
- buggy regex in edx-ora2 auto_auth logic had been updating multiple test users' emails to be `test_password`

FYI @yro @cahrens
