### PR TITLE
Upgrade edx-submissions, django-model-utils

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # edX Internal Requirements
-edx-submissions>=2.0.11,<3.0.0
+edx-submissions>=2.0.12,<3.0.0
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 git+https://github.com/edx/XBlock.git@xblock-1.0.1#egg=XBlock==1.0.1
 git+https://github.com/edx/xblock-sdk.git@v0.1.4#egg=xblock-sdk==0.1.4
@@ -8,7 +8,7 @@ git+https://github.com/edx/xblock-sdk.git@v0.1.4#egg=xblock-sdk==0.1.4
 boto3>=1.4.4,<2.0.0
 python-swiftclient>=3.1.0,<4.0.0
 defusedxml>=0.4.1,<1.0.0
-django-model-utils>=2.3.1,<3.0.0
+django-model-utils>=2.3.1
 django-nose>=1.4.1,<2.0.0
 dogapi>=1.2.1,<2.0.0
 jsonfield>=2.0.2,<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.0.1',
+    version='2.0.2',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
Bumps edx-submissions to 2.0.12 and removes the upward bound of django-model-utils for edx-platform's Django 1.11 upgrade.

- PLAT-1479