### PR TITLE
PLAT-1890 Fix allow_file_upload default value

### DIFF
--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -135,7 +135,7 @@ class OpenAssessmentBlock(MessageMixin,
     )
 
     allow_file_upload = Boolean(
-        default=None,
+        default=False,
         scope=Scope.content,
         help="Do not use. For backwards compatibility only."
     )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.1.6',
+    version='2.1.9',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
The `allow_file_upload` boolean xblock field has been defaulting to `None`, which just gets coerced to `False` on initialization after triggering a `ModifyingEnforceTypeWarning`.  Setting this to the more appropriate `False` value as part of a warning-squashing initiative in `edx-platform`.