### PR TITLE
Fix backward compatibility for older blocks' required text response

### DIFF
--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -252,7 +252,7 @@ class OpenAssessmentBlock(MessageMixin,
         Backward compatibility for existing blocks that were created without text_response
         or file_upload_response fields. These blocks will be treated as required text.
         """
-        if not self.file_upload_response and not self.text_response_raw:
+        if not self.file_upload_response_raw and not self.text_response_raw:
             return 'required'
         else:
             return self.text_response_raw


### PR DESCRIPTION
Older Ora2 blocks that required text responses but had optional file uploads would lose the required text response field because its checking `file_upload_response` instead of `file_upload_response_raw`