### PR TITLE
EDUCATOR-4870: Change 'teamless' message to include teamset name

### DIFF
--- a/openassessment/templates/openassessmentblock/message/oa_message_no_team.html
+++ b/openassessment/templates/openassessmentblock/message/oa_message_no_team.html
@@ -3,7 +3,13 @@
 <div id="openassessment__message__{{ xblock_id }}" class="message--warning openassessment__message message">
     <h4 class="message__title">{% trans "Team membership is required to view this assignment" %} </h4>
     <div class="message__content">
-        <p> {% trans "This is a team assignment for team set {{teamset_name}}. You are currently not on a team in team set {{teamset_name}}. You must be on a team in team set {{teamset_name}} to access this team assignment." %}</p>
+        <p> 
+            {% blocktrans %}
+            This is a team assignment for team set "{{ teamset_name }}".
+            You are currently not on a team in team set "{{teamset_name}}".
+            You must be on a team in team set "{{teamset_name}}" to access this team assignment.
+            {% endblocktrans %}
+        </p>
     </div>
 </div>
 {% endspaceless %}

--- a/openassessment/templates/openassessmentblock/message/oa_message_no_team.html
+++ b/openassessment/templates/openassessmentblock/message/oa_message_no_team.html
@@ -3,7 +3,7 @@
 <div id="openassessment__message__{{ xblock_id }}" class="message--warning openassessment__message message">
     <h4 class="message__title">{% trans "Team membership is required to view this assignment" %} </h4>
     <div class="message__content">
-        <p> {% trans "This is a team assignment. You are currently not on a team. You must be on a team to access this team assignment." %}</p>
+        <p> {% trans "This is a team assignment for team set {{teamset_name}}. You are currently not on a team in team set {{teamset_name}}. You must be on a team in team set {{teamset_name}} to access this team assignment." %}</p>
     </div>
 </div>
 {% endspaceless %}

--- a/openassessment/templates/openassessmentblock/message/oa_message_no_team.html
+++ b/openassessment/templates/openassessmentblock/message/oa_message_no_team.html
@@ -6,8 +6,8 @@
         <p> 
             {% blocktrans %}
             This is a team assignment for team set "{{ teamset_name }}".
-            You are currently not on a team in team set "{{teamset_name}}".
-            You must be on a team in team set "{{teamset_name}}" to access this team assignment.
+            You are currently not on a team in team set "{{ teamset_name }}".
+            You must be on a team in team set "{{ teamset_name }}" to access this team assignment.
             {% endblocktrans %}
         </p>
     </div>

--- a/openassessment/xblock/message_mixin.py
+++ b/openassessment/xblock/message_mixin.py
@@ -50,7 +50,7 @@ class MessageMixin(object):
         # Render the instruction message based on the status of the workflow
         # and the closed status.
         if self.teams_enabled and not self.valid_access_to_team_assessment():
-            path, context = 'openassessmentblock/message/oa_message_no_team.html', {}
+            path, context = self.render_message_no_team()
         elif status == "done" or status == "waiting":
             path, context = self.render_message_complete(status_details)
         elif problem_is_closed or active_step_deadline_info.get('is_closed'):
@@ -236,3 +236,14 @@ class MessageMixin(object):
             deadline_info.update(self_dict)
 
         return deadline_info
+
+    def render_message_no_team(self):
+        """
+        Render the message when the user is not part of a team in the selected teamset.
+        """
+        if self.teamset_config:
+            teamset_name = self.teamset_config.name
+        else:
+            teamset_name = '<id ' + self.selected_teamset_id + '>'
+        context = {'teamset_name': teamset_name}
+        return 'openassessmentblock/message/oa_message_no_team.html', context

--- a/openassessment/xblock/team_mixin.py
+++ b/openassessment/xblock/team_mixin.py
@@ -22,6 +22,15 @@ class TeamMixin(object):
             return self.runtime.service(self, 'teams')
         except NoSuchServiceError:
             logger.error(u'{}: Teams service unavailable'.format(self.location))
