### PR TITLE
Support .doc and .docx file extensions for file attachment download

### DIFF
--- a/openassessment/fileupload/backends/base.py
+++ b/openassessment/fileupload/backends/base.py
@@ -30,7 +30,9 @@ class Settings(object):
         'image/jpeg': '.jpg',
         'image/pjpeg': '.jpg',
         'image/png': '.png',
-        'application/pdf': '.pdf'
+        'application/pdf': '.pdf',
+        'application/msword': '.doc',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx'
     }
 
     @classmethod


### PR DESCRIPTION
This PR is complementary to  #1140  
Some files uploaded by students are ms word and office documents. On download, they become zip files and is confusing for the instructor. This PR adds `.doc` and `.docx` file extensions and their mime-types to prevent this issue on download. 