### PR TITLE
Move model imports into methods, enabling django upgrade

### DIFF
--- a/openassessment/xblock/course_items_listing_mixin.py
+++ b/openassessment/xblock/course_items_listing_mixin.py
@@ -8,7 +8,6 @@ import json
 from webob import Response
 from xblock.core import XBlock
 
-from openassessment.data import OraAggregateData
 from openassessment.xblock.staff_area_mixin import require_course_staff
 
 
@@ -25,5 +24,6 @@ class CourseItemsListingMixin(object):
         Get information about all ora2 blocks in the course with response count for each step.
 
         """
+        from openassessment.data import OraAggregateData
         responses = OraAggregateData.collect_ora2_responses(unicode(self.course_id))
         return Response(json.dumps(responses), content_type='application/json')

--- a/openassessment/xblock/grade_mixin.py
+++ b/openassessment/xblock/grade_mixin.py
@@ -9,11 +9,7 @@ from xblock.core import XBlock
 from django.utils.translation import ugettext as _
 
 from data_conversion import create_submission_dict
-from openassessment.assessment.api import peer as peer_api
-from openassessment.assessment.api import self as self_api
-from openassessment.assessment.api import staff as staff_api
 from openassessment.assessment.errors import PeerAssessmentError, SelfAssessmentError
-from submissions import api as sub_api
 
 
 class GradeMixin(object):
@@ -41,6 +37,8 @@ class GradeMixin(object):
         Returns:
             unicode: HTML content of the grade step.
         """
+        from submissions import api as sub_api
+
         # Retrieve the status of the workflow.  If no workflows have been
         # started this will be an empty dict, so status will be None.
         workflow = self.get_workflow_info()
@@ -84,6 +82,11 @@ class GradeMixin(object):
         Returns:
             tuple of context (dict), template_path (string)
         """
+        from openassessment.assessment.api import peer as peer_api
+        from openassessment.assessment.api import self as self_api
+        from openassessment.assessment.api import staff as staff_api
+        from submissions import api as sub_api
+
         # Peer specific stuff...
         assessment_steps = self.assessment_steps
         submission_uuid = workflow['submission_uuid']
@@ -186,6 +189,8 @@ class GradeMixin(object):
             Dict with keys 'success' (bool) and 'msg' (unicode)
 
         """
+        from openassessment.assessment.api import peer as peer_api
+
         feedback_text = data.get('feedback_text', u'')
         feedback_options = data.get('feedback_options', list())
 
@@ -245,6 +250,10 @@ class GradeMixin(object):
                 ...
             }
         """
+        from openassessment.assessment.api import peer as peer_api
+        from openassessment.assessment.api import self as self_api
+        from openassessment.assessment.api import staff as staff_api
+
         criteria = copy.deepcopy(self.rubric_criteria_with_labels)
 
         def has_feedback(assessments):
@@ -391,6 +400,8 @@ class GradeMixin(object):
             The option for the median peer grade.
 
         """
+        from openassessment.assessment.api import peer as peer_api
+
         median_scores = peer_api.get_assessment_median_scores(submission_uuid)
         median_score = median_scores.get(criterion['name'], None)
 

--- a/openassessment/xblock/leaderboard_mixin.py
+++ b/openassessment/xblock/leaderboard_mixin.py
@@ -9,7 +9,6 @@ from openassessment.assessment.errors import PeerAssessmentError, SelfAssessment
 from openassessment.fileupload import api as file_upload_api
 from openassessment.fileupload.exceptions import FileUploadError
 from openassessment.xblock.data_conversion import create_submission_dict
-from submissions import api as sub_api
 
 
 class LeaderboardMixin(object):
@@ -37,6 +36,7 @@ class LeaderboardMixin(object):
         Returns:
             unicode: HTML content of the leaderboard.
         """
+        from submissions import api as sub_api
         # Retrieve the status of the workflow.  If no workflows have been
         # started this will be an empty dict, so status will be None.
         workflow = self.get_workflow_info()
@@ -63,6 +63,7 @@ class LeaderboardMixin(object):
         Returns:
             template_path (string), tuple of context (dict)
         """
+        from submissions import api as sub_api
 
         # Retrieve top scores from the submissions API
         # Since this uses the read-replica and caches the results,

--- a/openassessment/xblock/self_assessment_mixin.py
+++ b/openassessment/xblock/self_assessment_mixin.py
@@ -5,7 +5,6 @@ from xblock.core import XBlock
 
 from openassessment.assessment.api import self as self_api
 from openassessment.workflow import api as workflow_api
-from submissions import api as submission_api
 
 from .data_conversion import (clean_criterion_feedback, create_rubric_dict, create_submission_dict,
                               verify_assessment_parameters)