+            raise
+
+    @cached_property
+    def teams_config_service(self):
+        try:
+            return self.runtime.service(self, 'teams_config')
+        except NoSuchServiceError:
+            logger.error(u'{}: Teams Configuration service unavailable'.format(self.location))
+            raise
 
     @cached_property
     def team(self):
@@ -40,6 +49,14 @@ class TeamMixin(object):
             raise ObjectDoesNotExist()
         team = self.teams_service.get_team(user, self.course_id, self.selected_teamset_id)
         return team
+
+    @cached_property
+    def teamset_config(self):
+        teams_config = self.teams_config_service.get_teams_config(self.course_id)
+        try:
+            return teams_config.teamsets_by_id[self.selected_teamset_id]
+        except KeyError:
+            return None
 
     def has_team(self):
         """

--- a/openassessment/xblock/team_mixin.py
+++ b/openassessment/xblock/team_mixin.py
@@ -25,7 +25,7 @@ class TeamMixin(object):
             raise
 
     @cached_property
-    def teams_config_service(self):
+    def teams_configuration_service(self):
         try:
             return self.runtime.service(self, 'teams_configuration')
         except NoSuchServiceError:
@@ -53,7 +53,7 @@ class TeamMixin(object):
     @cached_property
     def teamset_config(self):
         course_id = self.location.course_key if hasattr(self, 'location') else None
-        teams_config = self.teams_config_service.get_teams_configuration(course_id)
+        teams_config = self.teams_configuration_service.get_teams_configuration(course_id)
         try:
             return teams_config.teamsets_by_id[self.selected_teamset_id]
         except KeyError:

--- a/openassessment/xblock/team_mixin.py
+++ b/openassessment/xblock/team_mixin.py
@@ -27,7 +27,7 @@ class TeamMixin(object):
     @cached_property
     def teams_config_service(self):
         try:
-            return self.runtime.service(self, 'teams_config')
+            return self.runtime.service(self, 'teams_configuration')
         except NoSuchServiceError:
             logger.error(u'{}: Teams Configuration service unavailable'.format(self.location))
             raise
@@ -52,7 +52,8 @@ class TeamMixin(object):
 
     @cached_property
     def teamset_config(self):
-        teams_config = self.teams_config_service.get_teams_config(self.course_id)
+        course_id = self.location.course_key if hasattr(self, 'location') else None
+        teams_config = self.teams_config_service.get_teams_configuration(course_id)
         try:
             return teams_config.teamsets_by_id[self.selected_teamset_id]
         except KeyError:

--- a/openassessment/xblock/test/data/message_scenario_staff_assessment_only.xml
+++ b/openassessment/xblock/test/data/message_scenario_staff_assessment_only.xml
@@ -1,0 +1,29 @@
+<openassessment submission_due="2099-01-23">
+    <title>Open Assessment Test</title>
+    <prompt>
+        Given the state of the world today, what do you think should be done to
+        combat poverty? Please answer in a short essay of 200-300 words.
+    </prompt>
+    <rubric>
+        <prompt>Read for conciseness, clarity of thought, and form.</prompt>
+        <criterion>
+            <name>Form</name>
+            <prompt>How well-formed is it?</prompt>
+            <option points="3">
+                <name>Good</name>
+                <explanation>Good</explanation>
+            </option>
+            <option points="2">
+                <name>Fair</name>
+                <explanation>Fair</explanation>
+            </option>
+            <option points="1">
+                <name>Poor</name>
+                <explanation>Poor</explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="staff-assessment" required="True"/>
+    </assessments>
+</openassessment>

--- a/openassessment/xblock/test/test_team.py
+++ b/openassessment/xblock/test/test_team.py
@@ -25,7 +25,7 @@ class MockTeamsConfigService(object):
         self.teamset = mock.MagicMock()
         self.teamset.configure_mock(name=TEAMSET_NAME)
 
-    def get_teams_config(self, _):
+    def get_teams_configuration(self, _):
         return mock.MagicMock(
             teamsets_by_id={TEAMSET_ID: self.teamset}
         )

--- a/openassessment/xblock/test/test_team.py
+++ b/openassessment/xblock/test/test_team.py
@@ -17,7 +17,7 @@ TEAMSET_ID = 'teamset-1-id'
 TEAMSET_NAME = 'teamset-1-name'
 
 
-class MockTeamsConfigService(object):
+class MockTeamsConfigurationService(object):
     """
     Fixture class for testing ``TeamMixin``.
     """
@@ -56,11 +56,11 @@ class MockRuntime(object):
     """
     Fixture class for testing ``TeamMixin``.
     """
-    def __init__(self, has_teams_service, has_team, has_teams_config_service):
+    def __init__(self, has_teams_service, has_team, has_teams_configuration_service):
         self.has_teams_service = has_teams_service
         self.teams_service = MockTeamsService(has_team)
-        self.has_teams_config_service = has_teams_config_service
-        self.teams_config_service = MockTeamsConfigService()
+        self.has_teams_configuration_service = has_teams_configuration_service
+        self.teams_configuration_service = MockTeamsConfigurationService()
 
     def service(self, _, service_name):
         """
