### PR TITLE
Older Ora2 blocks that required text responses but had optional file …

### DIFF
--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -285,7 +285,7 @@ class OpenAssessmentBlock(MessageMixin,
         Backward compatibility for existing blocks that were created without text_response
         or file_upload_response fields. These blocks will be treated as required text.
         """
-        if not self.file_upload_response and not self.text_response_raw:
+        if not self.file_upload_response_raw and not self.text_response_raw:
             return 'required'
         return self.text_response_raw
 

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -457,11 +457,33 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         self.assertEqual(xblock.prompt, '[{"description": "Prompt 4."}, {"description": "Prompt 5."}]')
 
     @scenario('data/neither_response_type.xml')
+    def test_no_response_type_but_optional_file_upload(self, xblock):
+        """
+        Ensure that legacy courses that did not store raw file_upload/text response fields,
+        but do allow optional file uploads, will still load properly.
+        """
+        xblock.file_upload_response_raw = None
+        xblock.text_response_raw = None
+        xblock.file_upload_type_raw = 'optional'
+        self.assertEqual(xblock.text_response, 'required')
+
+    @scenario('data/neither_response_type.xml')
     def test_no_response_type(self, xblock):
         """
-        Ensure that legacy courses will still load properly.
+        Ensure that legacy courses that did not store raw file_upload/text response fields
+        will still load properly.
         """
         self.assertEqual(xblock.text_response, 'required')
+
+    @scenario('data/neither_response_type.xml')
+    def test_optional_text_response_no_file_upload_response(self, xblock):
+        """
+        Ensure that `text_response` gives back the non-null value of `text_response_raw`,
+        even if `file_upload_response_raw` is null.
+        """
+        xblock.file_upload_response_raw = None
+        xblock.text_response_raw = 'optional'
+        self.assertEqual(xblock.text_response, 'optional')
 
 
 class TestDates(XBlockHandlerTestCase):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.15",
+  "version": "2.6.16",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.6.15',
+    version='2.6.16',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
…uploads would lose the required text response field because its checking file_upload_response instead of file_upload_response_raw

Re-build of this PR, for testing's sake: https://github.com/edx/edx-ora2/pull/1120

**What this changes**
The `text_response` property of the ORA XBlock class.  It currently looks at `file_upload_response`, which is an evaluated property, rather than the direct attribute `file_upload_response_raw` that older ora2 blocks did not specify. The problem is that checking `file_upload_response` isn't strictly supporting backward compatibility, for the following reason: when an old ora2 block has required text responses and optional file uploads, checking `file_upload_response` returns `'optional'` which causes `text_response` to evaluate as `None` rather than `'required'`.