### PR TITLE
Store correct assessment type for team assignments

### DIFF
--- a/openassessment/xblock/static/js/spec/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/spec/studio/oa_edit_settings.js
@@ -285,27 +285,34 @@ describe("OpenAssessment.EditSettingsView", function() {
     });
 
     it('hides the training, self, and peer assessment types when teams are enabled', function() {
+        // Default config: teams are disabled, all assessments shown
         view.teamsEnabled(false);
         expect(view.teamsEnabled()).toBe(false);
 
-        // None of the assessment editors should be hidden when teams are disabled
-        $('.openassessment_assessment_module_settings_editor').each(function(index, editor) {
-            expect($(editor).hasClass('is--hidden')).toBe(false);
+        var allAssessmentTypes = [SELF, TRAINING, PEER, STAFF];
+        allAssessmentTypes.forEach(function(type) {
+            var selector = $(assessmentViews[type].element);
+            expect(view.isHidden(selector)).toBe(false);
         });
 
-        expect(assessmentViews[STAFF].isEnabled()).not.toBe(true);
-
+        // Teams config: only staff assessments supported, others hidden
         view.teamsEnabled(true);
         expect(view.teamsEnabled()).toBe(true);
-        [
-            '#oa_self_assessment_editor',
-            '#oa_peer_assessment_editor',
-            '#oa_student_training_editor',
-        ].forEach(function(editorId) {
-            expect($(editorId).hasClass('is--hidden')).toBe(true);
+
+        var shownForTeamAssessments = [STAFF];
+        var hiddenForTeamAssessments = [SELF, TRAINING, PEER];
+
+        hiddenForTeamAssessments.forEach(function(type) {
+            var selector = $(assessmentViews[type].element);
+            expect(view.isHidden(selector)).toBe(true);
         });
 
-        // for team assessments, it automatically selects 'staff-assessment'
+        shownForTeamAssessments.forEach(function(type) {
+            var selector = $(assessmentViews[type].element);
+            expect(view.isHidden(selector)).toBe(false);
+        });
+
+        // for team assessments, it also automatically selects 'staff-assessment'
         expect(assessmentViews[STAFF].isEnabled()).toBe(true);
     });
 });

--- a/openassessment/xblock/static/js/spec/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/spec/studio/oa_edit_settings.js
@@ -315,4 +315,21 @@ describe("OpenAssessment.EditSettingsView", function() {
         // for team assessments, it also automatically selects 'staff-assessment'
         expect(assessmentViews[STAFF].isEnabled()).toBe(true);
     });
+
+    it('treats hidden assessment types as unselected', function() {
+        // Select all assessment types
+        var allAssessmentTypes = [SELF, TRAINING, PEER, STAFF];
+        allAssessmentTypes.forEach(function(type) {
+            assessmentViews[type].isEnabled(true);
+        });
+
+        expect(view.assessmentsDescription().length).toBe(4);
+
+        // Hide some assessments, but leave them enabled
+        view.setHidden($(assessmentViews[SELF].element), true);
+        view.setHidden($(assessmentViews[PEER].element), true);
+
+        // "Saved" assessment types should be limited to visible types
+        expect(view.assessmentsDescription().length).toBe(2);
+    });
 });