@@ -70,8 +70,8 @@ class MockRuntime(object):
             if self.has_teams_service:
                 return self.teams_service
         elif service_name == 'teams_configuration':
-            if self.has_teams_config_service:
-                return self.teams_config_service
+            if self.has_teams_configuration_service:
+                return self.teams_configuration_service
         raise NoSuchServiceError()
 
 
@@ -87,10 +87,10 @@ class MockBlock(TeamMixin):
     in_studio_preview = False
 
     def __init__(
-        self, has_teams_service=True, has_teams_config_service=True,
+        self, has_teams_service=True, has_teams_configuration_service=True,
         has_user=True, has_team=True,
     ):
-        self.runtime = MockRuntime(has_teams_service, has_team, has_teams_config_service)
+        self.runtime = MockRuntime(has_teams_service, has_team, has_teams_configuration_service)
         self.has_user = has_user
 
     def get_real_user(self, anonymous_user_id):  # pylint: disable=unused-argument
@@ -147,8 +147,8 @@ class TeamMixinTest(TestCase):
         valid_access_to_team_assessment = block.valid_access_to_team_assessment()
         self.assertEqual(expected_valid, valid_access_to_team_assessment)
 
-    def test_teamset_config_no_teams_config_service(self):
-        block = MockBlock(has_teams_config_service=False)
+    def test_teamset_config_no_teams_configuration_service(self):
+        block = MockBlock(has_teams_configuration_service=False)
         with self.assertRaises(NoSuchServiceError):
             _ = block.teamset_config
 

--- a/openassessment/xblock/test/test_team.py
+++ b/openassessment/xblock/test/test_team.py
@@ -69,7 +69,7 @@ class MockRuntime(object):
         if service_name == 'teams':
             if self.has_teams_service:
                 return self.teams_service
-        elif service_name == 'teams_config':
+        elif service_name == 'teams_configuration':
             if self.has_teams_config_service:
                 return self.teams_config_service
         raise NoSuchServiceError()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.6.2',
+    version='2.6.3',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
[EDUCATOR-4870](https://openedx.atlassian.net/browse/EDUCATOR-4870)
@edx/masters-devs 

When a user tries to view a team-based ora for a teamset they are not in a team for, they are shown a screen telling them that they must be on a team before they can view this ORA.

This PR adds in several references to the name of the teamset that the user must be in, since in the future users will be able to be on multiple teams in a course, and getting a message saying "you aren't on a team" when you may be on several teams is unhelpful.

There is also a slight rework of some of the "mocking" in test_teams, since it turns out that some of the tests were just testing "mocked" behavior rather than actual behavior.

- [ ] https://github.com/edx/edx-platform/pull/22893 must be merged before this can be merged

<img width="696" alt="Screen Shot 2020-01-17 at 11 03 15 AM" src="https://user-images.githubusercontent.com/1639231/72626613-017a9d80-3919-11ea-9724-d468f6cd1917.png">
