### PR TITLE
fix multi-response training essays

### DIFF
--- a/openassessment/xblock/data_conversion.py
+++ b/openassessment/xblock/data_conversion.py
@@ -95,7 +95,7 @@ def update_assessments_format(assessments):
                 if isinstance(example, dict) and isinstance(example['answer'], list) and example['answer']:
                     example['answer'] = {
                         'parts': [
-                            {'text': example['answer'][0]}
+                            {'text': example_answer} for example_answer in example['answer']
                         ]
                     }
     return assessments

--- a/openassessment/xblock/test/test_data_conversion.py
+++ b/openassessment/xblock/test/test_data_conversion.py
@@ -56,6 +56,7 @@ class DataConversionTest(TestCase):
     @ddt.data(
         ([{'answer': 'Ans'}], [{'answer': {'parts': [{'text': 'Ans'}]}}]),
         ([{'answer': ['Ans']}], [{'answer': {'parts': [{'text': 'Ans'}]}}]),
+        ([{'answer': ['Ans', 'Ans1']}], [{'answer': {'parts': [{'text': 'Ans'},{'text': 'Ans1'}]}}]),
         ([{'answer': []}], [{'answer': []}]),
     )
     @ddt.unpack


### PR DESCRIPTION
[EDUCATOR-1847](https://openedx.atlassian.net/browse/EDUCATOR-1847)
This PR is made in effort to fix issue with example responses of multiple prompts. In case of multiple prompts, example responses against these prompts were not showing up on studio and lms.
Further details are on mentioned on ticket.  
### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [x] Code review: @awaisdar001 