### PR TITLE
add workaround to get all the upload URLs for a user in a block

### DIFF
--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -404,11 +404,27 @@ class OpenAssessmentBlock(MessageMixin,
             and self.user_state_upload_data_enabled() \
             and self.file_upload_response
 
-    def get_student_item_dict_from_username(self, username):
+    def should_get_all_files_urls(self, upload_urls):
         """
-        Get the item dict for a given username in the parent course of block.
+        Returns a boolean to decide if all the file submitted by a learner in a block should be obtained.
+
+        Following conditions should be true for boolean to be true:
+        1. The waffle flag/switch is enabled
+        2. the file upload is required or optional
+        3. the file data from submission is missing information
+
+        Arguments:
+            upload_urls(list): A list of (file url, description, name) tuple, if info present, else empty list
         """
-        anonymous_user_id = self.get_anonymous_user_id(username, self.course_id)
+        return not any(upload_urls) \
+            and self.is_fetch_all_urls_waffle_enabled() \
+            and self.file_upload_response
+
+    def get_student_item_dict_from_username_or_email(self, username_or_email):
+        """
+        Get the item dict for a given username or email in the parent course of block.
+        """
+        anonymous_user_id = self.get_anonymous_user_id(username_or_email, self.course_id)
         return self.get_student_item_dict(anonymous_user_id=anonymous_user_id)
 
     def get_anonymous_user_id_from_xmodule_runtime(self):

--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -273,6 +273,16 @@ class StaffAreaMixin(object):
                 ))
                 context['staff_file_urls'] = self.get_files_info_from_user_state(student_username)
 
+                # This particular check is for the cases affected by the incorrect filenum bug
+                # and gets all the upload URLs if feature enabled.
+                if self.should_get_all_files_urls(context['staff_file_urls']):
+                    logger.info(
+                        u"Retrieving all uploaded files by user:{username} in block:{block}".format(
+                            username=student_username,
+                            block=str(self.location)
+                        ))
+                    context['staff_file_urls'] = self.get_all_upload_urls_for_user(student_username)
+
         if self.rubric_feedback_prompt is not None:
             context["rubric_feedback_prompt"] = self.rubric_feedback_prompt
 

--- a/openassessment/xblock/waffle_mixin.py
+++ b/openassessment/xblock/waffle_mixin.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import
 
 WAFFLE_NAMESPACE = 'openresponseassessment'
 
+ALL_FILES_URLS = "all_files_urls"
 TEAM_SUBMISSIONS = 'team_submissions'
-
 USER_STATE_UPLOAD_DATA = "user_state_upload_data"
 
 
@@ -77,3 +77,9 @@ class WaffleMixin(object):
         Returns a boolean indicating the user state upload data flag is enabled or not.
         """
         return self.is_feature_enabled(USER_STATE_UPLOAD_DATA)
+
+    def is_fetch_all_urls_waffle_enabled(self):
+        """
+        Returns a boolean indicating the all files urls feature flag is enabled or not.
+        """
+        return self.is_feature_enabled(ALL_FILES_URLS)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.5.9",
+  "version": "2.6.0",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.5.9',
+    version='2.6.0',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
### [PROD-1109](https://openedx.atlassian.net/browse/PROD-1109)

### Description
This PR is introducing a **staff only** workaround(in `Manage Individual Learner` section) for an extreme edge case(where the local file upload indices aren't in sync with the indices of the actual files in the file storage system. The problem in question is happening as:
1. The learner creates a submission with file uploads
2. Due to an arbitrary reason, their submission is deleted by the course team.
3. When doing re-submission, they can see the links to their previously uploaded files and an option to delete them. 
4. Upon pressing delete, the index inconsistency happens. The file is deleted but local data isn't(and can't be updated as indices aren't set properly).
5. When learners re-submits and uploads the number of files less than or equal to previously uploaded count, the file link isn't visible to anyone.

Due to index inconsistency, the files aren't visible. The workaround being added in this PR will allow the staff members to see all the uploaded files by the learner, but only the URLs. No description or file name will be visible. The view will look like:
![all_files_no_name_desc](https://user-images.githubusercontent.com/40599381/72134706-89572980-33a6-11ea-860a-f8000549ae5c.png)

This workaround is behind a waffle flag `openresponseassessment.all_files_urls` and needs another flag `openresponseassessment.user_state_upload_data` to be activated as well. User state feature was added in https://github.com/edx/edx-ora2/pull/1312. The decision of activating user state feature was made due to the fact that if the upload information isn't present in submission, use data from the user state. However, even if the user state data isn't enough and file upload was required/optional, it could point to the index inconsistency issue. An **important note** that it will be used for a few courses only to avoid very manual workarounds for previously inconsistent data.

A glimpse of logs that will be hit when using this workaround:
```
staff_area_mixin.py:279 - Retrieving all uploaded files by user:edx in block:block-v1:myOrg+pd379+2019_T2+type@openassessment+block@19ce88259abb4ab8947126a09d46970e
submission_mixin.py:523 - Download URL exists for key 1eb2f9df643698e6195e05f093a830be/course-v1:myOrg+pd379+2019_T2/block-v1:myOrg+pd379+2019_T2+type@openassessment+block@19ce88259abb4ab8947126a09d46970e/3 in block block-v1:myOrg+pd379+2019_T2+type@openassessment+block@19ce88259abb4ab8947126a09d46970e for user edx
submission_mixin.py:523 - Download URL exists for key 1eb2f9df643698e6195e05f093a830be/course-v1:myOrg+pd379+2019_T2/block-v1:myOrg+pd379+2019_T2+type@openassessment+block@19ce88259abb4ab8947126a09d46970e/4 in block block-v1:myOrg+pd379+2019_T2+type@openassessment+block@19ce88259abb4ab8947126a09d46970e for user edx
```

### Waffle added
 - ALL_FILES_URLS = "all_files_urls"

### Testing
1. Fetch this branch in your local ORA and checkout to it.
2. Create a ORA that requires file upload. Upload a few files.
3. Now, delete the submission using `Staff Debug Info` and load the page.
4. On loading, the submission can be made again, with the links to previously uploaded files visible 
![old_submission_view](https://user-images.githubusercontent.com/40599381/72135029-4fd2ee00-33a7-11ea-87d3-cca6d783f1c6.png)
5. Press delete file. There will be an error.
6. Now create a new submission and upload files there.
7. After the submission, see the file links aren't visible(or the count is less than the uploaded files). Same will be the case in Manage individual learner section.
8. Now, in `waffle_utils/waffleflagcourseoverridemodel/`, add `openresponseassessment.all_files_urls`
 and `openresponseassessment.user_state_upload_data` and enable them for your course with `Force On` value.
9. When viewing the submission via `Manage Individual Learner`, all the uploaded files, except for the deleted ones, will be visible to the staff.

### Reviewers
 - [x] @awaisdar001 
 - [x] @iloveagent57 

### Post Review
 - [x] Squash & Rebase commits
 - [x] Version bump
