### PR TITLE
Fix file upload with django & filesystem backends

### DIFF
--- a/openassessment/fileupload/backends/django_storage.py
+++ b/openassessment/fileupload/backends/django_storage.py
@@ -2,7 +2,7 @@ import os
 
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
-from django.core.urlresolvers import reverse_lazy
+from django.core.urlresolvers import reverse
 
 from .base import BaseBackend
 
@@ -15,7 +15,7 @@ class Backend(BaseBackend):
         """
         Return the URL pointing to the ORA2 django storage upload endpoint.
         """
-        return reverse_lazy("openassessment-django-storage", kwargs={'key': key})
+        return reverse("openassessment-django-storage", kwargs={'key': key})
 
     def get_download_url(self, key):
         """

--- a/openassessment/fileupload/backends/filesystem.py
+++ b/openassessment/fileupload/backends/filesystem.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 import django.core.cache
-from django.core.urlresolvers import reverse_lazy
+from django.core.urlresolvers import reverse
 from django.utils.encoding import smart_text
 
 from .. import exceptions
@@ -47,7 +47,7 @@ class Backend(BaseBackend):
 
     def _get_url(self, key):
         key_name = self._get_key_name(key)
-        url = reverse_lazy("openassessment-filesystem-storage", kwargs={'key': key_name})
+        url = reverse("openassessment-filesystem-storage", kwargs={'key': key_name})
         return url
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.2.1',
+    version='2.2.2',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
`reverse_lazy` object cannot be dumped by `json.dumps`, which results in
TypeError when attempting to convert the xblock response to json.

Close #1139.