### PR TITLE
Bump to 2.2.3 (after S3 sig v4 revert)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.2.2',
+    version='2.2.3',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
@nedbat: Prepping this for Ironwood.2 so that we can at least get the commit that fixes uploads for folks using local disk instead of S3.