### PR TITLE
add user state upload info unit tests

### DIFF
--- a/openassessment/xblock/test/data/file_upload_missing_scenario.xml
+++ b/openassessment/xblock/test/data/file_upload_missing_scenario.xml
@@ -1,0 +1,28 @@
+<openassessment file_upload_response="optional" file_upload_type="custom" white_listed_file_types="pdf,srt,txt">
+    <title>Open Assessment Test</title>
+    <prompts>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat poverty? Please answer in a short essay of 200-300 words.</description>
+        </prompt>
+    </prompts>
+    <rubric>
+        <criterion feedback="optional">
+        <name>Ideas</name>
+        <label>Ideas</label>
+        <prompt>Determine if there is a unifying theme or main idea.</prompt>
+        <option points="3">
+          <name>Fair</name>
+          <label>Fair</label>
+          <explanation>Presents a unifying theme or main idea, but may include minor tangents.  Stays somewhat focused on topic and task.</explanation>
+        </option>
+        <option points="5">
+          <name>Good</name>
+          <label>Good</label>
+          <explanation>Presents a unifying theme or main idea without going off on tangents.  Stays completely focused on topic and task.</explanation>
+        </option>
+      </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="staff-assessment" required="True"/>
+    </assessments>
+</openassessment>

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -23,6 +23,10 @@ from openassessment.xblock.data_conversion import prepare_submission_for_seriali
 from openassessment.xblock.test.base import XBlockHandlerTestCase, scenario
 from submissions import api as sub_api
 
+FILE_URL = 'www.fileurl.com'
+SAVED_FILES_DESCRIPTIONS = ['file1', 'file2']
+SAVED_FILES_NAMES = ['file1.txt', 'file2.txt']
+
 STUDENT_ITEM = dict(
     student_id="Bob",
     course_id="test_course",
@@ -63,6 +67,21 @@ class NullUserService(object):
         A convenience method.
         """
         return MagicMock(opt_attrs={})
+
+
+class UserStateService(object):
+    """
+    An implementation of `user_state` runtime service, to be utilized by tests.
+    """
+
+    def get_state_as_dict(self, username=None, location=None):  # pylint: disable=unused-argument
+        """
+        Returns a default state regardless of any passed params.
+        """
+        return {
+            u'saved_files_descriptions': json.dumps(SAVED_FILES_DESCRIPTIONS),
+            u'saved_files_names': json.dumps(SAVED_FILES_NAMES)
+        }
 
 
 @ddt.ddt
@@ -737,6 +756,66 @@ class TestCourseStaff(XBlockHandlerTestCase):
         resp = xblock.render_student_info(request)
         self.assertIn("response was not found", resp.body.decode('utf-8').lower())
 
+    @patch('openassessment.xblock.waffle_mixin.WaffleMixin.user_state_upload_data_enabled')
+    @scenario('data/file_upload_missing_scenario.xml', user_id='Bob')
+    def test_staff_area_student_upload_info_from_user_state(self, xblock, waffle_patch):
+        """
+        Verify the student upload info is retrieved correctly from the user state.
+
+        Scenario: When the upload info is missing from submission
+        And upload is either required or optional
+        And user state waffle flag is enabled
+        Then user state is used for getting the upload data, if present
+        """
+        waffle_patch.return_value = True
+        self._setup_xblock_and_create_submission(xblock)
+        with patch("openassessment.fileupload.api.get_download_url") as get_download_url:
+            get_download_url.return_value = FILE_URL
+            __, context = xblock.get_student_info_path_and_context('Bob')
+            staff_urls = context['staff_file_urls']
+            for count in range(2):
+                self.assertTupleEqual(
+                    staff_urls[count], (FILE_URL, SAVED_FILES_DESCRIPTIONS[count], SAVED_FILES_NAMES[count])
+                )
+
+    @patch('openassessment.xblock.waffle_mixin.WaffleMixin.user_state_upload_data_enabled')
+    @scenario('data/file_upload_missing_scenario.xml', user_id='Bob')
+    def test_staff_area_student_user_state_not_used(self, xblock, waffle_patch):
+        """
+        Verify the user state isn't used if the waffle flag isn't on.
+
+        Scenario: When the upload info is missing from submission
+        And upload is either required or optional
+        If the waffle flag is not set
+        Then user state is not used for the upload info
+        And there is no upload information present
+        """
+        waffle_patch.return_value = False
+        self._setup_xblock_and_create_submission(xblock)
+        __, context = xblock.get_student_info_path_and_context('Bob')
+        self.assertFalse(any(context['staff_file_urls']))
+
+    @patch('openassessment.xblock.waffle_mixin.WaffleMixin.user_state_upload_data_enabled')
+    @scenario('data/file_upload_missing_scenario.xml', user_id='Bob')
+    def test_student_userstate_not_used_when_upload_info_in_submission(self, xblock, waffle_patch):
+        """
+        Verify the user state isn't used if the upload info is present in submission.
+
+        Scenario: When the upload info is present in submission
+        And upload is either required or optional
+        If the waffle flag is set
+        Then user state is not used for the upload info
+        """
+        waffle_patch.return_value = True
+        self._setup_xblock_and_create_submission(xblock, **{
+            'files_keys': [FILE_URL, FILE_URL],
+            'files_descriptions': [SAVED_FILES_DESCRIPTIONS[1], SAVED_FILES_DESCRIPTIONS[0]],
+            'files_names': [SAVED_FILES_NAMES[1], SAVED_FILES_NAMES[0]]
+        })
+        __, context = xblock.get_student_info_path_and_context('Bob')
+        # To add logging based check here
+        self.assertFalse(any(context['staff_file_urls']))
+
     def _verify_staff_assessment_context(self, context, required, ungraded=None, in_progress=None):
         """
         Internal helper for common staff assessment context verification.
@@ -826,3 +905,26 @@ class TestCourseStaff(XBlockHandlerTestCase):
                 ],
                 context['staff_file_urls']
             )
