### PR TITLE
This check is no longer valid, removing it as focus is not on the header

### DIFF
--- a/test/acceptance/pages.py
+++ b/test/acceptance/pages.py
@@ -353,14 +353,6 @@ class AssessmentPage(OpenAssessmentPage, AssessmentMixin):
         return self.q(css=css_class).is_present()
 
     @property
-    def is_on_top(self):
-        # TODO: On top behavior needs to be better defined. It is defined here more accurately as "near-top".
-        # pos = self.browser.get_window_position()
-        # return pos['y'] < 100
-        # self.wait_for_element_visibility(".chapter.is-open", "Chapter heading is on visible", timeout=10)
-        return self.q(css=".chapter.is-open").visible
-
-    @property
     def response_text(self):
         """
         Retrieve the text of the response shown in the assessment.

--- a/test/acceptance/tests.py
+++ b/test/acceptance/tests.py
@@ -300,9 +300,6 @@ class SelfAssessmentTest(OpenAssessmentTest):
         # Submit a response
         self.do_self_assessment()
 
-        # Check browser scrolled back to top of assessment
-        self.assertTrue(self.self_asmnt_page.is_on_top)
-
     @retry()
     @attr('acceptance')
     def test_latex(self):


### PR DESCRIPTION
button

This test is obsolete with the a11y refactoring we did.  It is not failing due to the changes in the UI for the new course outline.

This will also resolve the issues with ORA2 Build failures.