### PR TITLE
EDUCATOR-4911: Log exceptions for any error state in ORA file upload XBlock endpoints

### DIFF
--- a/openassessment/fileupload/api.py
+++ b/openassessment/fileupload/api.py
@@ -35,7 +35,10 @@ def get_download_url(key):
     """
     Returns the url at which the file that corresponds to the key can be downloaded.
     """
-    return backends.get_backend().get_download_url(key)
+    url = backends.get_backend().get_download_url(key)
+    if not url:
+        logger.exception('FileUploadError: Could not retrieve URL for key {}'.format(key))
+    return url
 
 
 def remove_file(key):
@@ -151,12 +154,7 @@ class FileUpload(object):
     def download_url(self):
         if self.exists:
             try:
-                url = get_download_url(self.key)
-                if not url:
-                    logger.exception(u'FileUploadError: No download url found for FileUpload with key {key}'.format(
-                        key=self.key
-                    ))
-                return url
+                return get_download_url(self.key)
             except FileUploadError as exc:
                 logger.exception(u'FileUploadError: URL retrieval failed for key {key} with error {error}'.format(
                     key=self.key,

--- a/openassessment/fileupload/api.py
+++ b/openassessment/fileupload/api.py
@@ -151,7 +151,12 @@ class FileUpload(object):
     def download_url(self):
         if self.exists:
             try:
-                return get_download_url(self.key)
+                url = get_download_url(self.key)
+                if not url:
+                    logger.exception(u'FileUploadError: No download url found for FileUpload with key {key}'.format(
+                        key=self.key
+                    ))
+                return url
             except FileUploadError as exc:
                 logger.exception(u'FileUploadError: URL retrieval failed for key {key} with error {error}'.format(
                     key=self.key,

--- a/openassessment/fileupload/tests/test_api_functions.py
+++ b/openassessment/fileupload/tests/test_api_functions.py
@@ -243,6 +243,7 @@ def test_file_descriptor_tuples_after_sharing_with_old_team(
 @pytest.mark.django_db
 @mock.patch('openassessment.fileupload.api.get_download_url', autospec=True)
 def test_team_file_descriptor_tuples(mock_get_download_url, shared_file_upload_fixture, mock_block):
+    mock_get_download_url.return_value = "some-download-url"
     block = mock_block(
         descriptions=['The first file'],
         names=['File A'],

--- a/openassessment/xblock/leaderboard_mixin.py
+++ b/openassessment/xblock/leaderboard_mixin.py
@@ -3,6 +3,7 @@ Leaderboard step in the OpenAssessment XBlock.
 """
 from __future__ import absolute_import
 
+import logging
 import six
 
 from django.utils.translation import ugettext as _
@@ -12,6 +13,8 @@ from openassessment.fileupload import api as file_upload_api
 from openassessment.fileupload.exceptions import FileUploadError
 from openassessment.xblock.data_conversion import create_submission_dict
 from xblock.core import XBlock
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class LeaderboardMixin(object):
@@ -136,6 +139,10 @@ class LeaderboardMixin(object):
         """
         try:
             file_download_url = file_upload_api.get_download_url(file_key)
-        except FileUploadError:
+        except FileUploadError as exc:
+            logger.exception(u'FileUploadError: URL retrieval failed for key {file_key} with error {error}'.format(
+                file_key=file_key,
+                error=exc
+            ))
             file_download_url = ''
         return file_download_url

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -423,13 +423,17 @@ class SubmissionMixin(object):
             filenum = int(filenum)
         except ValueError:
             filenum = -1
-
+        student_item_key = self._get_student_item_key(num=filenum)
         if self._can_delete_file(filenum):
             try:
                 self.file_manager.delete_upload(filenum)
+                logger.debug("Deleted file {student_item_key}".format(student_item_key=student_item_key))
                 return {'success': True}
             except FileUploadError as exc:
-                logger.exception(exc)
+                logger.exception("FileUploadError: Error when deleting file {student_item_key} : {exc}".format(
+                    student_item_key=student_item_key,
+                    exc=exc
+                ))
 
         return {'success': False}
 
@@ -474,9 +478,6 @@ class SubmissionMixin(object):
                 key=key,
                 error=exc
             ))
-
-        if not url:
-            logger.warning('FileUploadError: Could not retrieve URL for key {}'.format(key))
 
         return url
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.12",
+  "version": "2.6.13",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.6.12',
+    version='2.6.13',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
[EDUCATOR-4911: Log exceptions for any error state in ORA file upload XBlock endpoints](https://openedx.atlassian.net/browse/EDUCATOR-4911)

add some more logs