### PR TITLE
dump response without escaping to render special characters

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -478,7 +478,7 @@ class OraAggregateData(object):
                 submission['student_item'],
                 student_item['student_id'],
                 submission['submitted_at'],
-                submission['answer'],
+                json.dumps(submission['answer'], ensure_ascii=False),
                 assessments_cell,
                 assessments_parts_cell,
                 score.get('created_at', ''),

--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -478,6 +478,7 @@ class OraAggregateData(object):
                 submission['student_item'],
                 student_item['student_id'],
                 submission['submitted_at'],
+                #  Dumping required to render special characters in CSV
                 json.dumps(submission['answer'], ensure_ascii=False),
                 assessments_cell,
                 assessments_parts_cell,

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -6,6 +6,7 @@ Tests for openassessment data aggregation.
 from __future__ import absolute_import, print_function
 
 import csv
+import json
 import os.path
 
 import ddt
@@ -365,6 +366,7 @@ class TestOraAggregateData(TransactionCacheResetTest):
         self.assertEqual(feedback_cell, "")
 
 
+@ddt.ddt
 class TestOraAggregateDataIntegration(TransactionCacheResetTest):
     """
     Test that OraAggregateData behaves as expected when integrated.
@@ -448,13 +450,12 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
             'Feedback Statements Selected',
             'Feedback on Peer Assessments'
         ])
-
         self.assertEqual(data[0], [
             self.scorer_submission['uuid'],
             self.scorer_submission['student_item'],
             SCORER_ID,
             self.scorer_submission['submitted_at'],
-            self.scorer_submission['answer'],
+            json.dumps(self.scorer_submission['answer']),
             u'',
             u'',
             u'',
@@ -463,13 +464,12 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
             u'',
             u'',
         ])
-
         self.assertEqual(data[1], [
             self.submission['uuid'],
             self.submission['student_item'],
             STUDENT_ID,
             self.submission['submitted_at'],
-            self.submission['answer'],
+            json.dumps(self.submission['answer']),
             u"Assessment #{id}\n-- scored_at: {scored_at}\n-- type: PE\n".format(
                 id=self.assessment['id'],
                 scored_at=self.assessment['scored_at'],
@@ -494,6 +494,25 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
             FEEDBACK_OPTIONS['options'][0] + '\n' + FEEDBACK_OPTIONS['options'][1] + '\n',
             FEEDBACK_TEXT,
         ])
+
+    @ddt.data(
+        u'ゅせ第1図', u'ぞひのぽ。', u"ГЂіи lіиэ ъэтшээи"
+    )
+    def test_collect_ora2_data_with_special_characters(self, answer):
+        """
+        Scenario: Verify the data collection for ORA2 works with special or non-ascii characters.
+
+        Given the submission object
+        Then update its answer with a non-ascii value
+        And the submission is saved
+        When the ORA2 data for the submissions is obtained
+        Then the data's answer will be same as json dumped answer
+        """
+        submission = sub_api._get_submission_model(self.submission['uuid'])  # pylint: disable=protected-access
+        submission.answer = answer
+        submission.save()
+        _, rows = OraAggregateData.collect_ora2_data(COURSE_ID)
+        self.assertEqual(json.dumps(answer, ensure_ascii=False), rows[1][4])
 
     def test_collect_ora2_responses(self):
         item_id2 = self._other_item(2)

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -496,7 +496,9 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
         ])
 
     @ddt.data(
-        u'ゅせ第1図', u'ぞひのぽ。', u"ГЂіи lіиэ ъэтшээи"
+        u'ゅせ第1図 ГЂіи', u"lіиэ ъэтшээи",
+        {'parts': [{'text': u'ぞひのぽ ГЂіи lіиэ ъэтшээи'}]},
+        {'files_descriptions': [u"Ámate a ti mismo primero y todo lo demás"]}
     )
     def test_collect_ora2_data_with_special_characters(self, answer):
         """

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.4.0",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.4.1',
+    version='2.4.2',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
### [PROD-996](https://openedx.atlassian.net/browse/PROD-996)

### Description
This PR is updating the way ORA submission data is collected by dumping the student response. This change is to ensure that special characters are rendered in the CSV and aren't represented in the form of code points.
Following is the sample output before and after the change:

#### Before
`"{u'file_keys': [], u'files_sizes': [], u'files_name': [], u'files_descriptions': [], u'parts': [{u'text': u'\u95a2\u4fc2\u306e\u8a71\u984c\u306f\u3001\u30c8 '}]}"`

#### After
`"{""file_keys"": [], ""files_sizes"": [], ""files_name"": [], ""files_descriptions"": [], ""parts"": [{""text"": ""関係の話題は、ト ""}]}"` 


### Sandbox
 - https://dawoudsheraz.sandbox.edx.org/courses/course-v1:arb+123+2019_T2/course/

### Reviewers
 - [x] @awaisdar001 
 - [x] @Ayub-Khan 

### Testing Instructions

1. Visit the test ORA.
2. Create a submission with some Unicode data
3. Go to the Instructor tab with a staff account and navigate to the `Data Download` section.
4. Click generate ora data
5. Since the report isn't uploaded on the S3 and is saved locally, SSH into the sandbox(I will be giving the SSH access).
6. Navigate to `/tmp/edx-s3/grades` folder. Move into the folder with some hash as its title.
7. The report should be there. Viewing the report will render the special characters