### PR TITLE
Update submissions and DRF versions.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 git+https://github.com/edx/XBlock.git@xblock-0.4.12#egg=XBlock==0.4.12
 
 # edx-submissions
-git+https://github.com/edx/edx-submissions.git@2.0.0#egg=edx-submissions==2.0.0
+git+https://github.com/edx/edx-submissions.git@2.0.1#egg=edx-submissions==2.0.1
 
 # Third Party Requirements
 boto>=2.32.1,<3.0.0
@@ -16,7 +16,7 @@ defusedxml==0.4.1
 django<1.9a0 # Resolves known bug on gemnasium. See TNL-6266
 django-extensions==1.5.9
 django-model-utils==2.3.1
-djangorestframework>=3.1,<3.3
+git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 dogapi==1.2.1
 jsonfield==1.0.3
 lazy==1.1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='1.4.4',
+    version='1.4.5',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
In order to upgrade the version of django-rest-framework used by edx-platform, this dependency needs to be updated as well. Update the dependencies and bump the version number.

https://openedx.atlassian.net/browse/PLAT-1604