### PR TITLE
Be defensive against all types of example['answer']

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.1.0',
+    version='2.1.1',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
Per splunk:

```
Sep  6 15:04:04 ip-10-2-10-172 [service_variant=lms][openassessment.xblock.student_training_mixin][env:prod-edx-edxapp] ERROR [ip-10-2-10-172  18370] [student_training_mixin.py:56] - Could not render Learner Training step for submission 1d2281fb-a2da-477c-b1ae-51dc12cbff28.
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/openassessment/xblock/student_training_mixin.py", line 53, in render_student_training
    path, context = self.training_path_and_context()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/openassessment/xblock/student_training_mixin.py", line 133, in training_path_and_context
    if isinstance(example, dict) and isinstance(example['answer'], list) and isinstance(example['answer'][0], basestring):
IndexError: list index out of range
```