### PR TITLE
EDUCATOR-2634: added missing prompts_type in context of different pages

### DIFF
--- a/openassessment/assessment/api/self.py
+++ b/openassessment/assessment/api/self.py
@@ -18,7 +18,7 @@ SELF_TYPE = "SE"
 logger = logging.getLogger("openassessment.assessment.api.self")
 
 
-def submitter_is_finished(submission_uuid, self_requirements):
+def submitter_is_finished(submission_uuid, self_requirements):  # pylint: disable=unused-argument
     """
     Check whether a self-assessment has been completed for a submission.
 
@@ -57,7 +57,7 @@ def assessment_is_finished(submission_uuid, self_requirements):
     return submitter_is_finished(submission_uuid, self_requirements)
 
 
-def get_score(submission_uuid, self_requirements):
+def get_score(submission_uuid, self_requirements):  # pylint: disable=unused-argument
     """
     Get the score for this particular assessment.
 

--- a/openassessment/assessment/api/staff.py
+++ b/openassessment/assessment/api/staff.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("openassessment.assessment.api.staff")
 STAFF_TYPE = "ST"
 
 
-def submitter_is_finished(submission_uuid, staff_requirements):
+def submitter_is_finished(submission_uuid, staff_requirements):  # pylint: disable=unused-argument
     """
     Determine if the submitter has finished their requirements for staff
     assessment. Always returns True.
@@ -124,7 +124,7 @@ def on_cancel(submission_uuid):
         raise StaffAssessmentInternalError(error_message)
 
 
-def get_score(submission_uuid, staff_requirements):
+def get_score(submission_uuid, staff_requirements):  # pylint: disable=unused-argument
     """
     Generate a score based on a completed assessment for the given submission.
     If no assessment has been completed for this submission, this will return

--- a/openassessment/assessment/views.py
+++ b/openassessment/assessment/views.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 
 @login_required()
-def get_evaluations_for_student_item(request, course_id, student_id, item_id):
+def get_evaluations_for_student_item(request, course_id, student_id, item_id):  # pylint: disable=unused-argument
     """Retrieve all evaluations associated with the given student item.
 
     Developer utility for accessing all the evaluations associated with a

--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -711,7 +711,7 @@ class AssessmentWorkflowStep(models.Model):
 
 
 @receiver(assessment_complete_signal)
-def update_workflow_async(sender, **kwargs):
+def update_workflow_async(sender, **kwargs):  # pylint: disable=unused-argument
     """
     Register a receiver for the update workflow signal
     This allows asynchronous processes to update the workflow

--- a/openassessment/xblock/grade_mixin.py
+++ b/openassessment/xblock/grade_mixin.py
@@ -24,7 +24,7 @@ class GradeMixin(object):
     """
 
     @XBlock.handler
-    def render_grade(self, data, suffix=''):
+    def render_grade(self, data, suffix=''):  # pylint: disable=unused-argument
         """
         Render the grade step.
 
@@ -142,6 +142,7 @@ class GradeMixin(object):
             ),
             'file_upload_type': self.file_upload_type,
             'allow_latex': self.allow_latex,
+            'prompts_type': self.prompts_type,
             'file_urls': self.get_download_urls_from_submission(student_submission),
             'xblock_id': self.get_xblock_id()
         }
@@ -176,7 +177,7 @@ class GradeMixin(object):
         )
 
     @XBlock.json_handler
-    def submit_feedback(self, data, suffix=''):
+    def submit_feedback(self, data, suffix=''):  # pylint: disable=unused-argument
         """
         Submit feedback on an assessment.
 

--- a/openassessment/xblock/leaderboard_mixin.py
+++ b/openassessment/xblock/leaderboard_mixin.py
@@ -23,7 +23,7 @@ class LeaderboardMixin(object):
     """
 
     @XBlock.handler
-    def render_leaderboard(self, data, suffix=''):
+    def render_leaderboard(self, data, suffix=''):  # pylint: disable=unused-argument
         """
         Render the leaderboard.
 
@@ -104,6 +104,7 @@ class LeaderboardMixin(object):
 
         context = {'topscores': scores,
                    'allow_latex': self.allow_latex,
+                   'prompts_type': self.prompts_type,
                    'file_upload_type': self.file_upload_type,
                    'xblock_id': self.get_xblock_id()}
 

--- a/openassessment/xblock/message_mixin.py
+++ b/openassessment/xblock/message_mixin.py
@@ -18,7 +18,7 @@ class MessageMixin(object):
     """
 
     @XBlock.handler