+
+    def _setup_xblock_and_create_submission(self, xblock, **kwargs):
+        """
+        A shortcut method to setup ORA xblock and add a user submission to the block.
+        """
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, True, False, 'Bob'
+        )
+        # pylint: disable=protected-access
+        xblock.runtime._services['user'] = NullUserService()
+        xblock.runtime._services['user_state'] = UserStateService()
+
+        usage_id = xblock.scope_ids.usage_id
+        xblock.location = usage_id
+        student_item = STUDENT_ITEM.copy()
+        student_item["item_id"] = usage_id
+
+        self._create_submission(student_item, {
+            'text': "Text Answer",
+            'files_keys': kwargs.setdefault('files_keys', []),
+            'files_descriptions': kwargs.setdefault('files_descriptions', []),
+            'files_names': kwargs.setdefault('files_name', [])
+        }, ['staff'])

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,7 +16,7 @@ click-log==0.3.2
 click==7.0                # via click-log
 configparser==4.0.2
 contextlib2==0.6.0.post1
-coverage==5.0.1
+coverage==5.0.2
 ddt==1.0.0
 defusedxml==0.5.0
 django-model-utils==3.0.0
@@ -51,7 +51,7 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0
 moto==0.4.31
-packaging==19.2
+packaging==20.0
 path.py==8.2.1
 pathlib2==2.3.5
 pluggy==0.13.1
@@ -74,6 +74,7 @@ requests==2.22.0
 scandir==1.10.0
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.13.0
+testfixtures==6.10.3
 text-unidecode==1.3
 toml==0.10.0
 tox==3.14.3

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -13,7 +13,7 @@ certifi==2019.11.28
 chardet==3.0.4
 configparser==4.0.2
 contextlib2==0.6.0.post1
-coverage==5.0.1
+coverage==5.0.2
 ddt==1.0.0
 defusedxml==0.5.0
 django-model-utils==3.0.0
@@ -43,7 +43,7 @@ markupsafe==1.1.1
 mock==3.0.5
 more-itertools==5.0.0
 moto==0.4.31
-packaging==19.2
+packaging==20.0
 path.py==8.2.1
 pathlib2==2.3.5
 pluggy==0.13.1
@@ -63,6 +63,7 @@ requests==2.22.0
 scandir==1.10.0
 selenium==3.141.0
 six==1.13.0
+testfixtures==6.10.3
 text-unidecode==1.3
 toml==0.10.0
 tox==3.14.3

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -12,6 +12,7 @@ pytest==4.5.0
 pytest-cov==2.7.1                          # pytest extension for code coverage statistics
 pytest-django==3.7.0                       # pytest extension for better Django support
 moto
+testfixtures                        # Provides a LogCapture utility to be used by tests
 tox
 more-itertools
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,7 @@ certifi==2019.11.28
 chardet==3.0.4
 configparser==4.0.2       # via importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata
-coverage==5.0.1
+coverage==5.0.2
 ddt==1.0.0
 defusedxml==0.5.0
 django-model-utils==3.0.0
@@ -40,7 +40,7 @@ markupsafe==1.1.1
 mock==3.0.5
 more-itertools==5.0.0
 moto==0.4.31
-packaging==19.2           # via tox
+packaging==20.0           # via tox
 path.py==8.2.1
 pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
 pluggy==0.13.1            # via pytest, tox
@@ -57,6 +57,7 @@ pyyaml==5.2
 requests==2.22.0
 scandir==1.10.0           # via pathlib2
 six==1.13.0
+testfixtures==6.10.3
 text-unidecode==1.3       # via faker
 toml==0.10.0              # via tox
 tox==3.14.3


### PR DESCRIPTION
### [PROD-1097](https://openedx.atlassian.net/browse/PROD-1097)

### Description
This PR is adding the unit tests for the changes added in https://github.com/edx/edx-ora2/pull/1312. At that time, the changes had to be deployed due to increased escalations and tests were delayed for a follow-up PR. Other than the unit tests addition, a new dependency `testfixtures` has been made a part of the test environment. This willl allow to validate if certain logs were hit during the running of test suites. 