### PR TITLE
EDUCATOR-4858: Change ORA teams logic to consider the xblock's chosen teamset

### DIFF
--- a/openassessment/xblock/team_mixin.py
+++ b/openassessment/xblock/team_mixin.py
@@ -38,7 +38,7 @@ class TeamMixin(object):
         if not user:
             logger.error(u'{}: User lookup for anonymous_user_id {} failed'.format(self.location, anonymous_user_id))
             raise ObjectDoesNotExist()
-        team = self.teams_service.get_team(user, self.course_id)
+        team = self.teams_service.get_team(user, self.course_id, self.selected_teamset_id)
         return team
 
     def has_team(self):

--- a/openassessment/xblock/test/test_team.py
+++ b/openassessment/xblock/test/test_team.py
@@ -31,7 +31,7 @@ class MockTeamsService(object):
             mock.MagicMock(username='UserC'),
         ]
 
-    def get_team(self, user, course_id):  # pylint: disable=unused-argument
+    def get_team(self, user, course_id, teamset_id):  # pylint: disable=unused-argument
         return self.team if self.has_team else None
 
 
@@ -40,6 +40,7 @@ class MockBlock(TeamMixin):
     Fixture class for testing ``TeamMixin``.
     """
     location = mock.MagicMock()
+    selected_teamset_id = "teamset-id-0001"
     get_anonymous_user_id_from_xmodule_runtime = mock.MagicMock()
     course_id = mock.MagicMock()
     is_course_staff = False

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.6.1',
+    version='2.6.2',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
[EDUCATOR-4858: Change ORA teams logic to consider the xblock's chosen teamset](https://openedx.atlassian.net/browse/EDUCATOR-4858)

Use new lms api to consider teamset when looking up team

