### PR TITLE
add student module support for upload info

### DIFF
--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -266,6 +266,12 @@ class StaffAreaMixin(object):
         if submission:
             context["file_upload_type"] = self.file_upload_type
             context["staff_file_urls"] = self.get_download_urls_from_submission(submission)
+            if self.should_use_user_state(context["staff_file_urls"]):
+                logger.info(u"Checking student module for upload info for user: {username} in block: {block}".format(
+                    username=student_username,
+                    block=str(self.location)
+                ))
+                context['staff_file_urls'] = self.get_files_info_from_user_state(student_username)
 
         if self.rubric_feedback_prompt is not None:
             context["rubric_feedback_prompt"] = self.rubric_feedback_prompt

--- a/openassessment/xblock/waffle_mixin.py
+++ b/openassessment/xblock/waffle_mixin.py
@@ -8,6 +8,8 @@ WAFFLE_NAMESPACE = 'openresponseassessment'
 
 TEAM_SUBMISSIONS = 'team_submissions'
 
+USER_STATE_UPLOAD_DATA = "user_state_upload_data"
+
 
 def import_waffle_switch():
     """
@@ -51,16 +53,27 @@ class WaffleMixin(object):
         CourseWaffleFlag = import_course_waffle_flag()  # pylint: disable=invalid-name
         return CourseWaffleFlag(WAFFLE_NAMESPACE, flag_name)  # pylint: disable=feature-toggle-needs-doc
 
-    def team_submissions_enabled(self):
+    def is_feature_enabled(self, flag):
         """
         Returns True if a WaffleSwitch or CourseWaffleFlag
-        for team submissions is enabled for this block,
-        False otherwise.
+        is enabled for this block, False otherwise.
         """
-        if self._waffle_switch(TEAM_SUBMISSIONS).is_enabled():
+        if self._waffle_switch(flag).is_enabled():
             return True
 
-        if self._course_waffle_flag(TEAM_SUBMISSIONS).is_enabled(self.location.course_key):
+        if self._course_waffle_flag(flag).is_enabled(self.location.course_key):
             return True
 
         return False
+
+    def team_submissions_enabled(self):
+        """
+        Returns a boolean specifying if the team submission is enabled.
+        """
+        return self.is_feature_enabled(TEAM_SUBMISSIONS)
+
+    def user_state_upload_data_enabled(self):
+        """
+        Returns a boolean indicating the user state upload data flag is enabled or not.
+        """
+        return self.is_feature_enabled(USER_STATE_UPLOAD_DATA)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.4.9",
+  "version": "2.5.0",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.4.9',
+    version='2.5.0',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
### [PROD-1053](https://openedx.atlassian.net/browse/PROD-1053)

### Description
We have had various instances where the file upload information in `submissions` was missing. Because of that, during the peer assessment or staff viewing the submission, the files' information is not visible. However, there is evidence that files were uploaded. Some file artifacts, like description, were present in the student module. The learners themselves could see the link to their files. There isn't enough information on why it is happening. In an attempt to streamline our behavior, this PR is introducing a workaround that will allow the staff members to see the uploaded files. By using the service introduced in https://github.com/edx/edx-platform/pull/22425, when staff renders a learner's submission and file upload was either optional/required, the files data will be obtained from CSM under certain conditions. The workaround will be hidden behind the waffle switch/course override **openresponseassessment.user_state_upload_data**. 

Following is the log which will tell if the CSM was queried for the upload information for a particular user:
```
staff_area_mixin.py:272 - Checking student module for upload info for user: edx in block: block-v1:myOrg+pd379+2019_T2+type@openassessment+block@fc057c43a31d43468e10fab58151a368
```

### Testing Instructions
**Note: Since the sandbox creation has been down for a few days, the reviewers will have to test it out on their local machines**

1. Fetch this platform branch on your local: https://github.com/edx/edx-platform/pull/22495
2. Install the requirements to bring in the changes.
3. Create an ORA problem that requires file upload.
4. Submit and verify entries that have been created in both CSM and submission.
5. Now, go to MySQL and update the submission's raw_answer for the latest entry like following:
`{"file_keys":[],"files_sizes":[],"parts":[{"text":"Hello 2"}],"files_descriptions":[],"files_names":[]}`
     -  This is an attempt to mimic the behavior happening on the production where upload information is empty

6. View the learner's submission using `Manage Individual Learners`. Note the file information isn't present(view the submission in courseware as the service is made part of runtime in module_render).
7. Now, either enable waffle switch/course override **openresponseassessment.user_state_upload_data**.
8. View submission again through `Manage Individual Learners`. The file link will be visible and the file will be downloadable.
9. Also, confirm the logs have been hit when using CSM.

### Tests
 - They will be added in a follow-up PR


### Reviewers
 - [x] @awaisdar001 
 - [ ] @iloveagent57 

