### PR TITLE
When fetching file URLs from keys stored in Submission records, don't…

### DIFF
--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -447,14 +447,7 @@ class SubmissionMixin(object):
         Internal function for retrieving the download url.
 
         """
-        try:
-            return file_upload_api.get_download_url(self._get_student_item_key(file_num))
-        except FileUploadError as exc:
-            logger.exception(u"FileUploadError: Download URL retrieval for filenum {num} failed with {error}".format(
-                error=exc,
-                num=file_num
-            ))
-            return ''
+        return self._get_url_by_file_key(self._get_student_item_key(file_num))
 
     def _get_student_item_key(self, num=0):
         """
@@ -481,6 +474,10 @@ class SubmissionMixin(object):
                 key=key,
                 error=exc
             ))
+
+        if not url:
+            logger.warning('FileUploadError: Could not retrieve URL for key {}'.format(key))
+
         return url
 
     def get_download_urls_from_submission(self, submission):
@@ -509,8 +506,6 @@ class SubmissionMixin(object):
                     file_description = descriptions[idx].strip() if idx < len(descriptions) else ''
                     file_name = file_names[idx].strip() if idx < len(file_names) else ''
                     urls.append((file_download_url, file_description, file_name, False))
-                else:
-                    break
         elif 'file_key' in submission['answer']:
             key = submission['answer'].get('file_key', '')
             file_download_url = self._get_url_by_file_key(key)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.11",
+  "version": "2.6.12",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.6.11',
+    version='2.6.12',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
… break just because we encountered one missing file; there might be more, existing files after it.

Every place that `get_download_urls_from_submission()` is used:
```
adusenbery@aed-mbp:edx-ora2 (aed/more-submission-file-urls) $ ack get_download_urls_from_submission --python openassessment/
openassessment/xblock/staff_area_mixin.py
268:            context["staff_file_urls"] = self.get_download_urls_from_submission(submission)

openassessment/xblock/test/test_submission.py
490:    def test_get_download_urls_from_submission(self, xblock):
506:            actual_urls = xblock.get_download_urls_from_submission(mock_submission)
520:    def test_get_download_urls_from_submission_single_key(self, xblock):
532:            actual_urls = xblock.get_download_urls_from_submission(mock_submission)

openassessment/xblock/peer_assessment_mixin.py
243:                context_dict["peer_file_urls"] = self.get_download_urls_from_submission(peer_sub)
258:                context_dict["peer_file_urls"] = self.get_download_urls_from_submission(peer_sub)

openassessment/xblock/self_assessment_mixin.py
113:                context['self_file_urls'] = self.get_download_urls_from_submission(submission)

openassessment/xblock/grade_mixin.py
148:            'file_urls': self.get_download_urls_from_submission(student_submission),

openassessment/xblock/submission_mixin.py
483:    def get_download_urls_from_submission(self, submission):
```