-    def render_message(self, data, suffix=''):
+    def render_message(self, data, suffix=''):  # pylint: disable=unused-argument
         """
         Render the message step.
 

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -460,7 +460,7 @@ class OpenAssessmentBlock(MessageMixin,
             additional_js=["static/js/lib/backgrid/backgrid%s.js" % min_postfix]
         )
 
-    def grade_available_responses_view(self, context=None):
+    def grade_available_responses_view(self, context=None):  # pylint: disable=unused-argument
         """Grade Available Responses view.
 
         Auxiliary view which displays the staff grading area
@@ -1067,7 +1067,7 @@ class OpenAssessmentBlock(MessageMixin,
         )
 
     @XBlock.json_handler
-    def publish_event(self, data, suffix=''):
+    def publish_event(self, data, suffix=''):  # pylint: disable=unused-argument
         """
         Publish the given data to an event.
 

--- a/openassessment/xblock/peer_assessment_mixin.py
+++ b/openassessment/xblock/peer_assessment_mixin.py
@@ -36,7 +36,7 @@ class PeerAssessmentMixin(object):
 
     @XBlock.json_handler
     @verify_assessment_parameters
-    def peer_assess(self, data, suffix=''):
+    def peer_assess(self, data, suffix=''):  # pylint: disable=unused-argument
         """Place a peer assessment into OpenAssessment system
 
         Assess a Peer Submission.  Performs basic workflow validation to ensure
@@ -129,7 +129,7 @@ class PeerAssessmentMixin(object):
             return {'success': False, 'msg': self._('Could not load peer assessment.')}
 
     @XBlock.handler
-    def render_peer_assessment(self, data, suffix=''):
+    def render_peer_assessment(self, data, suffix=''):  # pylint: disable=unused-argument
         """Renders the Peer Assessment HTML section of the XBlock
 
         Generates the peer assessment HTML for the first section of an Open
@@ -175,6 +175,7 @@ class PeerAssessmentMixin(object):
         context_dict = {
             "rubric_criteria": self.rubric_criteria_with_labels,
             "allow_latex": self.allow_latex,
+            "prompts_type": self.prompts_type,
             "user_timezone": user_preferences['user_timezone'],
             "user_language": user_preferences['user_language'],
             "xblock_id": self.get_xblock_id(),

--- a/openassessment/xblock/self_assessment_mixin.py
+++ b/openassessment/xblock/self_assessment_mixin.py
@@ -61,6 +61,7 @@ class SelfAssessmentMixin(object):
 
         context = {
             'allow_latex': self.allow_latex,
+            'prompts_type': self.prompts_type,
             "xblock_id": self.get_xblock_id(),
             'user_timezone': user_preferences['user_timezone'],
             'user_language': user_preferences['user_language']

--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -117,6 +117,7 @@ class StaffAreaMixin(object):
 
         # Include Latex setting
         context['allow_latex'] = self.allow_latex
+        context['prompts_type'] = self.prompts_type
 
         # Include release/due dates for each step in the problem
         context['step_dates'] = list()
@@ -262,7 +263,8 @@ class StaffAreaMixin(object):
             'rubric_criteria': copy.deepcopy(self.rubric_criteria_with_labels),
             'student_username': student_username,
             'user_timezone': user_preferences['user_timezone'],
-            'user_language': user_preferences['user_language']
+            'user_language': user_preferences['user_language'],
+            "prompts_type": self.prompts_type,
         }
 
         if submission:

--- a/openassessment/xblock/staff_assessment_mixin.py
+++ b/openassessment/xblock/staff_assessment_mixin.py
@@ -30,7 +30,7 @@ class StaffAssessmentMixin(object):
     @XBlock.json_handler
     @require_course_staff("STUDENT_INFO")
     @verify_assessment_parameters
-    def staff_assess(self, data, suffix=''):
+    def staff_assess(self, data, suffix=''):  # pylint: disable=unused-argument
         """
         Create a staff assessment from a staff submission.
         """
@@ -75,7 +75,7 @@ class StaffAssessmentMixin(object):
             return {'success': True, 'msg': u""}
 
     @XBlock.handler
-    def render_staff_assessment(self, data, suffix=''):
+    def render_staff_assessment(self, data, suffix=''):  # pylint: disable=unused-argument
         """
         Renders the Staff Assessment HTML section of the XBlock
         Generates the staff assessment HTML for the Open
