### PR TITLE
Bump edx-submissions to v2.0.0.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 git+https://github.com/edx/XBlock.git@xblock-0.4.12#egg=XBlock==0.4.12
 
 # edx-submissions
-git+https://github.com/edx/edx-submissions.git@1.2.0#egg=edx-submissions==1.2.0
+git+https://github.com/edx/edx-submissions.git@2.0.0#egg=edx-submissions==2.0.0
 
 # Third Party Requirements
 boto>=2.32.1,<3.0.0


### PR DESCRIPTION
# [TNL-6697](https://openedx.atlassian.net/browse/TNL-6697)

This is to stay in step with a change to the way edx-platform pulls data from submissions.

Builds on edx/edx-submissions#57

## Reviewers

- [ ] @efischer19 
