### PR TITLE
added logs for information in case of FileUploadError

### DIFF
--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -250,7 +250,15 @@ class SubmissionMixin(object):
                         except IndexError:
                             pass
                 except FileUploadError:
-                    pass
+                    logger.exception(
+                        u"FileUploadError for student_item: {student_item_dict}"
+                        u" and submission data: {student_sub_data} with file"
+                        "descriptions {files_descriptions}".format(
+                            student_item_dict=student_item_dict,
+                            student_sub_data=student_sub_data,
+                            files_descriptions=files_descriptions 
+                        )
+                    )
                 if key_to_save:
                     student_sub_dict['file_keys'].append(key_to_save)
                     student_sub_dict['files_descriptions'].append(file_description)
@@ -311,7 +319,7 @@ class SubmissionMixin(object):
             url = file_upload_api.get_upload_url(key, content_type)
             return {'success': True, 'url': url}
         except FileUploadError:
-            logger.exception("Error retrieving upload URL.")
+            logger.exception("FileUploadError:Error retrieving upload URL for the data:{data}.".format(data=data))
             return {'success': False, 'msg': self._(u"Error retrieving upload URL.")}
 
     @XBlock.json_handler

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.2.4',
+    version='2.2.5',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
### [PROD-370](https://openedx.atlassian.net/browse/PROD-370)

### Description
In edx-ora2, we have seen a few instances where for a submission, the file uploads run into some sort of error. We were only able to find out this information from the courseware_studentmodule table, where the state column had the information about the uploaded file description. Currently, our codebase isn't doing anything in case of FileUploadError. Since our initial investigation hinted towards this exception, a simple piece of logging has been added in this PR to get more information, if we were to see such a case in the future.