### PR TITLE
Fix file upload tests

### DIFF
--- a/test/acceptance/pages.py
+++ b/test/acceptance/pages.py
@@ -178,7 +178,7 @@ class SubmissionPage(OpenAssessmentPage):
         Returns:
             bool
         """
-        return self.q(css="button.file__upload").attrs('disabled') == ['false']
+        return self.q(css="button.file__upload")[0].is_enabled()
 
     @property
     def upload_file_button_is_disabled(self):

--- a/test/acceptance/tests.py
+++ b/test/acceptance/tests.py
@@ -741,18 +741,12 @@ class FileUploadTest(OpenAssessmentTest):
         self.assertTrue(self.submission_page.has_file_error)
 
         # trying to upload a acceptable file
-        readme1 = os.path.dirname(os.path.realpath(__file__)) + '/README.rst'
-        readme2 = readme1.replace('test/acceptance/', '')  # There's another README located at ../../
-
-        files = ', '.join([readme1, readme2])
-        self.submission_page.visit().select_file(files)
+        readme = os.path.dirname(os.path.realpath(__file__)) + '/README.rst'
+        self.submission_page.visit().select_file(readme)
         self.assertFalse(self.submission_page.has_file_error)
         self.assertTrue(self.submission_page.upload_file_button_is_disabled)
 
         self.submission_page.add_file_description(0, 'file description 1')
-        self.assertTrue(self.submission_page.upload_file_button_is_disabled)
-
-        self.submission_page.add_file_description(1, 'file description 2')
         self.assertTrue(self.submission_page.upload_file_button_is_enabled)
 
         self.submission_page.upload_file()


### PR DESCRIPTION
We can't easily select multiple files in acceptance tests, so don't try that.

@jlajoie, can you be my reviewer here? The issue is that we "select a file for upload" by sending keys at an `<input>` element, and there's no good way to modify that to select multiple files.

- We can't just send them over as an array or serialized list, that results in only one of the two files being selected
- We can't modify the `<input>` element's `FileList` using javascript, because the HTML File API standard smartly realized that as being a huge security threat.
- We can't modify the bokchoy framework to accurately do things to a system dialog window

So, in the interest of having functional tests, I'm proposing we skip that part of the acceptance test; [I was the one who requested they be added in the initial PR](https://github.com/edx/edx-ora2/pull/964#issuecomment-290768906)