### PR TITLE
staff can override score even if learner has same score already earned

### DIFF
--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -325,8 +325,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
                     not old_score or
                     not self.STAFF_ANNOTATION_TYPE in [
                         annotation['annotation_type'] for annotation in old_score['annotations']
-                    ] or
-                    old_score['points_earned'] != new_staff_score['points_earned']
+                    ]
             ):
                 # Set the staff score using submissions api, and log that fact
                 self.set_staff_score(new_staff_score)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-3741

Sometimes there are cases when staff needs to override score even learner has earned the same score. This happens when learner has earned a score but has not completed other steps like peer assessment and staff wants to grade learner anyway.
This is allowed as per https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/open_response_assessments/Manage_ORA_Assignment.html#override-a-learner-s-assessment-grade