@@ -122,7 +122,9 @@ class StaffAssessmentMixin(object):
             context = {
                 'status_value': self._('Not Available'),
                 'message_title': self._('Waiting for a Staff Grade'),
-                'message_content': self._('Check back later to see if a course staff member has assessed your response. You will receive your grade after the assessment is complete.'),
+                'message_content': self._('Check back later to see if a course staff member has assessed '
+                                          'your response. You will receive your grade after the assessment '
+                                          'is complete.'),
                 'step_classes': 'is--showing',
                 'button_active': 'aria-expanded=true',
             }
@@ -134,7 +136,9 @@ class StaffAssessmentMixin(object):
                     'status_value': self._('Complete'),
                     'icon_class': 'fa-check',
                     'message_title': self._('You Must Complete the Steps Above to View Your Grade'),
-                    'message_content': self._('Although a course staff member has assessed your response, you will receive your grade only after you have completed all the required steps of this problem.'),
+                    'message_content': self._('Although a course staff member has assessed your response, '
+                                              'you will receive your grade only after you have completed '
+                                              'all the required steps of this problem.'),
                     'step_classes': 'is--initially--collapsed',
                     'button_active': 'aria-expanded=false',
                 }

--- a/openassessment/xblock/student_training_mixin.py
+++ b/openassessment/xblock/student_training_mixin.py
@@ -67,7 +67,6 @@ class StudentTrainingMixin(object):
             if isinstance(parts[0].get('text'), basestring):
                 return create_submission_dict({'answer': answer}, self.prompts)
 
-
     def _parse_answer_list(self, answer):
         """
         Helper to parse answer as a list of strings.
@@ -77,13 +76,11 @@ class StudentTrainingMixin(object):
         elif len(answer) == 0:
             return self._parse_answer_string("")
 
-
     def _parse_answer_string(self, answer):
         """
         Helper to parse answer as a plain string
         """
         return create_submission_dict({'answer': {'parts': [{'text': answer}]}}, self.prompts)
-
 
     def _parse_example(self, example):
         """
@@ -135,6 +132,7 @@ class StudentTrainingMixin(object):
 
         # add allow_latex field to the context
         context['allow_latex'] = self.allow_latex
+        context['prompts_type'] = self.prompts_type
         context['user_timezone'] = user_preferences['user_timezone']
         context['user_language'] = user_preferences['user_language']
 

--- a/openassessment/xblock/studio_mixin.py
+++ b/openassessment/xblock/studio_mixin.py
@@ -58,7 +58,7 @@ class StudioMixin(object):
         help="The order to display assessments in the editor."
     )
 
-    def studio_view(self, context=None):
+    def studio_view(self, context=None):  # pylint: disable=unused-argument
         """
         Render the OpenAssessment XBlock for editing in Studio.
 
@@ -157,7 +157,7 @@ class StudioMixin(object):
         }
 
     @XBlock.json_handler
-    def update_editor_context(self, data, suffix=''):
+    def update_editor_context(self, data, suffix=''):  # pylint: disable=unused-argument
         """
         Update the XBlock's configuration.
 
@@ -253,7 +253,7 @@ class StudioMixin(object):
         return {'success': True, 'msg': self._(u'Successfully updated OpenAssessment XBlock')}
 
     @XBlock.json_handler
-    def check_released(self, data, suffix=''):
+    def check_released(self, data, suffix=''):  # pylint: disable=unused-argument
         """
         Check whether the problem has been released.
 

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -49,7 +49,7 @@ class SubmissionMixin(object):
     ]
 
     @XBlock.json_handler
-    def submit(self, data, suffix=''):
+    def submit(self, data, suffix=''):  # pylint: disable=unused-argument
         """Place the submission text into Openassessment system
 
         Allows submission of new responses.  Performs basic workflow validation
@@ -153,7 +153,7 @@ class SubmissionMixin(object):
         return status, status_tag, status_text
 
     @XBlock.json_handler
