### PR TITLE
Drop Workflow.uuid field

### DIFF
--- a/openassessment/tests/data/db_fixtures/feedback_on_assessment.json
+++ b/openassessment/tests/data/db_fixtures/feedback_on_assessment.json
@@ -4,7 +4,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "3884f3cc-d0ae-11e3-9820-14109fd8dc43",
       "created": "2014-04-30T21:27:24.236Z",
       "submission_uuid": "387d840a-d0ae-11e3-bb0e-14109fd8dc43",
       "modified": "2014-04-30T21:28:41.814Z",
@@ -18,7 +17,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "178beedc-d0ae-11e3-afc3-14109fd8dc43",
       "created": "2014-04-30T21:26:28.917Z",
       "submission_uuid": "1783758f-d0ae-11e3-b495-14109fd8dc43",
       "modified": "2014-04-30T21:28:49.284Z",

--- a/openassessment/tests/data/db_fixtures/feedback_only_criterion.json
+++ b/openassessment/tests/data/db_fixtures/feedback_only_criterion.json
@@ -4,7 +4,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "3884f3cc-d0ae-11e3-9820-14109fd8dc43",
       "created": "2014-04-30T21:27:24.236Z",
       "submission_uuid": "28cebeca-d0ab-11e3-a6ab-14109fd8dc43",
       "modified": "2014-04-30T21:28:41.814Z",
@@ -18,7 +17,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "178beedc-d0ae-11e3-afc3-14109fd8dc43",
       "created": "2014-04-30T21:26:28.917Z",
       "submission_uuid": "cf5190b8-d0aa-11e3-a734-14109fd8dc43",
       "modified": "2014-04-30T21:28:49.284Z",

--- a/openassessment/tests/data/db_fixtures/peer_assessed.json
+++ b/openassessment/tests/data/db_fixtures/peer_assessed.json
@@ -4,7 +4,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "3884f3cc-d0ae-11e3-9820-14109fd8dc43",
       "created": "2014-04-30T21:27:24.236Z",
       "submission_uuid": "28cebeca-d0ab-11e3-a6ab-14109fd8dc43",
       "modified": "2014-04-30T21:28:41.814Z",
@@ -18,7 +17,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "178beedc-d0ae-11e3-afc3-14109fd8dc43",
       "created": "2014-04-30T21:26:28.917Z",
       "submission_uuid": "cf5190b8-d0aa-11e3-a734-14109fd8dc43",
       "modified": "2014-04-30T21:28:49.284Z",

--- a/openassessment/tests/data/db_fixtures/scored.json
+++ b/openassessment/tests/data/db_fixtures/scored.json
@@ -4,7 +4,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "3884f3cc-d0ae-11e3-9820-14109fd8dc43",
       "created": "2014-04-30T21:27:24.236Z",
       "submission_uuid": "28cebeca-d0ab-11e3-a6ab-14109fd8dc43",
       "modified": "2014-04-30T21:28:41.814Z",
@@ -18,7 +17,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "178beedc-d0ae-11e3-afc3-14109fd8dc43",
       "created": "2014-04-30T21:26:28.917Z",
       "submission_uuid": "cf5190b8-d0aa-11e3-a734-14109fd8dc43",
       "modified": "2014-04-30T21:28:49.284Z",

--- a/openassessment/tests/data/db_fixtures/self_assessed.json
+++ b/openassessment/tests/data/db_fixtures/self_assessed.json
@@ -4,7 +4,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "3884f3cc-d0ae-11e3-9820-14109fd8dc43",
       "created": "2014-04-30T21:27:24.236Z",
       "submission_uuid": "28cebeca-d0ab-11e3-a6ab-14109fd8dc43",
       "modified": "2014-04-30T21:28:41.814Z",
@@ -18,7 +17,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "178beedc-d0ae-11e3-afc3-14109fd8dc43",
       "created": "2014-04-30T21:26:28.917Z",
       "submission_uuid": "cf5190b8-d0aa-11e3-a734-14109fd8dc43",
       "modified": "2014-04-30T21:28:49.284Z",

