### PR TITLE
Bump edx-i18n-tools version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # edX Internal Requirements
-edx-i18n-tools==0.4.4
+edx-i18n-tools==0.4.5
 edx-submissions>=2.0.12,<3.0.0
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 git+https://github.com/edx/XBlock.git@xblock-1.0.1#egg=XBlock==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.1.15',
+    version='2.1.16',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
Bump from 0.4.4 to 0.4.5 (no change for this repo, just useful for downstream repos to not be pinned at 0.4.4).

Also bump ora2 release version to 2.1.16