### PR TITLE
Adds django storage backend for ORA2 file uploads.

### DIFF
--- a/openassessment/fileupload/api.py
+++ b/openassessment/fileupload/api.py
@@ -7,11 +7,13 @@ URLs to the new location.
 
 from . import backends
 
+
 def get_upload_url(key, content_type):
     """
     Returns a url (absolute or relative, depending on the endpoint) which can be used to upload a file to.
     """
     return backends.get_backend().get_upload_url(key, content_type)
+
 
 def get_download_url(key):
     """

--- a/openassessment/fileupload/backends/__init__.py
+++ b/openassessment/fileupload/backends/__init__.py
@@ -1,6 +1,7 @@
 from . import s3
 from . import filesystem
 from . import swift
+from . import django_storage
 
 from django.conf import settings
 
@@ -14,5 +15,7 @@ def get_backend():
         return filesystem.Backend()
     elif backend_setting == "swift":
         return swift.Backend()
+    elif backend_setting == "django":
+        return django_storage.Backend()
     else:
         raise ValueError("Invalid ORA2_FILEUPLOAD_BACKEND setting value: %s" % backend_setting)

--- a/openassessment/fileupload/backends/base.py
+++ b/openassessment/fileupload/backends/base.py
@@ -123,7 +123,6 @@ class BaseBackend(object):
             raise FileUploadRequestError("Key required for URL request")
         return Settings.get_bucket_name(), self._get_key_name(key)
 
-
     def _get_key_name(self, key):
         """Construct a key name with the given string and configured prefix.
 
@@ -140,4 +139,3 @@ class BaseBackend(object):
             prefix=Settings.get_prefix(),
             key=key
         )
-

--- a/openassessment/fileupload/backends/django_storage.py
+++ b/openassessment/fileupload/backends/django_storage.py
@@ -1,0 +1,67 @@
+import os
+from .base import BaseBackend
+
+from django.core.files.storage import default_storage
+from django.core.files.base import ContentFile
+from django.core.urlresolvers import reverse
+
+
+class Backend(BaseBackend):
+    """
+    Manage openassessment student files uploaded using the default django storage settings.
+    """
+    def get_upload_url(self, key, content_type):
+        """
+        Return the URL pointing to the ORA2 django storage upload endpoint.
+        """
+        return reverse("openassessment-django-storage", kwargs={'key': key})
+
+    def get_download_url(self, key):
+        """
+        Return the django storage download URL for the given key.
+
+        Returns None if no file exists at that location.
+        """
+        path = self._get_file_path(key)
+        if default_storage.exists(path):
+            return default_storage.url(path)
+        return None
+
+    def upload_file(self, key, content):
+        """
+        Upload the given file content to the keyed location.
+        """
+        path = self._get_file_path(key)
+        saved_path = default_storage.save(path, ContentFile(content))
+        return saved_path
+
+    def remove_file(self, key):
+        """
+        Remove the file at the given keyed location.
+
+        Returns True if the file exists, and was removed.
+        Returns False if the file does not exist, and so was not removed.
+        """
+        path = self._get_file_path(key)
+        if default_storage.exists(path):
+            default_storage.delete(path)
+            return True
+        return False
+
+    def _get_file_name(self, key):
+        """
+        Returns the name of the keyed file.
+
+        Since the backend storage may be folders, or it may use pseudo-folders,
+        make sure the filename doesn't include any path separators.
+        """
+        file_name = key.replace("..", "").strip("/ ")
+        file_name = file_name.replace(os.sep, "_")
+        return file_name
+
+    def _get_file_path(self, key):
+        """
+        Returns the path to the keyed file, including the storage prefix.
+        """
+        path = self._get_key_name(self._get_file_name(key))
+        return path

--- a/openassessment/fileupload/backends/filesystem.py
+++ b/openassessment/fileupload/backends/filesystem.py
@@ -80,6 +80,7 @@ def make_upload_url_available(url_key_name, timeout):
         1, timeout
     )
 
