### PR TITLE
EDUCATOR-4910: Make the ORA file upload template deal with dictionaries instead of tuples

### DIFF
--- a/openassessment/templates/openassessmentblock/oa_team_uploaded_files.html
+++ b/openassessment/templates/openassessmentblock/oa_team_uploaded_files.html
@@ -10,25 +10,26 @@
         {% endif %}
 
         <div class="submission__answer__files">
-        {% for file_url, file_description, file_name, owner_username in team_file_urls %}
-            <div class="submission__answer__team__file__block submission__answer__team__file__block__{{ forloop.counter0 }}" {% if not file_url %} deleted {% endif %}>
-            {% if file_url %}
+        {# TeamFileDescriptor is defined in openassessment/fileupload/api.py #}
+        {% for team_file_descriptor in team_file_urls %}
+            <div class="submission__answer__team__file__block submission__answer__team__file__block__{{ forloop.counter0 }}" {% if not team_file_descriptor.download_url %} deleted {% endif %}>
+            {% if team_file_descriptor.download_url %}
                 {% if file_upload_type == "image" %}
-                    {% if file_description %}
-                    <div class="submission__file__description__label" id="file_description_{{ xblock_id }}_{{ including_template }}_{{ forloop.counter0 }}">{{ file_description }}:</div>
+                    {% if team_file_descriptor.description %}
+                    <div class="submission__file__description__label" id="file_description_{{ xblock_id }}_{{ including_template }}_{{ forloop.counter0 }}">{{ team_file_descriptor.description }}:</div>
                     {% endif %}
-                    <div><img class="submission__answer__file submission--image" src="{{ file_url }}"
+                    <div><img class="submission__answer__file submission--image" src="{{ team_file_descriptor.download_url }}"
                             aria-labelledby="file_description_{{ xblock_id }}_{{ including_template }}_{{ forloop.counter0 }}" /></div>
                 {% elif file_upload_type == "pdf-and-image" or file_upload_type == "custom" %}
-                    <a href="{{ file_url }}" class="submission__answer__file submission--file" target="_blank">
-                        {% if file_description %}
-                        {{ file_description }} ( {{file_name}} )
+                    <a href="{{ team_file_descriptor.download_url }}" class="submission__answer__file submission--file" target="_blank">
+                        {% if team_file_descriptor.description %}
+                        {{ team_file_descriptor.description }} ( {{team_file_descriptor.name}} )
                         {% else %}
                         {% trans "View the files associated with this submission:" %} #{{ forloop.counter }}
                         {% endif %}
                     </a>
                 {% endif %}
-                [{% trans "Uploaded by" %} <strong class="emphasis">{{ owner_username }}</strong>]
+                [{% trans "Uploaded by" %} <strong class="emphasis">{{ team_file_descriptor.uploaded_by }}</strong>]
             {% endif %}
             </div>
         {% endfor %}

--- a/openassessment/templates/openassessmentblock/oa_uploaded_file.html
+++ b/openassessment/templates/openassessmentblock/oa_uploaded_file.html
@@ -17,26 +17,27 @@
           </h5>
         {% endif %}
         <div class="submission__answer__files">
-        {% for file_url, file_description, file_name, show_delete_button in file_urls %}
-            <div class="submission__answer__file__block submission__answer__file__block__{{ forloop.counter0 }}" {% if not file_url %} deleted {% endif %}>
-            {% if file_url %}
+        {# FileDescriptor is defined in openassessment/fileupload/api.py #}
+        {% for file_descriptor in file_urls %}
+            <div class="submission__answer__file__block submission__answer__file__block__{{ forloop.counter0 }}" {% if not file_descriptor.download_url %} deleted {% endif %}>
+            {% if file_descriptor.download_url %}
                 {% if file_upload_type == "image" %}
-                    {% if file_description %}
-                    <div class="submission__file__description__label" id="file_description_{{ xblock_id }}_{{ including_template }}_{{ forloop.counter0 }}">{{ file_description }}:</div>
+                    {% if file_descriptor.description %}
+                    <div class="submission__file__description__label" id="file_description_{{ xblock_id }}_{{ including_template }}_{{ forloop.counter0 }}">{{ file_descriptor.description }}:</div>
                     {% endif %}
-                    <div><img class="submission__answer__file submission--image" src="{{ file_url }}"
+                    <div><img class="submission__answer__file submission--image" src="{{ file_descriptor.download_url }}"
                             aria-labelledby="file_description_{{ xblock_id }}_{{ including_template }}_{{ forloop.counter0 }}" /></div>
                 {% elif file_upload_type == "pdf-and-image" or file_upload_type == "custom" %}
-                    <a href="{{ file_url }}" class="submission__answer__file submission--file" target="_blank">
-                        {% if file_description %}
-                        {{ file_description }} ( {{file_name}} )
+                    <a href="{{ file_descriptor.download_url }}" class="submission__answer__file submission--file" target="_blank">
+                        {% if file_descriptor.description %}
+                        {{ file_descriptor.description }} ( {{file_descriptor.name}} )
                         {% else %}
                         {% trans "View the files associated with this submission:" %} #{{ forloop.counter }}
                         {% endif %}
                     </a>
                 {% endif %}
-                {% if enable_delete_files and show_delete_button %}
-                    <button class="delete__uploaded__file" filenum="{{ forloop.counter0 }}" aria-label="Delete {{ file_description }} ({{file_name}})">
+                {% if enable_delete_files and file_descriptor.show_delete_button %}
+                    <button class="delete__uploaded__file" filenum="{{ forloop.counter0 }}" aria-label="Delete {{ file_descriptor.description }} ({{file_descriptor.name}})">
                         Delete File
                     </button>
                 {% endif %}


### PR DESCRIPTION
[EDUCATOR-4910](https://openedx.atlassian.net/browse/EDUCATOR-4910)

avoid unpacking tuples

I used object property notation rather than dict because it's available