### PR TITLE
EDUCATOR-4914: The oa_response_submitted template should include team file URLs in its context

### DIFF
--- a/openassessment/templates/openassessmentblock/response/oa_response_graded.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response_graded.html
@@ -32,6 +32,8 @@
 
                 {% trans "Your Uploaded Files"  as translated_header %}
                 {% include "openassessmentblock/oa_uploaded_file.html" with file_upload_type=file_upload_type file_urls=file_urls header=translated_header class_prefix="submission__answer" including_template="response_graded" xblock_id=xblock_id %}
+
+                {% include "openassessmentblock/oa_team_uploaded_files.html" with file_upload_type=file_upload_type team_file_urls=team_file_urls class_prefix="submission__team__answer" including_template="response_graded" xblock_id=xblock_id %}
             </article>
         </div>
     </div>

--- a/openassessment/templates/openassessmentblock/response/oa_response_submitted.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response_submitted.html
@@ -53,6 +53,8 @@
 
                 {% trans "Your Uploaded Files"  as translated_header %}
                 {% include "openassessmentblock/oa_uploaded_file.html" with file_upload_type=file_upload_type file_urls=file_urls header=translated_header class_prefix="submission__answer" including_template="response_submitted" xblock_id=xblock_id %}
+
+                {% include "openassessmentblock/oa_team_uploaded_files.html" with file_upload_type=file_upload_type team_file_urls=team_file_urls header=translated_header class_prefix="submission__team__answer" including_template="response_submitted" xblock_id=xblock_id %}
             </article>
         </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.6.10',
+    version='2.6.11',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
[EDUCATOR-4914: The oa_response_submitted template should include team file URLs in its context](https://openedx.atlassian.net/browse/EDUCATOR-4914)

The teammate files were already in the context, but we needed to add them to the template.

These are screenshots showing the change. They look the same, but one is the oa_response_submitted template and one is the oa_response_graded template. 

![Screen Shot 2020-02-14 at 12 28 19 PM](https://user-images.githubusercontent.com/1639231/74553844-2701c380-4f26-11ea-9a2f-4628508aac2c.png)
![Screen Shot 2020-02-14 at 12 31 59 PM](https://user-images.githubusercontent.com/1639231/74553847-279a5a00-4f26-11ea-8f2c-b51137b042c7.png)
