### PR TITLE
enhance FileUploadError exception logs

### DIFF
--- a/openassessment/fileupload/api.py
+++ b/openassessment/fileupload/api.py
@@ -58,7 +58,11 @@ def _safe_load_json_list(field):
     """
     try:
         return json.loads(field)
-    except ValueError:
+    except ValueError as exc:
+        logger.exception(u"JSON loads failed for field {field} with error {error}".format(
+            field=field,
+            error=exc
+        ))
         return []
 
 
@@ -98,7 +102,7 @@ class FileUpload(object):
             try:
                 return get_download_url(self.key)
             except FileUploadError:
-                logger.error('Error retrieving download URL for key {}.'.format(self.key))
+                logger.exception(u'FileUploadError: Error retrieving download URL for key {}.'.format(self.key))
                 return ''
 
     @property
@@ -190,7 +194,11 @@ class FileUploadManager(object):
                 names_to_add,
                 sizes_to_add,
             ) = self._dicts_to_key_lists(new_uploads, required_keys)
-        except FileUploadError:
+        except FileUploadError as exc:
+            logging.exception(u"FileUploadError: Metadata save for {data} failed with error {error}".format(
+                error=exc,
+                data=new_uploads
+            ))
             raise
 
         existing_file_descriptions, existing_file_names, existing_file_sizes = self._get_metadata_from_block()
@@ -282,7 +290,11 @@ class FileUploadManager(object):
             download_url = ''
             try:
                 download_url = get_download_url(file_key)
-            except FileUploadError:
+            except FileUploadError as exc:
+                logger.exception(u"FileUploadError: URL retrieval failed for key {key} with error {error}".format(
+                    key=file_key,
+                    error=exc
+                ))
                 pass
 
             if download_url:

--- a/openassessment/fileupload/api.py
+++ b/openassessment/fileupload/api.py
@@ -58,11 +58,7 @@ def _safe_load_json_list(field):
     """
     try:
         return json.loads(field)
-    except ValueError as exc:
-        logger.exception(u"JSON loads failed for field {field} with error {error}".format(
-            field=field,
-            error=exc
-        ))
+    except ValueError:
         return []
 
 
@@ -101,8 +97,11 @@ class FileUpload(object):
         if self.exists:
             try:
                 return get_download_url(self.key)
-            except FileUploadError:
-                logger.exception(u'FileUploadError: Error retrieving download URL for key {}.'.format(self.key))
+            except FileUploadError as exc:
+                logger.exception(u'FileUploadError: URL retrieval failed for key {key} with error {error}'.format(
+                    key=self.key,
+                    error=exc
+                ))
                 return ''
 
     @property
@@ -290,11 +289,7 @@ class FileUploadManager(object):
             download_url = ''
             try:
                 download_url = get_download_url(file_key)
-            except FileUploadError as exc:
-                logger.exception(u"FileUploadError: URL retrieval failed for key {key} with error {error}".format(
-                    key=file_key,
-                    error=exc
-                ))
+            except FileUploadError:
                 pass
 
             if download_url:

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -240,7 +240,10 @@ class SubmissionMixin(object):
                 {"saved_response": self.saved_files_descriptions}
             )
         except FileUploadError as exc:
-            logger.exception(six.text_type(exc))
+            logger.exception(u"FileUploadError: file description for data {data} failed with error {error}".format(
+                data=data,
+                error=exc
+            ))
             return {'success': False, 'msg': self._(u"Files metadata could not be saved.")}
 
         return {'success': True, 'msg': u''}
@@ -357,8 +360,11 @@ class SubmissionMixin(object):
         """
         try:
             return file_upload_api.get_download_url(self._get_student_item_key(file_num))
-        except FileUploadError:
-            logger.exception("Error retrieving download URL.")
+        except FileUploadError as exc:
+            logger.exception(u"FileUploadError: Download URL retrieval for filenum {num} failed with {error}".format(
+                error=exc,
+                num=file_num
+            ))
             return ''
 
     def _get_student_item_key(self, num=0):
@@ -391,7 +397,7 @@ class SubmissionMixin(object):
             if key:
                 url = file_upload_api.get_download_url(key)
         except FileUploadError:
-            logger.exception(u"Unable to generate download url for file key {}".format(key))
+            logger.exception(u"FileUploadError: Unable to generate download url for file key {}".format(key))
         return url
 
     def get_download_urls_from_submission(self, submission):

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -396,8 +396,11 @@ class SubmissionMixin(object):
         try:
             if key:
                 url = file_upload_api.get_download_url(key)
-        except FileUploadError:
-            logger.exception(u"FileUploadError: Unable to generate download url for file key {}".format(key))
+        except FileUploadError as exc:
+            logger.exception(u"FileUploadError: Download url for file key {key} failed with error {error}".format(
+                key=key,
+                error=exc
+            ))
         return url
 
     def get_download_urls_from_submission(self, submission):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.4.5',
+    version='2.4.6',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
### [PROD-1050](https://openedx.atlassian.net/browse/PROD-1050)

### Description
This PR is only adding/enhancing the FileUploadError log statements. There have been instances in ORA submissions where the file data wouldn't be saved alongside, even though the file was uploaded by the participant. These logs will help identify the potential point of failure. 
If none of the logs are hit for a future instance of incomplete submission, then it is highly likely that the `submission` entry is being created prior to successful file upload. 

```
submission_mixin.py:246 - FileUploadError: file description for data {u'fileMetadata': [{u'fileSize': 7, u'description': u'abc', u'fileName': u'test.txt'}]} failed with error Custom Raise
 ```

```
submission_mixin.py:367 - FileUploadError: Download URL retrieval for filenum 3 failed with Custom Raise
 ```

```
submission_mixin.py:403 - FileUploadError: Download url for file key 1eb2f9df643698e6195e05f093a830be/course-v1:myOrg+pd379+2019_T2/block-v1:myOrg+pd379+2019_T2+type@openassessment+block@55ae0ba307794cc9aab6891728f2d76c/3 failed with error Custom Raise
 ```

```
api.py:108 - FileUploadError: URL retrieval failed for key 1eb2f9df643698e6195e05f093a830be/course-v1:myOrg+pd379+2019_T2/block-v1:myOrg+pd379+2019_T2+type@openassessment+block@55ae0ba307794cc9aab6891728f2d76c/6 with error Custom Raise 
```

```
api.py:204 - FileUploadError: Metadata save for ({u'size': 7, u'description': u'it will fail', u'name': u'test.txt'},) failed with error Custom Raise
 ```