### PR TITLE
add support for linkifying submissions

### DIFF
--- a/openassessment/templates/openassessmentblock/oa_submission_answer.html
+++ b/openassessment/templates/openassessmentblock/oa_submission_answer.html
@@ -1,5 +1,6 @@
 {% spaceless %}
 {% load i18n %}
+{% load oa_extras %}
 <ol class="submission__answer__display__content">
     {% for part in answer.parts %}
         <li class="submission__answer__part">
@@ -15,7 +16,7 @@
             <div class="submission__answer__part__text">
                 <h5 class="submission__answer__part__text__title">{{ answer_text_label }}</h5>
                 <div class="submission__answer__part__text__value">
-                    {{ part.text|linebreaks }}
+                    {{ part.text|escape|link_and_linebreak }}
                 </div>
             </div>
             {% endif %}

--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -1,5 +1,6 @@
 {% load tz %}
 {% load i18n %}
+{% load oa_extras %}
 {% spaceless %}
 {% block list_item %}
 <li class="openassessment__steps__step step--response is--in-progress is--showing ui-slidable__container"
@@ -99,7 +100,7 @@
                                         aria-describedby="submission__answer__tip__{{ xblock_id }}"
                                         placeholder="{% trans "Enter your response to the prompt above." %}"
                                         maxlength="100000"
-                                    >{{ part.text }}</textarea>
+                                    >{{ part.text|escape|link_and_linebreak }}</textarea>
                                 </div>
                                 {% with forloop.counter|stringformat:"s" as submission_num %}
                                     {% include "openassessmentblock/oa_latex_preview.html" with id="submission__"|add:xblock_id|add:submission_num elem="div" preview_name="submission__"|add:submission_num %}

--- a/openassessment/templatetags/oa_extras.py
+++ b/openassessment/templatetags/oa_extras.py
@@ -1,0 +1,20 @@
+from django import template
+from django.template.defaultfilters import linebreaks, stringfilter
+from django.utils.safestring import mark_safe
+from django.utils.html import conditional_escape
+from bleach import callbacks
+
+import bleach
+
+register = template.Library()
+
+
+@register.filter(needs_autoescape=True)
+@stringfilter
+def link_and_linebreak(text, autoescape=True):
+
+    if text and len(text) > 0:
+        the_text = conditional_escape(text)
+        return mark_safe(linebreaks(bleach.linkify(the_text, callbacks=[callbacks.target_blank])))
+    else:
+        return text

--- a/openassessment/tests/test_templatetags.py
+++ b/openassessment/tests/test_templatetags.py
@@ -1,0 +1,41 @@
+import ddt
+from django.template import Context, Template
+import unittest
+
+
+@ddt.ddt
+class OAExtrasTests(unittest.TestCase):
+
+    template = Template(
+        "{% load oa_extras %}"
+        "{{ text|link_and_linebreak }}"
+    )
+
+    @ddt.data(
+        ("", ""),
+        ('check this https://dummy-url.com', 'https://dummy-url.com'),
+        ('Visit this URL http://dummy-url.com', 'http://dummy-url.com'),
+        ('dummy-text http://dummy-url.org', 'http://dummy-url.org'),
+        ('dummy-url.com dummy-text', 'dummy-url.com')
+    )
+    @ddt.unpack
+    def test_link_and_linebreak(self, text, link_text):
+        rendered_template = self.template.render(Context({'text': text}))
+        self.assertIn(link_text, rendered_template)
+        if text:
+            self.assertRegexpMatches(
+                rendered_template,
+                r'<a.*target="_blank".*>{link_text}</a>'.format(link_text=link_text),
+            )
+
+    @ddt.data(
+        ("hello <script></script>", "script"),
+        ("http://dummy-url.com <applet></applet>", "applet"),
+        ("<iframe></iframe>", "iframe"),
+        ("<link></link>", "link"),
+    )
+    @ddt.unpack
+    def test_html_tags(self, text, tag):
+        rendered_template = self.template.render(Context({'text': text}))
+        escaped_tag = "&lt;{tag}&gt;".format(tag=tag)
+        self.assertIn(escaped_tag, rendered_template)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,6 +5,8 @@ git+https://github.com/edx/XBlock.git@xblock-1.0.1#egg=XBlock==1.0.1
 git+https://github.com/edx/xblock-sdk.git@v0.1.4#egg=xblock-sdk==0.1.4
 
 # Third Party Requirements
+bleach==1.4
+html5lib==0.999
 boto>=2.39.0,<3.0.0
 python-swiftclient>=3.1.0,<4.0.0
 defusedxml>=0.4.1,<1.0.0


### PR DESCRIPTION
Add support for linkifying learner ORA submission through use of custom django tag filter. 

NOTE: django urlize tag was considered but couldn't be used as it doesn't provide a way to set the target attribute of the <a> element and we need to be able to set it to _blank to force opening the link in a new tab. 

This PR currently uses the bleach library to linkify, but others could be considered and swapped in just as easily.