### PR TITLE
Fix margin and orientation of arrows

### DIFF
--- a/openassessment/templates/openassessmentblock/grade/oa_grade_cancelled.html
+++ b/openassessment/templates/openassessmentblock/grade/oa_grade_cancelled.html
@@ -4,7 +4,7 @@
     <header class="step__header ui-slidable__control">
         <span>
             <button class="ui-slidable" aria-expanded="false" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labeledby="oa_step_title_grade">
-                <span class="icon fa fa-caret-down" aria-hidden="false"/>
+                <span class="icon fa fa-caret-right" aria-hidden="false"/>
             </button>
         </span>
 

--- a/openassessment/templates/openassessmentblock/grade/oa_grade_complete.html
+++ b/openassessment/templates/openassessmentblock/grade/oa_grade_complete.html
@@ -4,7 +4,7 @@
         <header class="step__header ui-slidable__control">
             <span>
                 <button class="ui-slidable" aria-expanded="true" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labeledby="oa_step_title_grade">
-                    <span class="icon fa fa-caret-down" aria-hidden="false"/>
+                    <span class="icon fa fa-caret-right" aria-hidden="false"/>
                 </button>
             </span>
 

--- a/openassessment/templates/openassessmentblock/grade/oa_grade_incomplete.html
+++ b/openassessment/templates/openassessmentblock/grade/oa_grade_incomplete.html
@@ -4,7 +4,7 @@
     <header class="step__header ui-slidable__control">
         <span>
             <button class="ui-slidable" aria-expanded="false" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labeledby="oa_step_title_grade">
-                <span class="icon fa fa-caret-down" aria-hidden="false"/>
+                <span class="icon fa fa-caret-right" aria-hidden="false"/>
             </button>
         </span>
 

--- a/openassessment/templates/openassessmentblock/grade/oa_grade_not_started.html
+++ b/openassessment/templates/openassessmentblock/grade/oa_grade_not_started.html
@@ -4,7 +4,7 @@
     <header class="step__header ui-slidable__control">
         <span>
             <button class="ui-slidable" aria-expanded="false" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labeledby="oa_step_title_grade">
-                <span class="icon fa fa-caret-down" aria-hidden="false"/>
+                <span class="icon fa fa-caret-right" aria-hidden="false"/>
             </button>
         </span>
 

--- a/openassessment/templates/openassessmentblock/grade/oa_grade_waiting.html
+++ b/openassessment/templates/openassessmentblock/grade/oa_grade_waiting.html
@@ -4,7 +4,7 @@
     <header class="step__header ui-slidable__control">
         <span>
             <button class="ui-slidable" aria-expanded="false" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labeledby="oa_step_title_grade">
-                <span class="icon fa fa-caret-down" aria-hidden="false"/>
+                <span class="icon fa fa-caret-right" aria-hidden="false"/>
             </button>
         </span>
 

--- a/openassessment/templates/openassessmentblock/peer/oa_peer_assessment.html
+++ b/openassessment/templates/openassessmentblock/peer/oa_peer_assessment.html
@@ -14,7 +14,7 @@
         <span>
             {% block button %}
                 <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labeledby="oa_step_title_peer">
-                    <span class="icon fa fa-caret-down" aria-hidden="false"/>
+                    <span class="icon fa fa-caret-right" aria-hidden="false"/>
                 </button>
             {% endblock %}
         </span>

--- a/openassessment/templates/openassessmentblock/peer/oa_peer_closed.html
+++ b/openassessment/templates/openassessmentblock/peer/oa_peer_closed.html
@@ -7,7 +7,7 @@
 
 {% block button %}
     <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labeledby="oa_step_title_peer">
-        <span class="icon fa fa-caret-down" aria-hidden="false"/>
+        <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}
 

--- a/openassessment/templates/openassessmentblock/peer/oa_peer_complete.html
+++ b/openassessment/templates/openassessmentblock/peer/oa_peer_complete.html
@@ -18,7 +18,7 @@
 
 {% block button %}
     <button class="ui-slidable" aria-expanded="false" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labeledby="oa_step_title_peer">
-        <span class="icon fa fa-caret-down" aria-hidden="false"/>
+        <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}
 

--- a/openassessment/templates/openassessmentblock/peer/oa_peer_turbo_mode.html
+++ b/openassessment/templates/openassessmentblock/peer/oa_peer_turbo_mode.html
@@ -13,7 +13,7 @@
 
 {% block button %}
     <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labeledby="oa_step_title_peer">
-        <span class="icon fa fa-caret-down" aria-hidden="false"/>
+        <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}
 

