### PR TITLE
ORA File names not rendered

### DIFF
--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -432,7 +432,7 @@ class SubmissionMixin(object):
         if 'file_keys' in submission['answer']:
             file_keys = submission['answer'].get('file_keys', [])
             descriptions = submission['answer'].get('files_descriptions', [])
-            file_names = submission['answer'].get('files_name', [])
+            file_names = submission['answer'].get('files_name', submission['answer'].get('files_names', []))
             for idx, key in enumerate(file_keys):
                 file_download_url = self._get_url_by_file_key(key)
                 if file_download_url:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.5.2",
+  "version": "2.5.4",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.5.3',
+    version='2.5.4',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
In edX-Platform ORA file uploads don't show the names of the files for following: [`PROD-1093`](https://openedx.atlassian.net/browse/PROD-1093)
1. when viewed through the Manage Individual Learners section. 
2. peer assessment
3. Other than the above-mentioned artifacts, there can be other places where the name isn’t visible, The name data is in the database. This ticket is supposed to find out why the uploads' names aren't shown. 

**Issue :**
DB records are for file names are present with 2 different keys ie `files_name` and `files_names`

**Fix:**
This issue is fixed by updating the code to check for both attributes while data composition.