### PR TITLE
Do not try to upload/submit when uploaded file is moved or deleted.

### DIFF
--- a/openassessment/xblock/static/js/spec/lms/oa_response.js
+++ b/openassessment/xblock/static/js/spec/lms/oa_response.js
@@ -702,4 +702,20 @@ describe("OpenAssessment.ResponseView", function() {
         expect(view.files).toEqual(null);
         expect($(view.element).find('.file__upload').first().is(':disabled')).toEqual(true);
     });
+
+     it("prevents user from uploading files when file is moved or deleted", function() {
+
+         spyOn(view.baseView, 'toggleActionError').and.callThrough();
+         view.fileUploadResponse = 'optional';
+
+         var file = [{type: 'image/jpeg', size: 0, name: 'picture.jpg', data: ''}];
+         view.prepareUpload(file, 'image', ['test1']);
+         view.uploadFiles();
+
+         expect(view.hasAllUploadFiles()).toEqual(false);
+         expect(view.baseView.toggleActionError).toHaveBeenCalledWith('upload',
+            "Your file " + file[0].name + " has been deleted or path has been changed.");
+
+
+    });
 });


### PR DESCRIPTION
## [Learner can submit a 'saved file description' without actually submitting a file. EDUCATOR-467](https://openedx.atlassian.net/browse/EDUCATOR-1933)

### Description
This PR fixes that all the files which are moved or deleted could not b uploaded and it throws error and will not save *saved file description* value.

### How to Test?

**stage** 

- Go to: https://courses.stage.edx.org/courses/course-v1:edx+aishaq+2016/courseware/6d17fb1d5881426f9c22043a4927240b/5651d34ad39d4a54b0525f9561655d28/?activate_block_id=block-v1%3Aedx%2Baishaq%2B2016%2Btype%40sequential%2Bblock%405651d34ad39d4a54b0525f9561655d28
- Enter text in text prompt.
- Click 'choose files', select a file. DO NOT click "upload files"
- Enter file description.
- On your computer, delete the chosen file or move it - i.e. make it un-upload-able.
- Click Submit. See pop-up asking whether you want to upload file and confirm submission. Click yes for both.
- See a brief flash of red error message in the platform. Then the message clears and see that your submission has been made without the file.
- As an instructor: Download a .csv for the problem location.
- Observe the submission state contains the 'saved_file_description' of the file that was not uploaded.

**sandbox** 
_*In progress.......*_

### Tests
 - [x] Jasmine Test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @efischer19 
- [ ] @Rabia23 


### Post-review
- [x] Rebase and squash commits
