### PR TITLE
s/question/prompt in user-facing strings

### DIFF
--- a/openassessment/templates/openassessmentblock/leaderboard/oa_leaderboard_show.html
+++ b/openassessment/templates/openassessmentblock/leaderboard/oa_leaderboard_show.html
@@ -21,7 +21,7 @@
                 </div>
                 {% endwith %}
                 <div class="leaderboard__answer">
-                    {% trans "Your peer's response to the question above" as translated_label %}
+                    {% trans "Your peer's response to the prompt above" as translated_label %}
                     {% include "openassessmentblock/oa_submission_answer.html" with answer=topscore.submission.answer answer_text_label=translated_label %}
                     {% include "openassessmentblock/oa_uploaded_file.html" with file_upload_type=file_upload_type file_urls=topscore.files class_prefix="submission__answer" including_template="leaderboard_show" xblock_id=xblock_id %}
                 </div>

--- a/openassessment/templates/openassessmentblock/message/oa_message_open.html
+++ b/openassessment/templates/openassessmentblock/message/oa_message_open.html
@@ -5,11 +5,11 @@
         <p>
             {% if approaching %}
                 {% blocktrans with start_tag='<strong>'|safe end_tag="</strong>"|safe %}
-                    Assignment submissions will close soon. To receive a grade, first provide a response to the question, then complete the steps below the {{ start_tag }}Your Response{{ end_tag }} field.
+                    Assignment submissions will close soon. To receive a grade, first provide a response to the prompt, then complete the steps below the {{ start_tag }}Your Response{{ end_tag }} field.
                 {% endblocktrans %}
             {% else %}
                 {% blocktrans with start_tag="<strong>"|safe end_tag="</strong>"|safe %}
-                    This assignment has several steps. In the first step, you'll provide a response to the question. The other steps appear below the {{ start_tag }}Your Response{{ end_tag }} field.
+                    This assignment has several steps. In the first step, you'll provide a response to the prompt. The other steps appear below the {{ start_tag }}Your Response{{ end_tag }} field.
                 {% endblocktrans %}
             {% endif %}
         </p>

--- a/openassessment/templates/openassessmentblock/oa_base.html
+++ b/openassessment/templates/openassessmentblock/oa_base.html
@@ -12,7 +12,7 @@
                 {% block message %}
                 <div class="openassessment__message message">
                     <div class="message__content">
-                        <p>{% trans "This assignment has several steps. In the first step, you'll provide a response to the question. The other steps appear below the Your Response field." %}</p>
+                        <p>{% trans "This assignment has several steps. In the first step, you'll provide a response to the prompt. The other steps appear below the Your Response field." %}</p>
                     </div>
                 </div>
                 {% endblock %}

--- a/openassessment/templates/openassessmentblock/peer/oa_peer_assessment.html
+++ b/openassessment/templates/openassessmentblock/peer/oa_peer_assessment.html
@@ -65,7 +65,7 @@
                         <article class="peer-assessment peer-assessment--001">
                             <div class="peer-assessment__display">
 
-                                {% trans "Your peer's response to the question above" as translated_label %}
+                                {% trans "Your peer's response to the prompt above" as translated_label %}
                                 {% include "openassessmentblock/oa_submission_answer.html" with answer=peer_submission.answer answer_text_label=translated_label %}
 
                                 {% trans "Associated Files"  as translated_header %}

--- a/openassessment/templates/openassessmentblock/peer/oa_peer_turbo_mode.html
+++ b/openassessment/templates/openassessmentblock/peer/oa_peer_turbo_mode.html
@@ -48,7 +48,7 @@
                 <li class="list--peer-assessments__item">
                     <article class="peer-assessment peer-assessment--001">
                         <div class="peer-assessment__display">
-                            {% trans "Your peer's response to the question above" as translated_label %}
+                            {% trans "Your peer's response to the prompt above" as translated_label %}
                             {% include "openassessmentblock/oa_submission_answer.html" with answer=peer_submission.answer answer_text_label=translated_label %}
 
                             {% trans "Associated Files" as translated_header %}

--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -46,7 +46,7 @@
         <div class="wrapper--step__content">
             <div class="step__instruction">
                 <p>
