### PR TITLE
Upgrade bleach to 2.1.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,8 +6,8 @@ git+https://github.com/edx/XBlock.git@xblock-1.0.1#egg=XBlock==1.0.1
 git+https://github.com/edx/xblock-sdk.git@v0.1.4#egg=xblock-sdk==0.1.4
 
 # Third Party Requirements
-bleach==1.4
-html5lib==0.999
+bleach==2.1.4
+html5lib==1.0.1
 boto>=2.39.0,<3.0.0
 python-swiftclient>=3.1.0,<4.0.0
 defusedxml>=0.4.1,<1.0.0


### PR DESCRIPTION
This PR is made in effort to upgrade `bleach` library to version 2.1.4 on edx-platform