### PR TITLE
Set proper file extension on download

### DIFF
--- a/openassessment/fileupload/backends/base.py
+++ b/openassessment/fileupload/backends/base.py
@@ -20,6 +20,13 @@ class Settings(object):
         publicly viewable or all uploaded files will not be seen.
     """
     DEFAULT_FILE_UPLOAD_STORAGE_PREFIX = "submissions_attachments"
+    FILE_EXTENSIONS_BY_TYPE = {
+        'image/gif': '.gif',
+        'image/jpeg': '.jpg',
+        'image/pjpeg': '.jpg',
+        'image/png': '.png',
+        'application/pdf': '.pdf'
+    }
 
     @classmethod
     def get_bucket_name(cls):

--- a/openassessment/fileupload/tests/test_api.py
+++ b/openassessment/fileupload/tests/test_api.py
@@ -308,6 +308,17 @@ class TestFileUploadServiceWithFilesystemBackend(TestCase):
         result = self.backend.remove_file(self.key)
         self.assertFalse(result)
 
+    def test_file_extension_is_added_on_download(self):
+        self.set_key(u"myfile")
+        upload_url = self.backend.get_upload_url(self.key, self.content_type)
+        self.client.put(upload_url, data=self.content.read(), content_type=self.content_type)
+        download_url = self.backend.get_download_url(self.key)
+        download_response = self.client.get(download_url)
+        self.assertEqual(
+            "attachment; filename=myfile.jpg",
+            download_response.get('Content-Disposition')
+        )
+
 
 @override_settings(
     ORA2_FILEUPLOAD_BACKEND='swift',
@@ -460,3 +471,17 @@ class TestFileUploadServiceWithDjangoStorageBackend(TestCase):
         # File no longer exists
         download_url = self.backend.get_download_url(self.key)
         self.assertIsNone(download_url)
+
+    # def test_file_extension_is_added_on_download(self):
+        # self.key = u"myfile"
+        # upload_url = self.backend.get_upload_url(self.key, self.content_type)
+        # self.client.put(upload_url, data=self.content.read(), content_type=self.content_type)
+        # download_url = self.backend.get_download_url(self.key)
+
+        # download_response = self.client.get(download_url)
+        # print download_url
+        # print download_response
+        # self.assertEqual(
+            # "attachment; filename=myfile.txt",
+            # download_response.get('Content-Disposition')
+        # )

--- a/openassessment/fileupload/views_filesystem.py
+++ b/openassessment/fileupload/views_filesystem.py
@@ -43,8 +43,12 @@ def download_file(key):
         content_type = metadata.get("Content-Type", 'application/octet-stream')
     with open(file_path, 'r') as f:
         response = HttpResponse(f.read(), content_type=content_type)
-        file_name = os.path.basename(os.path.dirname(file_path))
-        response['Content-Disposition'] = 'attachment; filename=' + file_name
+
+    file_name = os.path.basename(os.path.dirname(file_path))
+    file_extension = Settings.FILE_EXTENSIONS_BY_TYPE.get(content_type, '')
+    if not file_name.endswith(file_extension):
+        file_name += file_extension
+    response['Content-Disposition'] = 'attachment; filename=' + file_name
     return response
 
 


### PR DESCRIPTION
This change is required because file keys no longer refer to the file
name. Unfortunately, we do not retrieve the former file name, just the
extension.
This is possible for the filesystem backend. I haven't managed to do so
for the django-storage backend.