-    def save_submission(self, data, suffix=''):
+    def save_submission(self, data, suffix=''):  # pylint: disable=unused-argument
         """
         Save the current student's response submission.
         If the student already has a response saved, this will overwrite it.
@@ -193,7 +193,7 @@ class SubmissionMixin(object):
             return {'success': False, 'msg': self._(u"This response was not submitted.")}
 
     @XBlock.json_handler
-    def save_files_descriptions(self, data, suffix=''):
+    def save_files_descriptions(self, data, suffix=''):  # pylint: disable=unused-argument
         """
         Save the descriptions for each uploaded file.
 
@@ -456,7 +456,7 @@ class SubmissionMixin(object):
             u'This response has not been saved.')
 
     @XBlock.handler
-    def render_submission(self, data, suffix=''):
+    def render_submission(self, data, suffix=''):  # pylint: disable=unused-argument
         """Renders the Submission HTML section of the XBlock
 
         Generates the submission HTML for the first section of an Open

--- a/openassessment/xblock/test/data/student_training_mixin.json
+++ b/openassessment/xblock/test/data/student_training_mixin.json
@@ -16,6 +16,7 @@
                 ]}
             },
             "allow_latex": false,
+            "prompts_type": "text",
             "training_rubric": {
                 "criteria": [
                     {

--- a/openassessment/xblock/test/test_leaderboard.py
+++ b/openassessment/xblock/test/test_leaderboard.py
@@ -290,6 +290,7 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
             {
                 'topscores': scores,
                 'allow_latex': xblock.allow_latex,
+                'prompts_type': xblock.prompts_type,
                 'file_upload_type': xblock.file_upload_type,
                 'xblock_id': xblock.scope_ids.usage_id
             },

--- a/openassessment/xblock/test/test_peer.py
+++ b/openassessment/xblock/test/test_peer.py
@@ -309,6 +309,7 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             'must_grade': 5,
             'review_num': 1,
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': pytz.utc,
             'user_language': 'en'
         }
@@ -326,6 +327,7 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             'must_grade': 5,
             'review_num': 1,
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': pytz.utc,
             'user_language': 'en'
         }
@@ -343,6 +345,7 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             'must_grade': 5,
             'review_num': 1,
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': pytz.utc,
             'user_language': 'en'
         }
@@ -363,6 +366,7 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             'review_num': 1,
             'submit_button_text': 'submit your assessment & move to response #2',
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': pytz.utc,
             'user_language': 'en'
         }
@@ -404,6 +408,7 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             'peer_file_urls': [],
             'submit_button_text': 'submit your assessment & move to response #2',
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': pytz.utc,
             'user_language': 'en'
         }
@@ -425,6 +430,7 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             'review_num': 1,
             'submit_button_text': 'submit your assessment & move to response #2',
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': pytz.utc,
             'user_language': 'en'
         }
@@ -450,6 +456,7 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             'review_num': 1,
             'submit_button_text': 'submit your assessment & move to response #2',
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': pytz.utc,
             'user_language': 'en'
         }
@@ -487,6 +494,7 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             'review_num': 1,
             'submit_button_text': 'submit your assessment & move to response #2',
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': pytz.utc,
             'user_language': 'en'
         }
@@ -516,6 +524,7 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             'must_grade': 5,
             'review_num': 1,
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': pytz.utc,
             'user_language': 'en'
         }
@@ -550,6 +559,7 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             'rubric_criteria': xblock.rubric_criteria,
             'submit_button_text': 'Submit your assessment & review another response',
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': pytz.utc,
             'user_language': 'en'
         }
@@ -582,6 +592,7 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             'rubric_criteria': xblock.rubric_criteria,
             'submit_button_text': 'Submit your assessment & review another response',
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': pytz.utc,
             'user_language': 'en'
         }
@@ -605,6 +616,7 @@ class TestPeerAssessmentRender(XBlockHandlerTestCase):
             'rubric_criteria': xblock.rubric_criteria,
             'submit_button_text': 'Submit your assessment & review another response',
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': pytz.utc,
             'user_language': 'en'
         }

--- a/openassessment/xblock/test/test_self.py
+++ b/openassessment/xblock/test/test_self.py
@@ -175,6 +175,7 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
             {
                 'self_start': datetime.datetime(5999, 1, 1).replace(tzinfo=pytz.utc),
                 'allow_latex': False,
+                'prompts_type': 'text',
                 'user_timezone': pytz.utc,
                 'user_language': 'en'
             }
@@ -189,6 +190,7 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
             {
                 'self_due': datetime.datetime(2000, 1, 1).replace(tzinfo=pytz.utc),
                 'allow_latex': False,
+                'prompts_type': 'text',
                 'user_timezone': pytz.utc,
                 'user_language': 'en'
             }
@@ -201,6 +203,7 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
             xblock, 'openassessmentblock/self/oa_self_unavailable.html',
             {
                 'allow_latex': False,
+                'prompts_type': 'text',
                 'user_timezone': pytz.utc,
                 'user_language': 'en'
             }
@@ -218,6 +221,7 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
             xblock, 'openassessmentblock/self/oa_self_unavailable.html',
             {
                 'allow_latex': False,
+                'prompts_type': 'text',
                 'user_timezone': pytz.utc,
                 'user_language': 'en'
             }
@@ -235,6 +239,7 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
             xblock, 'openassessmentblock/self/oa_self_complete.html',
             {
                 'allow_latex': False,
+                'prompts_type': 'text',
                 'user_timezone': None,
                 'user_language': None
             },
@@ -257,6 +262,7 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
             xblock, 'openassessmentblock/self/oa_self_complete.html',
             {
                 'allow_latex': False,
+                'prompts_type': 'text',
                 'user_timezone': None,
                 'user_language': None
 
@@ -278,6 +284,7 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
             xblock, 'openassessmentblock/self/oa_self_complete.html',
             {
                 'allow_latex': False,
+                'prompts_type': 'text',
                 'user_timezone': None,
                 'user_language': None
             },
@@ -294,6 +301,7 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
             xblock, 'openassessmentblock/self/oa_self_cancelled.html',
             {
                 'allow_latex': False,
+                'prompts_type': 'text',
                 'user_timezone': pytz.utc,
                 'user_language': 'en'
             },
@@ -314,6 +322,7 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
                 'file_upload_type': None,
                 'self_file_urls': [],
                 'allow_latex': False,
+                'prompts_type': 'text',
                 'user_timezone': pytz.utc,
                 'user_language': 'en'
             },
@@ -339,6 +348,7 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
             xblock, 'openassessmentblock/self/oa_self_complete.html',
             {
                 'allow_latex': False,
+                'prompts_type': 'text',
                 'user_timezone': pytz.utc,
                 'user_language': 'en'
             },
@@ -359,6 +369,7 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
             {
                 'self_due': datetime.datetime(2000, 1, 1).replace(tzinfo=pytz.utc),
                 'allow_latex': False,
+                'prompts_type': 'text',
                 'user_timezone': pytz.utc,
                 'user_language': 'en'
             },
@@ -391,6 +402,7 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
             {
                 'self_due': datetime.datetime(2000, 1, 1).replace(tzinfo=pytz.utc),
                 'allow_latex': False,
+                'prompts_type': 'text',
                 'user_timezone': pytz.utc,
                 'user_language': 'en'
             },

--- a/openassessment/xblock/test/test_student_training.py
+++ b/openassessment/xblock/test/test_student_training.py
@@ -190,6 +190,7 @@ class StudentTrainingAssessTest(StudentTrainingTest):
         self.assertFalse(resp['corrections'])
         expected_context = {
             "allow_latex": False,
+            'prompts_type': 'text',
             'user_timezone': None,
             'user_language': None
         }
@@ -329,6 +330,7 @@ class StudentTrainingRenderTest(StudentTrainingTest):
         expected_context = {
             'training_due': "2000-01-01T00:00:00+00:00",
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': None,
             'user_language': None
         }
@@ -344,6 +346,7 @@ class StudentTrainingRenderTest(StudentTrainingTest):
         expected_template = "openassessmentblock/student_training/student_training_cancelled.html"
         expected_context = {
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': None,
             'user_language': None
         }
@@ -364,6 +367,7 @@ class StudentTrainingRenderTest(StudentTrainingTest):
         expected_context = {
             'training_start': datetime.datetime(3000, 1, 1).replace(tzinfo=pytz.utc),
             'allow_latex': False,
+            'prompts_type': 'text',
             'user_timezone': None,
             'user_language': None
         }


### PR DESCRIPTION
This PR has changes to add missing `prompts_type` in context of different pages. These changes should fix issue report [here](https://openedx.atlassian.net/browse/EDUCATOR-2634?focusedCommentId=315242&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-315242)