@@ -53,6 +52,7 @@ class SelfAssessmentMixin(object):
             SubmissionError: Error occurred while retrieving the current submission.
             SelfAssessmentRequestError: Error occurred while checking if we had a self-assessment.
         """
+        from submissions import api as submission_api
 
         path = 'openassessmentblock/self/oa_self_unavailable.html'
         problem_closed, reason, start_date, due_date = self.is_closed(step="self-assessment")

--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -8,15 +8,10 @@ import logging
 
 from xblock.core import XBlock
 
-from openassessment.assessment.api import peer as peer_api
-from openassessment.assessment.api import self as self_api
-from openassessment.assessment.api import staff as staff_api
 from openassessment.assessment.errors import PeerAssessmentInternalError
-from openassessment.workflow import api as workflow_api
 from openassessment.workflow.errors import AssessmentWorkflowError, AssessmentWorkflowInternalError
 from openassessment.xblock.data_conversion import create_submission_dict
 from openassessment.xblock.resolve_dates import DISTANT_FUTURE, DISTANT_PAST
-from submissions import api as submission_api
 
 from .user_data import get_user_preferences
 
@@ -152,6 +147,7 @@ class StaffAreaMixin(object):
         """
         Returns a context with staff assessment "ungraded" and "in-progress" counts.
         """
+        from openassessment.assessment.api import staff as staff_api
         grading_stats = staff_api.get_staff_grading_statistics(course_id, item_id)
 
         return {
@@ -187,6 +183,8 @@ class StaffAreaMixin(object):
 
         Must be course staff to render this view.
         """
+        from openassessment.assessment.api import staff as staff_api
+        from submissions import api as submission_api
         try:
             student_item_dict = self.get_student_item_dict()
             course_id = student_item_dict.get('course_id')
@@ -286,6 +284,8 @@ class StaffAreaMixin(object):
         Args:
             student_username (unicode): The username of the student to report.
         """
+        from submissions import api as submission_api
+
         anonymous_user_id = None
         student_item = None
         submissions = None
@@ -323,6 +323,10 @@ class StaffAreaMixin(object):
             submission_uuid (unicode): The uuid of the submission, should NOT be None.
             context: the context to update with additional information
         """
+        from openassessment.assessment.api import peer as peer_api
+        from openassessment.assessment.api import self as self_api
+        from openassessment.assessment.api import staff as staff_api
+
         assessment_steps = self.assessment_steps
 
         self_assessment = None
@@ -392,6 +396,7 @@ class StaffAreaMixin(object):
         for a given problem. It will cancel the workflow using traditional methods to remove it from the grading pools,
         and pass through to the submissions API to orphan the submission so that the user can create a new one.
         """
+        from submissions import api as submission_api
         # Note that student_item cannot be constructed using get_student_item_dict, since we're in a staff context
         student_item = {
             'course_id': course_id,
@@ -447,6 +452,7 @@ class StaffAreaMixin(object):
 
         If requesting_user is not provided, we will use the user to which this xblock is currently bound.
         """
+        from openassessment.workflow import api as workflow_api
         try:
             assessment_requirements = self.workflow_requirements()
             if requesting_user_id is None:

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -7,7 +7,6 @@ from data_conversion import create_submission_dict, prepare_submission_for_seria
 from openassessment.fileupload import api as file_upload_api
 from openassessment.fileupload.exceptions import FileUploadError
 from openassessment.workflow.errors import AssessmentWorkflowError
-from submissions import api
 from validation import validate_submission
 
 from .resolve_dates import DISTANT_FUTURE
@@ -69,6 +68,7 @@ class SubmissionMixin(object):
                 associated status tag (str), and status text (unicode).
 
         """
+        from submissions import api
         if 'submission' not in data:
             return (
                 False,
@@ -225,6 +225,7 @@ class SubmissionMixin(object):
         return {'success': False, 'msg': self._(u"Files descriptions were not submitted.")}
 
     def create_submission(self, student_item_dict, student_sub_data, files_descriptions=None):
+        from submissions import api
 
         # Store the student's response text in a JSON-encodable dict
         # so that later we can add additional response fields.
@@ -433,6 +434,7 @@ class SubmissionMixin(object):
                 the front end.
 
         """
+        from submissions import api
         try:
             return api.get_submission(submission_uuid)
         except api.SubmissionRequestError:

--- a/openassessment/xblock/validation.py
+++ b/openassessment/xblock/validation.py
@@ -7,7 +7,6 @@ from openassessment.assessment.api.student_training import validate_training_exa
 from openassessment.assessment.serializers import InvalidRubric, rubric_from_dict
 from openassessment.xblock.data_conversion import convert_training_examples_list_to_dict
 from openassessment.xblock.resolve_dates import DateValidationError, InvalidDateFormat, resolve_dates
-from submissions.api import MAX_TOP_SUBMISSIONS
 
 
 def _match_by_order(items, others):
@@ -315,6 +314,7 @@ def validator(oa_block, _, strict_post_release=True):
     Returns:
         callable, of a form that can be passed to `update_from_xml`.
     """
+    from submissions.api import MAX_TOP_SUBMISSIONS
 
     def _inner(rubric_dict, assessments, leaderboard_show=0, submission_start=None, submission_due=None):
 


### PR DESCRIPTION
These changes rearrange model imports in order to enable Django 1.9+ support.

https://github.com/edx/edx-platform/pull/16110 confirms these changes do not break edx-platform tests under the existing Django 1.8.

fyi @doctoryes 