### PR TITLE
Fix file upload for S3 regions requiring Signature version 4

### DIFF
--- a/openassessment/fileupload/backends/s3.py
+++ b/openassessment/fileupload/backends/s3.py
@@ -66,8 +66,10 @@ def _connect_to_s3():
     # environment vars or configuration files instead.
     aws_access_key_id = getattr(settings, 'AWS_ACCESS_KEY_ID', None)
     aws_secret_access_key = getattr(settings, 'AWS_SECRET_ACCESS_KEY', None)
+    aws_s3_host = getattr(settings, 'AWS_S3_HOST', None)
 
     return boto.connect_s3(
         aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key
+        aws_secret_access_key=aws_secret_access_key,
+        host=aws_s3_host
     )


### PR DESCRIPTION
Passing the `host` parameter to boto's `connect_s3` method solves the issue and should not introduce new problems. It was suggested [on StackOverflow](https://stackoverflow.com/a/29451280/41387).

Without this fix we get the following error when using an S3 bucket from `eu-central-1` region:

```
File "/edx/app/edxapp/venvs/edxapp/src/ora2/openassessment/fileupload/api.py" in remove_file
  29.     return backends.get_backend().remove_file(key)
File "/edx/app/edxapp/venvs/edxapp/src/ora2/openassessment/fileupload/backends/s3.py" in remove_file
  49.         bucket = conn.get_bucket(bucket_name)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/boto/s3/connection.py" in get_bucket
  503.             return self.head_bucket(bucket_name, headers=headers)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/boto/s3/connection.py" in head_bucket
  550.                 response.status, response.reason, body)
Exception Value: S3ResponseError: 400 Bad Request
```