### PR TITLE
EDUCATOR-4858 setup: track teamset id rather than name 

### DIFF
--- a/openassessment/templates/openassessmentblock/edit/oa_edit_basic_settings_list.html
+++ b/openassessment/templates/openassessmentblock/edit/oa_edit_basic_settings_list.html
@@ -160,8 +160,8 @@
                 <div class="wrapper-comp-setting">
                     <label for="openassessment_teamset_selector" class="setting-label">{% trans "Select Team Set"%}</label>
                     <select id="openassessment_teamset_selector" class="input setting-input" name="teamset selection">
-                        {% for teamset_name in teamset_names %}
-                            <option value='{{teamset_name}}' {% if selected_teamset_name == teamset_name %} selected="true" {% endif %}>{{teamset_name}}</option>
+                        {% for teamset in teamsets %}
+                            <option value='{{teamset.teamset_id}}' {% if selected_teamset_id == teamset.teamset_id %} selected="true" {% endif %}>{{teamset.name}}</option>
                         {% endfor %}
 
                     </select>

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -269,10 +269,10 @@ class OpenAssessmentBlock(MessageMixin,
         help="Whether team submissions are enabled for this case study.",
     )
 
-    selected_teamset_name = String(
+    selected_teamset_id = String(
         default=u"",
         scope=Scope.settings,
-        help="The name of the selected teamset.",
+        help="The id of the selected teamset.",
     )
 
     @property
@@ -1202,6 +1202,8 @@ class OpenAssessmentBlock(MessageMixin,
 
         """
         if hasattr(self, "xmodule_runtime"):
+            if self.xmodule_runtime.get_real_user is None:  # pylint: disable=no-member
+                return None
             user = self.xmodule_runtime.get_real_user(anonymous_user_id)  # pylint: disable=no-member
             if user:
                 return user

--- a/openassessment/xblock/schema.py
+++ b/openassessment/xblock/schema.py
@@ -115,7 +115,7 @@ EDITOR_UPDATE_SCHEMA = Schema({
     Required('allow_latex'): bool,
     Required('leaderboard_show'): int,
     Optional('teams_enabled'): bool,
-    Optional('selected_teamset_name'): utf8_validator,
+    Optional('selected_teamset_id'): utf8_validator,
     Required('assessments'): [
         Schema({
             Required('name'): All(utf8_validator, In(VALID_ASSESSMENT_TYPES)),

--- a/openassessment/xblock/static/js/src/oa_server.js
+++ b/openassessment/xblock/static/js/src/oa_server.js
@@ -452,7 +452,7 @@ if (typeof OpenAssessment.Server === "undefined" || !OpenAssessment.Server) {
                 allow_latex: options.latexEnabled,
                 leaderboard_show: options.leaderboardNum,
                 teams_enabled: options.teamsEnabled,
-                selected_teamset_name: options.selectedTeamsetName
+                selected_teamset_id: options.selectedTeamsetId
             });
             return $.Deferred(function(defer) {
                 $.ajax({

--- a/openassessment/xblock/static/js/src/studio/oa_edit.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit.js
@@ -209,7 +209,7 @@ OpenAssessment.StudioView.prototype = {
             leaderboardNum: view.settingsView.leaderboardNum(),
             editorAssessmentsOrder: view.settingsView.editorAssessmentsOrder(),
             teamsEnabled: view.settingsView.teamsEnabled(),
-            selectedTeamsetName: view.settingsView.teamset(),
+            selectedTeamsetId: view.settingsView.teamset(),
         }).done(
             // Notify the client-side runtime that we finished saving
             // so it can hide the "Saving..." notification.

--- a/openassessment/xblock/studio_mixin.py
+++ b/openassessment/xblock/studio_mixin.py
@@ -165,8 +165,8 @@ class StudioMixin(object):
             'teams_enabled': self.teams_enabled,
             'base_asset_url': self._get_base_url_path_for_course_assets(course_id),
             'is_released': self.is_released(),
-            'teamset_names': self.get_teamset_names(course_id),
-            'selected_teamset_name': self.selected_teamset_name,
+            'teamsets': self.get_teamsets(course_id),
+            'selected_teamset_id': self.selected_teamset_id,
         }
 
     @XBlock.json_handler
@@ -263,7 +263,7 @@ class StudioMixin(object):
         self.allow_latex = bool(data['allow_latex'])
         self.leaderboard_show = data['leaderboard_show']
         self.teams_enabled = bool(data.get('teams_enabled', False))
-        self.selected_teamset_name = data.get('selected_teamset_name', '')
+        self.selected_teamset_id = data.get('selected_teamset_id', '')
 
         return {'success': True, 'msg': self._(u'Successfully updated OpenAssessment XBlock')}
 
@@ -414,11 +414,11 @@ class StudioMixin(object):
             return None
         return team_configuration
 
-    def get_teamset_names(self, course_id):
+    def get_teamsets(self, course_id):
         """
         Wrapper around get_team_configuration that returns team names only for display
         """
         team_configuration = self.get_team_configuration(course_id)
         if not team_configuration:
             return None
-        return [teamset.name for teamset in team_configuration.teamsets]
+        return team_configuration.teamsets

--- a/openassessment/xblock/team_mixin.py
+++ b/openassessment/xblock/team_mixin.py
@@ -68,13 +68,15 @@ class TeamMixin(object):
         If we are course staff or in studio preview, return dummy data to
         render the page like a student would see
         """
-        if self.has_team():
+        if self.in_studio_preview:
+            return self.STAFF_OR_PREVIEW_INFO
+        elif self.has_team():
             return {
                 'team_name': self.team.name,
                 'team_usernames': [user.username for user in self.team.users.all()],
                 'team_url': self.teams_service.get_team_detail_url(self.team),
             }
-        elif self.is_course_staff or self.in_studio_preview:
+        elif self.is_course_staff:
             return self.STAFF_OR_PREVIEW_INFO
         else:
             return None

--- a/openassessment/xblock/test/test_studio.py
+++ b/openassessment/xblock/test/test_studio.py
@@ -135,13 +135,13 @@ class StudioViewTest(XBlockHandlerTestCase):
 
     @scenario('data/basic_scenario.xml')
     def test_render_studio_view(self, xblock):
-        self._mock_teamset_names_only(xblock)
+        self._mock_teamsets(xblock)
         frag = self.runtime.render(xblock, 'studio_view')
         self.assertTrue(frag.body_html().find('openassessment-edit'))
 
     @scenario('data/student_training.xml')
     def test_render_studio_with_training(self, xblock):
-        self._mock_teamset_names_only(xblock)
+        self._mock_teamsets(xblock)
         frag = self.runtime.render(xblock, 'studio_view')
         self.assertTrue(frag.body_html().find('openassessment-edit'))
 
@@ -155,7 +155,7 @@ class StudioViewTest(XBlockHandlerTestCase):
 
     @scenario('data/basic_scenario.xml')
     def test_include_leaderboard_in_editor(self, xblock):
-        self._mock_teamset_names_only(xblock)
+        self._mock_teamsets(xblock)
         xblock.leaderboard_show = 15
         self.assertEqual(xblock.editor_context()['leaderboard_show'], 15)
 
@@ -189,14 +189,14 @@ class StudioViewTest(XBlockHandlerTestCase):
     def test_update_editor_context_saves_teams_enabled(self, xblock):
         data = copy.deepcopy(self.UPDATE_EDITOR_DATA)
         data['teams_enabled'] = True
-        ts_name = 'selected_teamset'
-        data['selected_teamset_name'] = ts_name
+        ts_id = 'selected_teamsetid'
+        data['selected_teamset_id'] = ts_id
         xblock.runtime.modulestore = MagicMock()
         xblock.runtime.modulestore.has_published_version.return_value = False
         resp = self.request(xblock, 'update_editor_context', json.dumps(data), response_format='json')
         self.assertTrue(resp['success'], msg=resp.get('msg'))
         self.assertTrue(xblock.teams_enabled)
-        self.assertEqual(ts_name, xblock.selected_teamset_name)
+        self.assertEqual(ts_id, xblock.selected_teamset_id)
 
     @file_data('data/invalid_update_xblock.json')
     @scenario('data/basic_scenario.xml')
@@ -270,7 +270,7 @@ class StudioViewTest(XBlockHandlerTestCase):
 
     @scenario('data/self_then_peer.xml')
     def test_render_editor_assessment_order(self, xblock):
-        self._mock_teamset_names_only(xblock)
+        self._mock_teamsets(xblock)
         # Expect that the editor uses the order defined by the problem.
         self._assert_rendered_editor_order(xblock, [
             'student-training',
@@ -330,7 +330,7 @@ class StudioViewTest(XBlockHandlerTestCase):
 
     @scenario('data/basic_scenario.xml')
     def test_editor_context_assigns_labels(self, xblock):
-        self._mock_teamset_names_only(xblock)
+        self._mock_teamsets(xblock)
         # Strip out any labels from criteria/options that may have been imported.
         for criterion in xblock.rubric_criteria:
             if 'label' in criterion:
@@ -363,12 +363,13 @@ class StudioViewTest(XBlockHandlerTestCase):
 
     @scenario('data/basic_scenario.xml')
     def test_render_studio_with_teamset_names(self, xblock):
-        self._mock_teamset_names_only(xblock)
+        self._mock_teamsets(xblock)
         frag = self.runtime.render(xblock, 'studio_view')
         self.assertTrue(frag.body_html().find('teamset_name_a'))
+        self.assertTrue(frag.body_html().find('teamset_id_a'))
 
     @scenario('data/basic_scenario.xml')
-    def test_get_teamset_names(self, xblock):
+    def test_get_teamsets(self, xblock):
         xblock.xmodule_runtime = Mock(
             course_id='test_course',
             anonymous_student_id='test_student',
@@ -381,12 +382,15 @@ class StudioViewTest(XBlockHandlerTestCase):
         mock_team_configuration_service.get_teams_configuration.return_value = mock_teams_config
         xblock.runtime.service.return_value = mock_team_configuration_service
 
-        teamset_names = xblock.get_teamset_names("test_course")
-        self.assertEqual(teamset_names, [ts.name for ts in mock_teams_config.teamsets])
+        teamsets = xblock.get_teamsets("test_course")
+        self.assertEqual([ts.name for ts in teamsets], [ts.name for ts in mock_teams_config.teamsets])
 
-    def _mock_teamset_names_only(self, xblock):
+    def _mock_teamsets(self, xblock):
         """
         Bare bones mock to allow rendering tests to function as before
         """
-        xblock.get_teamset_names = Mock()
-        xblock.get_teamset_names.return_value = ["teamset_name_a", "teamset_name_b"]
+        xblock.get_teamsets = Mock()
+        xblock.get_teamsets.return_value = [
+            Mock(name="teamset_name_a", teamset_id='teamset_id_a'),
+            Mock(name="teamset_name_b", teamset_id='teamset_id_b'),
+        ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.6.0',
+    version='2.6.1',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
Some changes that were needed for [EDUCATOR-4858](https://openedx.atlassian.net/browse/EDUCATOR-4858)

I thought they were decent enough to chunk into their own PR.

- Track the ID of the teamset/topic rather than name since that's what we'll need for database lookups
- Changes to the template to reflect the above and to change the `value`s of the dropdowns
- A bugfix i thought I'd throw in here rather than opening a new ticket