### PR TITLE
resource_string provides a byte string.

### DIFF
--- a/openassessment/xblock/studio_mixin.py
+++ b/openassessment/xblock/studio_mixin.py
@@ -89,7 +89,8 @@ class StudioMixin(object):
             self.add_javascript_files(fragment, "static/js/src/studio")
         else:
             # TODO: switch to add_javascript_url once XBlock resources are loaded from the CDN
-            fragment.add_javascript(pkg_resources.resource_string(__name__, "static/js/openassessment-studio.min.js"))
+            js_bytes = pkg_resources.resource_string(__name__, "static/js/openassessment-studio.min.js")
+            fragment.add_javascript(js_bytes.decode('utf-8'))
         js_context_dict = {
             "FILE_EXT_BLACK_LIST": self.FILE_EXT_BLACK_LIST,
         }

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.5.2',
+    version='2.5.3',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
Docs here: https://setuptools.readthedocs.io/en/latest/pkg_resources.html

The resource string provides bytes but we should convert to unicode as
soon as we get it for passing around purposes.

This data is eventually added as part of a json response so having a
byte string breaks that far downstream.