### PR TITLE
Set proper extension on file attachment download

### DIFF
--- a/openassessment/fileupload/backends/base.py
+++ b/openassessment/fileupload/backends/base.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import abc
+import mimetypes
 
 import six
 
@@ -24,6 +25,13 @@ class Settings(object):
         publicly viewable or all uploaded files will not be seen.
     """
     DEFAULT_FILE_UPLOAD_STORAGE_PREFIX = "submissions_attachments"  # pylint: disable=invalid-name
+    FILE_EXTENSIONS_BY_TYPE = {
+        'image/gif': '.gif',
+        'image/jpeg': '.jpg',
+        'image/pjpeg': '.jpg',
+        'image/png': '.png',
+        'application/pdf': '.pdf'
+    }
 
     @classmethod
     def get_bucket_name(cls):
@@ -39,6 +47,16 @@ class Settings(object):
         Defaults to the DEFAULT_FILE_UPLOAD_STORAGE_PREFIX class attribute.
         """
         return getattr(settings, "FILE_UPLOAD_STORAGE_PREFIX", cls.DEFAULT_FILE_UPLOAD_STORAGE_PREFIX)
+
+    @classmethod
+    def guess_extension(cls, mime_type):
+        """
+        Guess a file extension (with a leading dot) given its mime type. If no
+        file is found, return an empty extension.
+        """
+        if mime_type in cls.FILE_EXTENSIONS_BY_TYPE:
+            return cls.FILE_EXTENSIONS_BY_TYPE[mime_type]
+        return mimetypes.guess_extension(mime_type) or ''
 
 
 class BaseBackend(six.with_metaclass(abc.ABCMeta, object)):

--- a/openassessment/fileupload/tests/test_api.py
+++ b/openassessment/fileupload/tests/test_api.py
@@ -310,6 +310,17 @@ class TestFileUploadServiceWithFilesystemBackend(TestCase):
         result = self.backend.remove_file(self.key)
         self.assertFalse(result)
 
+    def test_file_extension_is_added_on_download(self):
+        self.set_key(u"myfile")
+        upload_url = self.backend.get_upload_url(self.key, self.content_type)
+        self.client.put(upload_url, data=self.content.read(), content_type=self.content_type)
+        download_url = self.backend.get_download_url(self.key)
+        download_response = self.client.get(download_url)
+        self.assertEqual(
+            "attachment; filename=myfile.jpg",
+            download_response.get('Content-Disposition')
+        )
+
 
 @override_settings(
     ORA2_FILEUPLOAD_BACKEND='swift',

--- a/openassessment/fileupload/views_filesystem.py
+++ b/openassessment/fileupload/views_filesystem.py
@@ -46,8 +46,12 @@ def download_file(key):
         content_type = metadata.get("Content-Type", 'application/octet-stream')
     with open(file_path, 'r') as f:
         response = HttpResponse(f.read(), content_type=content_type)
-        file_name = os.path.basename(os.path.dirname(file_path))
-        response['Content-Disposition'] = 'attachment; filename=' + file_name
+
+    file_name = os.path.basename(os.path.dirname(file_path))
+    file_extension = Settings.guess_extension(content_type)
+    if not file_name.endswith(file_extension):
+        file_name += file_extension
+    response['Content-Disposition'] = 'attachment; filename=' + file_name
     return response
 
 


### PR DESCRIPTION
On attachment download, file extensions were no longer correctly set.
This was inconvenient because file extension could not be properly set.
For instance, instead of downloading "myattachment.pdf", the filename
was set to "hvriuehvrhjzkjpeofu1345RFV76cgfc" (without the ".pdf"
suffix).

This regression was introduced when file keys stopped referring to file
names. Now, we can no longer retrieve the original file name, just the
extension.

Note that the proposed fix works only for the "filesystem" backend: for
the "django" backend, we do not store the metadata associated to the
uploaded files. Thus, the original file content type is lost after the
upload.

This issue was raised a couple times publicly, although no formal issue
was created in the github repo:
2017-03: https://groups.google.com/forum/#!topic/edx-code/YJuNMeIaJi0
2018-03: https://openedx.slack.com/messages/C08B4LZEZ/convo/C08B4LZEZ-1521550202.000508/?thread_ts=1521550202.000508
2018-09: https://openedx.slack.com/messages/C08B4LZEZ/convo/C08B4LZEZ-1537270442.000100/