--- a/openassessment/templates/openassessmentblock/peer/oa_peer_turbo_mode_waiting.html
+++ b/openassessment/templates/openassessmentblock/peer/oa_peer_turbo_mode_waiting.html
@@ -7,7 +7,7 @@
 
 {% block button %}
     <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labeledby="oa_step_title_peer">
-        <span class="icon fa fa-caret-down" aria-hidden="false"/>
+        <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}
 

--- a/openassessment/templates/openassessmentblock/peer/oa_peer_waiting.html
+++ b/openassessment/templates/openassessmentblock/peer/oa_peer_waiting.html
@@ -8,7 +8,7 @@
 
 {% block button %}
     <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labeledby="oa_step_title_peer">
-        <span class="icon fa fa-caret-down" aria-hidden="false"/>
+        <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}
 

--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -11,7 +11,7 @@
         <span>
             {% block button %}
                 <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labeledby="oa_step_title_response">
-                    <span class="icon fa fa-caret-down" aria-hidden="false"/>
+                    <span class="icon fa fa-caret-right" aria-hidden="false"/>
                 </button>
             {% endblock %}
         </span>

--- a/openassessment/templates/openassessmentblock/response/oa_response_cancelled.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response_cancelled.html
@@ -10,7 +10,7 @@
 
 {% block button %}
     <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labeledby="oa_step_title_response">
-        <span class="icon fa fa-caret-down" aria-hidden="false"/>
+        <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}
 

--- a/openassessment/templates/openassessmentblock/response/oa_response_closed.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response_closed.html
@@ -8,7 +8,7 @@
 
 {% block button %}
     <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labeledby="oa_step_title_response">
-        <span class="icon fa fa-caret-down" aria-hidden="false"/>
+        <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}
 

--- a/openassessment/templates/openassessmentblock/response/oa_response_graded.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response_graded.html
@@ -9,7 +9,7 @@
 
 {% block button %}
     <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labeledby="oa_step_title_response">
-        <span class="icon fa fa-caret-down" aria-hidden="false"/>
+        <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}
 

--- a/openassessment/templates/openassessmentblock/response/oa_response_submitted.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response_submitted.html
@@ -9,7 +9,7 @@
 
 {% block button %}
     <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labeledby="oa_step_title_response">
-        <span class="icon fa fa-caret-down" aria-hidden="false"/>
+        <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}
 

--- a/openassessment/templates/openassessmentblock/self/oa_self_assessment.html
+++ b/openassessment/templates/openassessmentblock/self/oa_self_assessment.html
@@ -11,7 +11,7 @@
         <span>
             {% block button %}
                 <button class="ui-slidable" aria-expanded="true" id="oa_self_{{ xblock_id }}" aria-controls="oa_self_{{ xblock_id }}_content" aria-labeledby="oa_step_title_self">
-                    <span class="icon fa fa-caret-down" aria-hidden="false"/>
+                    <span class="icon fa fa-caret-right" aria-hidden="false"/>
                 </button>
             {% endblock %}
         </span>

--- a/openassessment/templates/openassessmentblock/self/oa_self_closed.html
+++ b/openassessment/templates/openassessmentblock/self/oa_self_closed.html
@@ -9,7 +9,7 @@
 
 {% block button %}
     <button class="ui-slidable" aria-expanded="true" id="oa_self_{{ xblock_id }}" aria-controls="oa_self_{{ xblock_id }}_content" aria-labeledby="oa_step_title_self">
-        <span class="icon fa fa-caret-down" aria-hidden="false"/>
+        <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}
 

--- a/openassessment/xblock/static/sass/oa/utilities/_shame.scss
+++ b/openassessment/xblock/static/sass/oa/utilities/_shame.scss
@@ -39,6 +39,7 @@
 
     .step__deadline {
       color: $heading-color;
+      margin-left: 5px;
     }
 
     // step title/name

--- a/openassessment/xblock/static/sass/oa/views/_oa-base.scss
+++ b/openassessment/xblock/static/sass/oa/views/_oa-base.scss
@@ -174,6 +174,7 @@
       .step__deadline {
         @extend %hd-4;
         color: $heading-color;
+        margin-left: 5px;
       }
     }
 


### PR DESCRIPTION


Change the orientation of arrows to be consistent with the rest of the
platform. Add a margin between due-date and header label.

WL-1507

Will look like this:
![ora-new-open](https://user-images.githubusercontent.com/27503539/37607191-ba4e3db4-2b6d-11e8-9cc9-dea6d568cf3e.png)
![ora-new-closed](https://user-images.githubusercontent.com/27503539/37607192-ba607bdc-2b6d-11e8-9636-0fe5ace0daa9.png)

