### PR TITLE
Allow extra keys in the editor schema.

### DIFF
--- a/openassessment/xblock/schema.py
+++ b/openassessment/xblock/schema.py
@@ -8,7 +8,16 @@ import dateutil
 from pytz import utc
 import six
 
-from voluptuous import All, Any, In, Invalid, Range, Required, Schema
+from voluptuous import (
+    All,
+    Any,
+    In,
+    Invalid,
+    Optional,
+    Range,
+    Required,
+    Schema,
+)
 
 
 def utf8_validator(value):
@@ -105,6 +114,7 @@ EDITOR_UPDATE_SCHEMA = Schema({
     'white_listed_file_types': utf8_validator,
     Required('allow_latex'): bool,
     Required('leaderboard_show'): int,
+    Optional('teams_enabled'): bool,
     Required('assessments'): [
         Schema({
             Required('name'): All(utf8_validator, In(VALID_ASSESSMENT_TYPES)),

--- a/openassessment/xblock/test/test_studio.py
+++ b/openassessment/xblock/test/test_studio.py
@@ -182,6 +182,16 @@ class StudioViewTest(XBlockHandlerTestCase):
         self.assertTrue(resp['success'], msg=resp.get('msg'))
         self.assertEqual(xblock.leaderboard_show, 42)
 
+    @scenario('data/basic_scenario.xml')
+    def test_update_editor_context_saves_teams_enabled(self, xblock):
+        data = copy.deepcopy(self.UPDATE_EDITOR_DATA)
+        data['teams_enabled'] = True
+        xblock.runtime.modulestore = MagicMock()
+        xblock.runtime.modulestore.has_published_version.return_value = False
+        resp = self.request(xblock, 'update_editor_context', json.dumps(data), response_format='json')
+        self.assertTrue(resp['success'], msg=resp.get('msg'))
+        self.assertTrue(xblock.teams_enabled)
+
     @file_data('data/invalid_update_xblock.json')
     @scenario('data/basic_scenario.xml')
     def test_update_context_invalid_request_data(self, xblock, data):

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.3.7',
+    version='2.3.8',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
Posts to the `update_editor_context` studio endpoint now allow an optional `teams_enabled` key.