+
 def make_download_url_available(url_key_name, timeout):
     """
     Authorize a download URL.
@@ -93,11 +94,13 @@ def make_download_url_available(url_key_name, timeout):
         1, timeout
     )
 
+
 def is_upload_url_available(url_key_name):
     """
     Return True if the corresponding upload URL is available.
     """
     return get_cache().get(smart_text(get_upload_cache_key(url_key_name))) is not None
+
 
 def is_download_url_available(url_key_name):
     """
@@ -105,8 +108,10 @@ def is_download_url_available(url_key_name):
     """
     return get_cache().get(smart_text(get_download_cache_key(url_key_name))) is not None
 
+
 def get_upload_cache_key(url_key_name):
     return "upload/" + url_key_name
+
 
 def get_download_cache_key(url_key_name):
     return "download/" + url_key_name

--- a/openassessment/fileupload/backends/s3.py
+++ b/openassessment/fileupload/backends/s3.py
@@ -2,10 +2,9 @@ import boto
 import logging
 from django.conf import settings
 
-logger = logging.getLogger("openassessment.fileupload.api")
-
 from .base import BaseBackend
 from ..exceptions import FileUploadInternalError
+logger = logging.getLogger("openassessment.fileupload.api")
 
 
 class Backend(BaseBackend):
@@ -70,5 +69,3 @@ def _connect_to_s3():
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key
     )
-
-

--- a/openassessment/fileupload/backends/swift.py
+++ b/openassessment/fileupload/backends/swift.py
@@ -17,11 +17,9 @@ import swiftclient
 import urlparse
 import requests
 
-
-logger = logging.getLogger("openassessment.fileupload.api")
-
 from .base import BaseBackend
 from ..exceptions import FileUploadInternalError
+logger = logging.getLogger("openassessment.fileupload.api")
 
 
 class Backend(BaseBackend):

--- a/openassessment/fileupload/urls.py
+++ b/openassessment/fileupload/urls.py
@@ -1,6 +1,11 @@
 from django.conf.urls import patterns, url
 
+urlpatterns = patterns(
+    'openassessment.fileupload.views_django_storage',
+    url(r'^django/(?P<key>.+)/$', 'django_storage', name='openassessment-django-storage'),
+)
 
-urlpatterns = patterns('openassessment.fileupload.views_filesystem',
+urlpatterns += patterns(
+    'openassessment.fileupload.views_filesystem',
     url(r'^(?P<key>.+)/$', 'filesystem_storage', name='openassessment-filesystem-storage'),
 )

--- a/openassessment/fileupload/views_django_storage.py
+++ b/openassessment/fileupload/views_django_storage.py
@@ -1,0 +1,18 @@
+"""
+Provides the upload endpoint for the django storage backend.
+"""
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import HttpResponse
+from django.views.decorators.http import require_http_methods
+
+from .backends.django_storage import Backend
+
+
+@login_required()
+@require_http_methods(["PUT"])
+def django_storage(request, key):
+    """
+    Upload files using django storage backend.
+    """
+    Backend().upload_file(key, request.body)
+    return HttpResponse()

--- a/openassessment/fileupload/views_filesystem.py
+++ b/openassessment/fileupload/views_filesystem.py
@@ -88,6 +88,7 @@ def save_to_file(key, content, metadata=None):
         safe_remove(metadata_path)
         raise
 
+
 def safe_save(path, content):
     """
     Save content to path. Creates the appropriate directories, if required.
@@ -106,6 +107,7 @@ def safe_save(path, content):
         os.makedirs(dir_path)
     with open(path, 'w') as f:
         f.write(content)
