### PR TITLE
add logs for diagnostic

### DIFF
--- a/openassessment/fileupload/api.py
+++ b/openassessment/fileupload/api.py
@@ -51,7 +51,7 @@ def get_student_file_key(student_item_dict, index=0):
     return key_template.format(index=index, **student_item_dict)
 
 
-def _safe_load_json_list(field):
+def _safe_load_json_list(field, log_error=False):
     """
     Tries to load JSON-ified string,
     returns an empty list if we try to load some non-JSON-encoded string.
@@ -59,6 +59,11 @@ def _safe_load_json_list(field):
     try:
         return json.loads(field)
     except ValueError:
+        if log_error:
+            logger.exception("URLWorkaround: Safe Load failed for data field:{field} with type:{type}".format(
+                field=field,
+                type=type(field)
+            ))
         return []
 
 

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -466,9 +466,14 @@ class SubmissionMixin(object):
         item_dict = self.get_student_item_dict_from_username(username)
         if u'saved_files_descriptions' in user_state:
             # pylint: disable=protected-access
-            files_descriptions = file_upload_api._safe_load_json_list(user_state.get('saved_files_descriptions'))
-
-            files_names = file_upload_api._safe_load_json_list(user_state.get('saved_files_names', '[]'))
+            files_descriptions = file_upload_api._safe_load_json_list(
+                user_state.get('saved_files_descriptions'),
+                log_error=True
+            )
+            files_names = file_upload_api._safe_load_json_list(
+                user_state.get('saved_files_names', '[]'),
+                log_error=True
+            )
             for index, description in enumerate(files_descriptions):
                 file_key = file_upload_api.get_student_file_key(item_dict, index)
                 download_url = self._get_url_by_file_key(file_key)
@@ -477,6 +482,11 @@ class SubmissionMixin(object):
                     files_info.append((download_url, description, file_name))
                 else:
                     # If file has been removed, the URL doesn't exist
+                    logger.info("URLWorkaround: no URL for description {desc} & key {key} for user:{user}".format(
+                        desc=description,
+                        user=username,
+                        key=file_key
+                    ))
                     continue
         return files_info
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.5.2",
+  "version": "2.5.4",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.5.3',
+    version='2.5.4',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
### [PROD-1109](https://openedx.atlassian.net/browse/PROD-1109)

### Description
This PR is adding a few logs to identify where the URL generation is going wrong in user state workaround. Following are the sample logs:

```
submission_mixin.py:488 - URLWorkaround: no URL for description optional & key 1eb2f9df643698e6195e05f093a830be/course-v1:myOrg+pd379+2019_T2/block-v1:myOrg+pd379+2019_T2+type@openassessment+block@fc057c43a31d43468e10fab58151a368 for user:edx
```

```
api.py:66 - URLWorkaround: Safe Load failed for data field:["optional"] with type:<class 'str'>
```

```
api.py:66 - URLWorkaround: Safe Load failed for data field:["test.txt"] with type:<class 'str'>

```

### Reviewers
 - [x] @awaisdar001 

### Post Review
 - [x] Squash
 - [x] Version bump