### PR TITLE
All files with upper case extension changes into lowercase.

### DIFF
--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -298,7 +298,7 @@ class SubmissionMixin(object):
         if self.file_upload_type == 'pdf-and-image' and content_type not in self.ALLOWED_FILE_MIME_TYPES:
             return {'success': False, 'msg': self._(u"Content type must be PDF, GIF, PNG or JPG.")}
 
-        if self.file_upload_type == 'custom' and file_ext not in self.white_listed_file_types:
+        if self.file_upload_type == 'custom' and file_ext.lower() not in self.white_listed_file_types:
             return {'success': False, 'msg': self._(u"File type must be one of the following types: {}").format(
                 ', '.join(self.white_listed_file_types))}
 

--- a/openassessment/xblock/test/data/custom_file_upload.xml
+++ b/openassessment/xblock/test/data/custom_file_upload.xml
@@ -1,0 +1,20 @@
+<openassessment file_upload_type="custom" white_listed_file_types="pdf" submission_due="2035-03-11T18:20">
+    <title>
+        Global Poverty
+    </title>
+    <rubric>
+        <prompt>
+            Given the state of the world today, what do you think should be done to combat poverty?
+
+            Read for conciseness, clarity of thought, and form.
+        </prompt>
+    </rubric>
+    <assessments>
+        <assessment name="peer-assessment"
+                    start="2014-03-11T10:00-18:10"
+                    due="2035-12-21T22:22-7:00"
+                    must_grade="1"
+                    must_be_graded_by="1" />
+        <assessment name="self-assessment" />
+    </assessments>
+</openassessment>

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -221,6 +221,29 @@ class SubmissionTest(XBlockHandlerTestCase):
         self.assertTrue(resp['success'])
         self.assertEqual(u'', resp['url'])
 
+    @mock_s3
+    @override_settings(
+        AWS_ACCESS_KEY_ID='foobar',
+        AWS_SECRET_ACCESS_KEY='bizbaz',
+        FILE_UPLOAD_STORAGE_BUCKET_NAME="mybucket"
+    )
+    @scenario('data/custom_file_upload.xml')
+    def test_upload_files_with_uppercase_ext(self, xblock):
+        """
+        Tests that files with upper case extention uploaded successfully
+        """
+        xblock.xmodule_runtime = Mock(
+            course_id='test_course',
+            anonymous_student_id='test_student',
+        )
+        resp = self.request(xblock, 'upload_url', json.dumps({'contentType': 'filename',
+                                                              'filename': 'test.PDF'}), response_format='json')
+        self.assertTrue(resp['success'])
+        self.assertTrue(resp['url'].startswith(
+            'https://mybucket.s3.amazonaws.com/submissions_attachments/test_student/test_course/' +
+            xblock.scope_ids.usage_id
+        ))
+
 
 class SubmissionRenderTest(XBlockHandlerTestCase):
     """


### PR DESCRIPTION
## [File upload extensions are case sensitive. EDUCATOR-467](https://openedx.atlassian.net/browse/EDUCATOR-467)

### Description
This PR fixes that all the custom extensions with upper case letter converted into the lower case and successfully uploaded.

### How to Test?

**Edge Production** 

- Go to:  https://edge.edx.org/courses/course-v1:edX+TC101x+2017_T1/jump_to_id/2deac101ad854e55ad43cc0f482ca6f1
- Upload a file with the extension `.R `The user receives an error message.
<img width="813" alt="screen shot 2017-05-29 at 5 34 40 pm" src="https://cloud.githubusercontent.com/assets/7627421/26549995/27b2b922-4495-11e7-8d36-1bb2d9e996db.png">


**Sandbox**

- https://ora-ext.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/9fca584977d04885bc911ea76a9ef29e/07bc32474380492cb34f76e5f9d9a135/
- Upload a file with the extension `.R `. File Uploaded Succesffully.



### Tests
 - [x] Unit Test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @mushtaqak 
- [ ] @asadazam93 


### Post-review
- [ ] Rebase and squash commits
