### PR TITLE
Proposal to display peer assessment results on the peer assessment step

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.1.18',
+    version='2.1.19',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
Sometimes in some cases students may need to see how they were assessed by the other students (before the final score was obtained). It could be presented as the little block in the "peer assessment" view similar to "Peer Assessments for This Learner" tab in the staff window. If you are interested in this feature I may provide my solution (will be good to merge it into master :slightly_smiling_face:  ):

-------

![001](https://user-images.githubusercontent.com/1876893/45585904-c7992180-b8f5-11e8-89be-3625a33c7f50.jpeg)

-------

![002](https://user-images.githubusercontent.com/1876893/45585907-cc5dd580-b8f5-11e8-9fe5-c461c7204d16.jpeg)

-------

![003](https://user-images.githubusercontent.com/1876893/45585909-d1228980-b8f5-11e8-9a36-c2a146b4463e.jpeg)