+
 
 def safe_remove(path):
     """Remove a file if it exists.


### PR DESCRIPTION
Adds a fileupload backend named "django", which uses the default django storage backend.

OpenCraft needs this change because the current `swift` backend doesn't work with OVH's SWIFT service.  The `swift` backend relies on generating temporary `POST/GET` URLs which are used to upload/download files, but OVH throws CORS-related errors when attempting to use these URLs in the browser.

Instead of attempting to change the `swift` backend to work with OVH, we decided to add a `django` storage backend, which will work with the currently configured django storage settings on the platform.  This fixes the issue for us with OVH, but also allows file uploads to work by default in the devstack.

**JIRA tickets**: [OSPR-1808](https://openedx.atlassian.net/browse/OSPR-1808)

**Sandbox URL**:

* LMS: https://pr15446.sandbox.opencraft.hosting/
* Studio: https://studio-pr15446.sandbox.opencraft.hosting/

**Partner information**: 3rd party-hosted open edX instance

**Merge deadline**: None

**Testing instructions**:

Devstacks use django FileSystemStorage by default, so they're a good place to test this change using `django.core.files.storage.FileSystemStorage`.
1. Checkout `open-craft:jill/ora2-django-storage`, the branch used in https://github.com/edx/edx-platform/pull/15446.  This change:
   * adds the ORA2 fileupload URLs to `lms/urls.py`
   * sets `ORA2_FILEUPLOAD_BACKEND = "django"` in `lms/envs/devstack.py`
   * updates `requirements/edx/base.txt` to install ORA2 from this branch.
1. In vagrant as the `edxapp` user, run `paver run_all_servers`
1. Sign in to Studio, and create a new course.
1. Add an Open Response Assessment problem, and click `Edit`.
1. Click `Settings`, and scroll down to set:
    * File Uploads Response: Optional or Required.
    * File Upload Types: select any option.
1. Preview the new Unit
1. Upload one or more files of the appropriate type, add captions, and click `Upload Files` to save.
1. Ensure that the uploaded files are saved as expected, and can be viewed/downloaded.
1. Refresh the unit to make sure the uploaded files are still displayed.

The sandbox shown above uses SWIFT storage on OVH, and so it's a good place to test this change using `swift.storage.SwiftStorage`.
1. Sign into the [sandbox server](https://pr15446.sandbox.opencraft.hosting/login) using any standard test account.
1. Enrol in the test course, [ORA2 Django Storage](https://pr15446.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+PR15446+2017_01/about).
1. Visit the configured [ORA2 unit](https://pr15446.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+PR15446+2017_01/jump_to/block-v1:OpenCraft+PR15446+2017_01+type@vertical+block@fa8d669b79ae4af78e77b8c79247a53b)
1. Follow steps 7-9 above to verify file uploads.

**Author notes and concerns**:

This new `django` backend could in theory replace the existing backends, since most deployments are likely to use the same storage mechanism for ORA2 that they use on the platform.  
However, in practice, it was impossible to make the `django` backend preserve the same file destinations between all mechanisms, and so changing the backend on an existing deployment could result in lost submissions.
*Note: ORA2 appends the `[/{index}]` suffix for multiple file uploads, when `{index} > 0`.  When `{index} == 0`, it is omitted.*
I.e.,
* `ORA2_FILEUPLOAD_BACKEND = 's3'` (default): stores to `{bucket}/{prefix}/{key}[/{index}]`
* `ORA2_FILEUPLOAD_BACKEND = 'swift'`: stores to `{bucket}/{prefix}/{key}[/{index}]`
* `ORA2_FILEUPLOAD_BACKEND = 'filesystem'`: stores two files, `{media_root}/{bucket}/{prefix}/{key}[/{index}]/content` and `{media_root}/{bucket}/{prefix}/{key}[/{index}]/metadata.json`, and creates any subdirectories required.
* `ORA2_FILEUPLOAD_BACKEND = 'django'`: stores to `{storage_root}/{prefix}/{key}[_{index}]`.
   The destination filename must be flattened from `{key}[/{index}]` to `{key}[_{index}]` because it must be storage-agnostic, and so can't create subdirectories.  Also, it must gracefully handle the cases where `{index} == 0` and is therefore omitted from the key by ORA2, and where `{index} > 0`, when it is included.  
   Specifically, if we didn't replace the dir separator with an unerscore and the default django storage points to the local filesystem, then the first file would write to `{storage_root}/{prefix}/{key}`, and the next file would fail to write to `{storage_root}/{prefix}/{key}/1`, because `{storage_root}/{prefix}/{key}` already exists as a file, not a directory.

**Reviewers**
- [x] @bdero
- [ ] edX reviewer[s] TBD - CC @gsong 