### PR TITLE
Fixed the "Allow LaTeX Responses" setting

### DIFF
--- a/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
@@ -263,7 +263,7 @@ OpenAssessment.EditSettingsView.prototype = {
                 sel.val(0);
             }
         }
-        return sel.val() === 1;
+        return sel.val() === "1";
     },
     /**
     Get or set the number of scores to show in the leaderboard.


### PR DESCRIPTION
This is a small fix to make the LaTeX response setting work.

Testing instructions:

1. Go to the `Advanced Settings` of a course in Studio and add `"ora2"` to the *Advanced Module List*
1. Add an Open Response Assessment problem to a new Unit
1. Select "Edit" on the new ORA problem to open the settings modal
1. Change "Allow LaTeX Responses" to `True`, and click *Save* to close the settings dialog
1. Select "Edit" again and observe that the "Allow LaTeX Responses" setting is incorrectly set back to `False`
1. Clone this repository into the `/edx/app/src` directory, checkout the branch for this PR, and install the xblock like so:
   ```
   pip install -e file:///edx/src/edx-ora2/#egg=ora2==localdev
   ```
1. Restart Studio and perform steps 3 and 4 again
1. Select "Edit" to open the settings dialog again and observe that the value of "Allow LaTeX Responses" was correctly perserved as `True`