-                    {% trans "Enter your response to the question." %}
+                    {% trans "Enter your response to the prompt." %}
                     {% if submission_due %}
                     {% trans "You can save your progress and return to complete your response at any time before the due date" %}
                     (<span class="step__deadline">
@@ -89,7 +89,7 @@
                                         class="submission__answer__part__text__value"
                                         aria-labelledby="submission__answer__part__text__title__{{ forloop.counter }}__{{ xblock_id }}"
                                         aria-describedby="submission__answer__tip__{{ xblock_id }}"
-                                        placeholder="{% trans "Enter your response to the question above." %}"
+                                        placeholder="{% trans "Enter your response to the prompt above." %}"
                                         maxlength="100000"
                                     >{{ part.text }}</textarea>
                                 </div>

--- a/openassessment/templates/openassessmentblock/staff_area/oa_staff_grade_learners_assessment.html
+++ b/openassessment/templates/openassessmentblock/staff_area/oa_staff_grade_learners_assessment.html
@@ -22,7 +22,7 @@
                             </h4>
                         </header>
 
-                        {% trans "The learner's response to the question above" as translated_label %}
+                        {% trans "The learner's response to the prompt above" as translated_label %}
                         {% include "openassessmentblock/oa_submission_answer.html" with answer=submission.answer answer_text_label=translated_label %}
 
                         {% trans "Associated Files" as translated_header %}

--- a/openassessment/templates/openassessmentblock/staff_area/oa_staff_override_assessment.html
+++ b/openassessment/templates/openassessmentblock/staff_area/oa_staff_override_assessment.html
@@ -21,7 +21,7 @@
                         </h3>
                     </header>
 
-                    {% trans "The learner's response to the question above" as translated_label %}
+                    {% trans "The learner's response to the prompt above" as translated_label %}
                     {% include "openassessmentblock/oa_submission_answer.html" with answer=submission.answer answer_text_label=translated_label %}
 
                     {% trans "Associated Files" as translated_header %}

--- a/openassessment/templates/openassessmentblock/staff_area/oa_student_info.html
+++ b/openassessment/templates/openassessmentblock/staff_area/oa_student_info.html
@@ -43,7 +43,7 @@
                 </p>
             {% else %}
                 <div class="wrapper--content">
-                    {% trans "The learner's response to the question above" as translated_label %}
+                    {% trans "The learner's response to the prompt above" as translated_label %}
                     {% include "openassessmentblock/oa_submission_answer.html" with answer=submission.answer answer_text_label=translated_label %}
 
                     {% trans "Associated Files" as translated_header %}

--- a/openassessment/templates/openassessmentblock/student_training/student_training.html
+++ b/openassessment/templates/openassessmentblock/student_training/student_training.html
@@ -72,7 +72,7 @@
             <div class="step__content">
                 <article class="student-training__display">
 
-                    {% trans "The response to the question above:" as translated_label %}
+                    {% trans "The response to the prompt above:" as translated_label %}
                     {% include "openassessmentblock/oa_submission_answer.html" with answer=training_essay.answer answer_text_label=translated_label %}
 
                 </article>

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -146,7 +146,7 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         # Verify that prompts intentionally left empty don't create DOM elements
         xblock_fragment = self.runtime.render(xblock, "student_view")
         body_html = xblock_fragment.body_html()
-        present_prompt_text = "you'll provide a response to the question"
+        present_prompt_text = "you'll provide a response to the prompt"
         missing_article = u'<article class="submission__answer__part__prompt'
         self.assertIn(present_prompt_text, body_html)
         self.assertNotIn(missing_article, body_html)

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -25,7 +25,7 @@ from .base import XBlockHandlerTestCase, scenario
 
 class SubmissionTest(XBlockHandlerTestCase):
     SUBMISSION = json.dumps({
-        "submission": ["This is my answer to the first question!", "This is my answer to the second question!"]
+        "submission": ["This is my answer to the first prompt!", "This is my answer to the second prompt!"]
     })
 
     @scenario('data/basic_scenario.xml', user_id='Bob')
@@ -37,8 +37,8 @@ class SubmissionTest(XBlockHandlerTestCase):
     def test_submit_answer_too_long(self, xblock):
         # Maximum answer length is 100K, once the answer has been JSON-encoded
         long_submission = json.dumps({
-            "submission": ["This is my answer to the first question!" * 100000,
-                           "This is my answer to the second question!"]
+            "submission": ["This is my answer to the first prompt!" * 100000,
+                           "This is my answer to the second prompt!"]
         })
         resp = self.request(xblock, 'submit', long_submission, response_format='json')
         self.assertFalse(resp[0])
@@ -576,7 +576,7 @@ class SubmissionRenderTest(XBlockHandlerTestCase):
     def test_integration(self, xblock):
         # Expect that the response step is open and displays the deadline
         resp = self.request(xblock, 'render_submission', json.dumps(dict()))
-        self.assertIn('Enter your response to the question', resp)
+        self.assertIn('Enter your response to the prompt', resp)
         self.assertIn('2999-05-06T00:00:00+00:00', resp)
 
         # Create a submission for the user


### PR DESCRIPTION
# [PI-131](https://openedx.atlassian.net/browse/PI-131)

Sandbox view at https://dahlia.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/graded_interactions/175e76c4951144a29d46211361266e0e/

<img width="887" alt="screen shot 2017-07-06 at 12 36 59 pm" src="https://user-images.githubusercontent.com/7373924/27922071-d982325c-6247-11e7-9221-25c2e09b0322.png">

@sstack22 @srpearce 

I applied the substitution in every location I could find (listed here), let me know if that's not desirable:
- leaderboard entries
- `This assignment has several steps. In the first step, you'll provide a response to the prompt.`
- peer assessment, showing the other user's "response to the prompt"
- `Enter your response to the prompt` placeholder
- staff assessment/debug tools showing the student's "response to the prompt"
- student training examples
- test code
