### PR TITLE
Fix broken auto_auth page

### DIFF
--- a/test/acceptance/auto_auth.py
+++ b/test/acceptance/auto_auth.py
@@ -1,7 +1,7 @@
 """
 Auto-auth page (used to automatically log in during testing).
 """
-
+import json
 import os
 import re
 import urllib
@@ -54,6 +54,8 @@ class AutoAuthPage(PageObject):
         if roles is not None:
             self._params['roles'] = roles
 
+        self.data = {}
+
     @property
     def url(self):
         """
@@ -68,24 +70,17 @@ class AutoAuthPage(PageObject):
         return url
 
     def is_browser_on_page(self):
-        message = self.q(css='BODY').text[0]
-        match = re.search(r'Logged in user ([^$]+) with password ([^$]+) and user_id ([^$]+)$', message)
-        return True if match else False
+        self.data = json.loads(self.q(css='BODY').text[0])
+        return self.data['created_status'] == "Logged in"
 
     def get_user_id(self):
         """
         Finds and returns the user_id
         """
-        message = self.q(css='BODY').text[0].strip()
-        match = re.search(r' user_id ([^$]+)$', message)
-        return match.groups()[0] if match else None
+        return self.data['user_id']
 
     def get_username_and_email(self):
         """
         Finds and returns the username and email address of the current user.
         """
-        message = self.q(css='BODY').text[0].strip()
-        match = re.search(r'Logged in user (\S+) \((.*)\).*', message)
-        if not match:
-            return None
-        return match.group(1), match.group(2)
+        return self.data['username'], self.data['email']


### PR DESCRIPTION
After https://github.com/edx/edx-platform/pull/15157, the LMS auto_auth page returns json instead of text.

Example, per https://ora2.sandbox.edx.org/auto_auth?course_id=course-v1%3Aedx%2BORA203%2Bcourse&staff=false:
```
{
  "username": "c825f57eb37e48bfafd65be7f6f304", 
  "user_id": 75, 
  "anonymous_id": "a98a083ae5962ceab3ee3f207fa8b8ef", 
  "created_status": "Logged in", 
  "password": "c825f57eb37e48bfafd65be7f6f304", 
  "email": "c825f57eb37e48bfafd65be7f6f304@example.com"
}
```

I've made the changes that jumped out at me to resolve this; acceptance tests pass against ora2.sandbox.edx.org when I run them locally.

@jlajoie to review, since he did the ORA pipeline work. I don't believe we'll need to make any other changes to our testing setup.

FYI @cahrens @edx/educator-dahlia 