--- a/openassessment/xblock/static/js/spec/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/spec/studio/oa_edit_settings.js
@@ -19,6 +19,8 @@ describe("OpenAssessment.EditSettingsView", function() {
             return this._enabled;
         };
 
+        this.element = $('<div>', {id: name});
+
         this.validate = function() {
             return this.isValid;
         };
@@ -265,6 +267,21 @@ describe("OpenAssessment.EditSettingsView", function() {
 
         view.teamsEnabled(true);
         expect(view.teamsEnabled()).toBe(true);
+    });
+
+    it('can hide/show elements on the page', function() {
+        var selector = $(assessmentViews[PEER].element);
+
+        // element shown by default should return hidden = false
+        expect(view.isHidden(selector)).toBe(false);
+
+        // explicitly hiding an element should return hidden = true
+        view.setHidden(selector, true);
+        expect(view.isHidden(selector)).toBe(true);
+
+        // explicitly showing an element should return hidden = false
+        view.setHidden(selector, false);
+        expect(view.isHidden(selector)).toBe(false);
     });
 
     it('hides the training, self, and peer assessment types when teams are enabled', function() {

--- a/openassessment/xblock/static/js/spec/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/spec/studio/oa_edit_settings.js
@@ -267,13 +267,16 @@ describe("OpenAssessment.EditSettingsView", function() {
         expect(view.teamsEnabled()).toBe(true);
     });
 
-    it("hides the training, self, and peer assessment types when teams are enabled", function() {
+    it('hides the training, self, and peer assessment types when teams are enabled', function() {
         view.teamsEnabled(false);
         expect(view.teamsEnabled()).toBe(false);
+
         // None of the assessment editors should be hidden when teams are disabled
         $('.openassessment_assessment_module_settings_editor').each(function(index, editor) {
             expect($(editor).hasClass('is--hidden')).toBe(false);
         });
+
+        expect(assessmentViews[STAFF].isEnabled()).not.toBe(true);
 
         view.teamsEnabled(true);
         expect(view.teamsEnabled()).toBe(true);
@@ -281,8 +284,11 @@ describe("OpenAssessment.EditSettingsView", function() {
             '#oa_self_assessment_editor',
             '#oa_peer_assessment_editor',
             '#oa_student_training_editor',
-        ].forEach(function (editorId, index) {
+        ].forEach(function(editorId) {
             expect($(editorId).hasClass('is--hidden')).toBe(true);
         });
+
+        // for team assessments, it automatically selects 'staff-assessment'
+        expect(assessmentViews[STAFF].isEnabled()).toBe(true);
     });
 });

--- a/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
@@ -54,21 +54,26 @@ OpenAssessment.EditSettingsView = function(element, assessmentViews, data) {
 
     function onTeamsEnabledChange(selectedValue) {
         var teamsetElement = $('#openassessment_teamset_selection_wrapper', self.element);
+
         var selfAssessmentElement = $('#oa_self_assessment_editor', self.element);
         var peerAssessmentElement = $('#oa_peer_assessment_editor', self.element);
         var trainingAssessmentElement = $('#oa_student_training_editor', self.element);
-        if (!selectedValue || selectedValue === '0') {
-            teamsetElement.addClass('is--hidden');
-            selfAssessmentElement.removeClass('is--hidden');
-            peerAssessmentElement.removeClass('is--hidden');
-            trainingAssessmentElement.removeClass('is--hidden');
-        } else {
-            teamsetElement.removeClass('is--hidden');
-            self.assessmentViews.oa_staff_assessment_editor.isEnabled(true);
+        var staffAssessment = self.assessmentViews['oa_staff_assessment_editor'];
 
-            selfAssessmentElement.addClass('is--hidden');
-            peerAssessmentElement.addClass('is--hidden');
-            trainingAssessmentElement.addClass('is--hidden');
+        if (!selectedValue || selectedValue === '0') {
+            self.setHidden(teamsetElement, true);
+
+            self.setHidden(selfAssessmentElement, false);
+            self.setHidden(peerAssessmentElement, false);
+            self.setHidden(trainingAssessmentElement, false);
+        } else {
+            self.setHidden(teamsetElement, false);
+
+            self.setHidden(selfAssessmentElement, true);
+            self.setHidden(peerAssessmentElement, true);
+            self.setHidden(trainingAssessmentElement, true);
+
+            staffAssessment.isEnabled(true);
         }
     }
 
@@ -320,6 +325,28 @@ OpenAssessment.EditSettingsView.prototype = {
         }
         return this.settingSelectorEnabled('#openassessment_team_enabled_selector', isEnabled);
     },
+
+    /**
+     * Hide elements, including setting the aria-hidden attribute for screen readers.
+     *
+     * @param {JQuery.selector} selector - The selector matching the elements to hide.
+     * @param {boolean} hidden - Whether to hide or show the elements.
+     */
+    setHidden: function(selector, hidden) {
+        selector.toggleClass('is--hidden', hidden);
+        selector.attr('aria-hidden', hidden ? 'true' : 'false');
+    },
+
+    /**
+     * Check whether elements are hidden.
+     *
+     * @param {JQuery.selector} selector - The selector matching the elements to check.
+     * @return {boolean} - True if all the elements are hidden, else false.
+     */
+    isHidden: function(selector) {
+        return selector.hasClass('is--hidden') && selector.attr('aria-hidden') === 'true';
+    },
+
     /**
     Get or set the teamset.
 

--- a/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
@@ -55,23 +55,23 @@ OpenAssessment.EditSettingsView = function(element, assessmentViews, data) {
     function onTeamsEnabledChange(selectedValue) {
         var teamsetElement = $('#openassessment_teamset_selection_wrapper', self.element);
 
-        var selfAssessmentElement = $('#oa_self_assessment_editor', self.element);
-        var peerAssessmentElement = $('#oa_peer_assessment_editor', self.element);
-        var trainingAssessmentElement = $('#oa_student_training_editor', self.element);
+        var selfAssessment = self.assessmentViews['oa_self_assessment_editor'];
+        var peerAssessment = self.assessmentViews['oa_peer_assessment_editor'];
+        var trainingAssessment = self.assessmentViews['oa_student_training_editor'];
         var staffAssessment = self.assessmentViews['oa_staff_assessment_editor'];
 
         if (!selectedValue || selectedValue === '0') {
             self.setHidden(teamsetElement, true);
 
-            self.setHidden(selfAssessmentElement, false);
-            self.setHidden(peerAssessmentElement, false);
-            self.setHidden(trainingAssessmentElement, false);
+            self.setHidden($(selfAssessment.element), false);
+            self.setHidden($(peerAssessment.element), false);
+            self.setHidden($(trainingAssessment.element), false);
         } else {
             self.setHidden(teamsetElement, false);
 
-            self.setHidden(selfAssessmentElement, true);
-            self.setHidden(peerAssessmentElement, true);
-            self.setHidden(trainingAssessmentElement, true);
+            self.setHidden($(selfAssessment.element), true);
+            self.setHidden($(peerAssessment.element), true);
+            self.setHidden($(trainingAssessment.element), true);
 
             staffAssessment.isEnabled(true);
         }

--- a/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
@@ -64,6 +64,8 @@ OpenAssessment.EditSettingsView = function(element, assessmentViews, data) {
             trainingAssessmentElement.removeClass('is--hidden');
         } else {
             teamsetElement.removeClass('is--hidden');
+            self.assessmentViews.oa_staff_assessment_editor.isEnabled(true);
+
             selfAssessmentElement.addClass('is--hidden');
             peerAssessmentElement.addClass('is--hidden');
             trainingAssessmentElement.addClass('is--hidden');

--- a/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
@@ -52,25 +52,27 @@ OpenAssessment.EditSettingsView = function(element, assessmentViews, data) {
         ])
     ).install();
 
+    function onTeamsEnabledChange(selectedValue) {
+        var teamsetElement = $('#openassessment_teamset_selection_wrapper', self.element);
+        var selfAssessmentElement = $('#oa_self_assessment_editor', self.element);
+        var peerAssessmentElement = $('#oa_peer_assessment_editor', self.element);
+        var trainingAssessmentElement = $('#oa_student_training_editor', self.element);
+        if (!selectedValue || selectedValue === '0') {
+            teamsetElement.addClass('is--hidden');
+            selfAssessmentElement.removeClass('is--hidden');
+            peerAssessmentElement.removeClass('is--hidden');
+            trainingAssessmentElement.removeClass('is--hidden');
+        } else {
+            teamsetElement.removeClass('is--hidden');
+            selfAssessmentElement.addClass('is--hidden');
+            peerAssessmentElement.addClass('is--hidden');
+            trainingAssessmentElement.addClass('is--hidden');
+        }
+    }
+
     this.teamsEnabledSelectControl = new OpenAssessment.SelectControl(
         $('#openassessment_team_enabled_selector', this.element),
-        function(selectedValue) {
-            var teamsetElement = $('#openassessment_teamset_selection_wrapper', self.element);
-            var selfAssessmentElement = $('#oa_self_assessment_editor', self.element);
-            var peerAssessmentElement = $('#oa_peer_assessment_editor', self.element);
-            var trainingAssessmentElement = $('#oa_student_training_editor', self.element);
-            if (!selectedValue || selectedValue === '0') {
-                teamsetElement.addClass('is--hidden');
-                selfAssessmentElement.removeClass('is--hidden');
-                peerAssessmentElement.removeClass('is--hidden');
-                trainingAssessmentElement.removeClass('is--hidden');
-            } else {
-                teamsetElement.removeClass('is--hidden');
-                selfAssessmentElement.addClass('is--hidden');
-                peerAssessmentElement.addClass('is--hidden');
-                trainingAssessmentElement.addClass('is--hidden');
-            }
-        },
+        onTeamsEnabledChange,
         new OpenAssessment.Notifier([
             new OpenAssessment.AssessmentToggleListener(),
         ])
@@ -105,6 +107,7 @@ OpenAssessment.EditSettingsView = function(element, assessmentViews, data) {
     );
 
     this.initializeSortableAssessments();
+    onTeamsEnabledChange($('#openassessment_team_enabled_selector').val());
 };
 
 OpenAssessment.EditSettingsView.prototype = {

--- a/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
@@ -55,10 +55,10 @@ OpenAssessment.EditSettingsView = function(element, assessmentViews, data) {
     function onTeamsEnabledChange(selectedValue) {
         var teamsetElement = $('#openassessment_teamset_selection_wrapper', self.element);
 
-        var selfAssessment = self.assessmentViews['oa_self_assessment_editor'];
-        var peerAssessment = self.assessmentViews['oa_peer_assessment_editor'];
-        var trainingAssessment = self.assessmentViews['oa_student_training_editor'];
-        var staffAssessment = self.assessmentViews['oa_staff_assessment_editor'];
+        var selfAssessment = self.assessmentViews.oa_self_assessment_editor;
+        var peerAssessment = self.assessmentViews.oa_peer_assessment_editor;
+        var trainingAssessment = self.assessmentViews.oa_student_training_editor;
+        var staffAssessment = self.assessmentViews.oa_staff_assessment_editor;
 
         if (!selectedValue || selectedValue === '0') {
             self.setHidden(teamsetElement, true);

--- a/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
@@ -390,7 +390,9 @@ OpenAssessment.EditSettingsView.prototype = {
         $('.openassessment_assessment_module_settings_editor', this.assessmentsElement).each(
             function() {
                 var asmntView = view.assessmentViews[$(this).attr('id')];
-                if (asmntView.isEnabled()) {
+                var isHidden = $(asmntView.element).hasClass('is--hidden');
+
+                if (asmntView.isEnabled() && !isHidden) {
                     var description = asmntView.description();
                     description.name = asmntView.name;
                     assessmentDescList.push(description);

--- a/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
@@ -419,9 +419,9 @@ OpenAssessment.EditSettingsView.prototype = {
         $('.openassessment_assessment_module_settings_editor', this.assessmentsElement).each(
             function() {
                 var asmntView = view.assessmentViews[$(this).attr('id')];
-                var isHidden = $(asmntView.element).hasClass('is--hidden');
+                var isVisible = !view.isHidden($(asmntView.element));
 
-                if (asmntView.isEnabled() && !isHidden) {
+                if (asmntView.isEnabled() && isVisible) {
                     var description = asmntView.description();
                     description.name = asmntView.name;
                     assessmentDescList.push(description);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.7",
+  "version": "2.6.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.19",
+  "version": "2.6.20",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.6.19',
+    version='2.6.20',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
JIRA: [EDUCATOR-4962](https://openedx.atlassian.net/browse/EDUCATOR-4962)
FYI: @edx/masters-devs 

## Bug
Currently, we only support staff assessments for team open responses so we hide other assessment options in the settings tab.

Saving and returning to the settings tab for a team assignment, unsupported assessment types were reappearing and the incorrect assessment type was selected.

## Root cause
When assessment types could remain selected even when hidden. We also didn't re-hide unsupported assessment types on load, only when the `teams enabled` option was changed

## Fixes
- If the assessment has teams enabled, hide unsupported assessment types on load
- Treat a hidden assessment type as not selected
- **Bonus refactoring:** add show/hide function to settings view instead of manually manipulating classes
- **Bonus UX enhancement:** automatically select "staff assessment" when enabling teams for an assessment
