### PR TITLE
Bump version to release i18n changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.1.17',
+    version='2.1.18',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
Bump version to release i18n changes.
Need to update edx-ora2 i18ntools version to update edx-platform i18ntools version. Need to updated edx-i18ntools version because current version is not supported and breaking extract_translations. 

Kindly Review @edx/learner-spartans 