### PR TITLE
Ignore reset signal for staff grades

### DIFF
--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -438,7 +438,8 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
         sub_api.reset_score(
             sub_dict['student_item']['student_id'],
             self.course_id,
-            self.item_id
+            self.item_id,
+            emit_signal=False,
         )
         sub_api.set_score(
             self.submission_uuid,


### PR DESCRIPTION
Just an idea I had of how we can clean up the ORA/submissions and Robust Grades interaction, wanted to get it down before I forgot. Let's discuss further tomorrow @nasthagiri.