### PR TITLE
Update some of the workaround submission methods

### DIFF
--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -483,7 +483,7 @@ class SubmissionMixin(object):
                 download_url = self._get_url_by_file_key(file_key)
                 if download_url:
                     file_name = files_names[index] if index < len(files_names) else ''
-                    files_info.append((download_url, description, file_name))
+                    files_info.append((download_url, description, file_name, False))
                 else:
                     # If file has been removed, the URL doesn't exist
                     logger.info("URLWorkaround: no URL for description {desc} & key {key} for user:{user}".format(
@@ -526,7 +526,7 @@ class SubmissionMixin(object):
                     user=username_or_email,
                     block=str(self.location)
                 ))
-                file_uploads.append((download_url, '', ''))
+                file_uploads.append((download_url, '', '', False))
             else:
                 continue
 

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -779,8 +779,15 @@ class TestCourseStaff(XBlockHandlerTestCase):
             staff_urls = context['staff_file_urls']
             for count in range(2):
                 self.assertTupleEqual(
-                    staff_urls[count], (FILE_URL, SAVED_FILES_DESCRIPTIONS[count], SAVED_FILES_NAMES[count])
+                    staff_urls[count], (FILE_URL, SAVED_FILES_DESCRIPTIONS[count], SAVED_FILES_NAMES[count], False)
                 )
+
+            self._verify_staff_assessment_rendering(
+                xblock,
+                'openassessmentblock/staff_area/oa_staff_grade_learners_assessment.html',
+                context,
+                FILE_URL,
+            )
 
     @patch('openassessment.xblock.waffle_mixin.WaffleMixin.user_state_upload_data_enabled')
     @scenario('data/file_upload_missing_scenario.xml', user_id='Bob')
@@ -857,8 +864,26 @@ class TestCourseStaff(XBlockHandlerTestCase):
         # Calling this method directly as using `get_student_info_path_and_context`
         # will use user state. This is because we are mocking get_download_url method.
         staff_urls = xblock.get_all_upload_urls_for_user('Bob')
-        expected_staff_urls = [(FILE_URL, '', '')] * xblock.MAX_FILES_COUNT
+        expected_staff_urls = [(FILE_URL, '', '', False)] * xblock.MAX_FILES_COUNT
         self.assertEqual(staff_urls, expected_staff_urls)
+
+        new_context = {key: value for key, value in context.items()}
+        new_context['staff_file_urls'] = staff_urls
+        self._verify_staff_assessment_rendering(
+            xblock,
+            'openassessmentblock/staff_area/oa_staff_grade_learners_assessment.html',
+            new_context,
+            FILE_URL,
+        )
+
+    def _verify_staff_assessment_rendering(self, xblock, template_path, context, *expected_strings):
+        """
+        The file upload template has a hard dependency on the length of the file description tuple,
+        so make sure we don't blow up when trying to render it with this context.
+        """
+        response = xblock.render_assessment(template_path, context_dict=context)
+        for expected_string in expected_strings:
+            self.assertIn(expected_string, response.body.decode('utf-8'))
 
     def _verify_staff_assessment_context(self, context, required, ungraded=None, in_progress=None):
         """

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.6.4',
+    version='2.6.5',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
There are a couple of "workaround" methods in the `SubmissionMixin` class that grab some file description tuples that are eventually rendered in the `oa_file_upload.html`, and I didn't account for the changing length of those tuples in my previous PR (#1332).  This PR updates those methods and introduces some test code that actually renders the template with the tuples produced in those workaround methods.