--- a/openassessment/tests/data/db_fixtures/submitted.json
+++ b/openassessment/tests/data/db_fixtures/submitted.json
@@ -4,7 +4,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "178beedc-d0ae-11e3-afc3-14109fd8dc43",
       "created": "2014-04-30T21:26:28.917Z",
       "submission_uuid": "cf5190b8-d0aa-11e3-a734-14109fd8dc43",
       "modified": "2014-04-30T21:28:49.284Z",

--- a/openassessment/tests/data/db_fixtures/unicode.json
+++ b/openassessment/tests/data/db_fixtures/unicode.json
@@ -413,7 +413,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "997dd6ca-d1f9-11e3-9c70-14109fd8dc43",
       "created": "2014-05-02T12:59:30.346Z",
       "submission_uuid": "99765973-d1f9-11e3-841a-14109fd8dc43",
       "modified": "2014-05-02T12:59:50.217Z",
@@ -427,7 +426,6 @@
     "model": "workflow.assessmentworkflow",
     "fields": {
       "status": "done",
-      "uuid": "8c5b94d1-d1f9-11e3-9ca3-14109fd8dc43",
       "created": "2014-05-02T12:59:08.311Z",
       "submission_uuid": "8c52cfdc-d1f9-11e3-953c-14109fd8dc43",
       "modified": "2014-05-02T12:59:54.943Z",

--- a/openassessment/workflow/migrations/0003_remove_unique_uuid.py
+++ b/openassessment/workflow/migrations/0003_remove_unique_uuid.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workflow', '0002_remove_django_extensions'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='assessmentworkflow',
+            name='uuid',
+            field=models.UUIDField(default=None, null=True),
+        ),
+    ]

--- a/openassessment/workflow/migrations/0004_reverse_gen_uuid.py
+++ b/openassessment/workflow/migrations/0004_reverse_gen_uuid.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models, transaction
+import uuid
+
+
+def gen_uuid(apps, schema_editor):
+    workflow_model_class = apps.get_model('workflow', 'AssessmentWorkflow')
+    total_len = workflow_model_class.objects.count()
+    current_index = 0
+    chunk_size = 1000
+    while current_index < total_len:
+        end_chunk = current + chunk_size if total_len - chunk_size >= current_index else total_len
+        with transaction.atomic():
+            for workflow in workflow_model_class.objects.all()[current_index:end_chunk].iterator():
+                workflow.uuid = uuid.uuid4()
+                workflow.save()
+        current_index = current_index + chunk_size
+
+
+class Migration(migrations.Migration):
+    """
+    If we want to undo the "remove uuid field" operation, we must do so in
+    multiple migrations to deal with the field being unique and non null.
+
+    https://docs.djangoproject.com/en/1.9/howto/writing-migrations/#migrations-that-add-unique-fields
+    """
+
+    dependencies = [
+        ('workflow', '0003_remove_unique_uuid'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrations.RunPython.noop, reverse_code=gen_uuid)
+    ]

--- a/openassessment/workflow/migrations/0005_remove_uuid.py
+++ b/openassessment/workflow/migrations/0005_remove_uuid.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workflow', '0004_reverse_gen_uuid'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='assessmentworkflow',
+            name='uuid',
+        ),
+    ]

--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -88,7 +88,6 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
     STAFF_ANNOTATION_TYPE = "staff_defined"
 
     submission_uuid = models.CharField(max_length=36, db_index=True, unique=True)
-    uuid = models.UUIDField(db_index=True, unique=True, default=uuid4)
 
     # These values are used to find workflows for a particular item
     # in a course without needing to look up the submissions for that item.


### PR DESCRIPTION
This PR will need to remain open for a while, as we want to deprecate usage of the field before running the migration to drop it in the database. Builds on https://github.com/edx/edx-ora2/pull/1034, I'll update this PR to pint at master after that lands.

Note that the migrations to drop the table are a set of 3 files, this allows for the migration to be reversible (since adding unique, non-null columns to a table is not a simple operation)