### PR TITLE
Updated travis validate translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ compile_translations:
 generate_dummy_translations:
 	i18n_tool dummy
 
+# Test translation files
+validate_translations:
+	cd ./openassessment/ && i18n_tool validate -v
+
 # check if translation files are up-to-date
 detect_changed_source_translations:
 	i18n_tool changed
@@ -60,7 +64,7 @@ push_translations:
 	tx push -s
 
 # extract, compile, and check if translation files are up-to-date
-validate_translations: extract_translations compile_translations generate_dummy_translations detect_changed_source_translations
+check_translations_up_to_date: extract_translations compile_translations generate_dummy_translations detect_changed_source_translations
 
 ################
 #Tests and checks

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
 # edX Internal Requirements
+edx-i18n-tools==0.4.4
 edx-submissions>=2.0.12,<3.0.0
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 git+https://github.com/edx/XBlock.git@xblock-1.0.1#egg=XBlock==1.0.1

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -1,4 +1,3 @@
 pep8==1.7.0
 
 git+https://github.com/edx/edx-lint.git@0.5.4#egg=edx_lint==0.5.4
-git+https://github.com/edx/i18n-tools.git@v0.3.9#egg=i18n_tools==0.3.9

--- a/tox.ini
+++ b/tox.ini
@@ -38,4 +38,5 @@ commands =
     npm install jscs --no-save
     make quality
     python manage.py makemessages -l eo
+    make check_translations_up_to_date
     make validate_translations


### PR DESCRIPTION
Updated travis to use the i18n-tools validate
to validate translations in pullrequests.
LEARNER-2556