### PR TITLE
Django2: upgrade django-model-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.24",
+  "version": "2.6.25",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ boto==2.39.0
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 defusedxml==0.5.0
-django-model-utils==3.0.0
+django-model-utils==3.2.0
 django-simple-history==2.8.0
 django==2.2.10
 djangorestframework==3.9.4

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,7 +7,7 @@ futures==3.3.0 ; python_version == "2.7"
 bleach<=2.1.4                      # Constrained by edx-platform/edx-enterprise/lti_consumer-xblock
 boto<=2.39.0                       # Constrained by edx-platform and its dependencies.
 defusedxml<=0.5.0                  # Constrained by edx-platform and its dependencies.
-django-model-utils==3.0.0          # Constrained by edx-platform and its dependencies.
+django-model-utils<4.0.0          # Constrained by edx-platform and its dependencies.
 fs<=2.0.18                         # Constrained by edx-platform/XBlock
 jsonfield2<3.1.0
 lazy<=1.1                          # Constrained by edx-platform and its dependencies.

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -17,7 +17,7 @@ click==7.0                # via click-log
 coverage==5.0.3
 ddt==1.0.0
 defusedxml==0.5.0
-django-model-utils==3.0.0
+django-model-utils==3.2.0
 git+https://github.com/edx/django-pyfs.git@1.0.6#egg=django-pyfs
 django-simple-history==2.8.0
 django==2.2.10

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -15,7 +15,7 @@ chardet==3.0.4
 coverage==5.0.3
 ddt==1.0.0
 defusedxml==0.5.0
-django-model-utils==3.0.0
+django-model-utils==3.2.0
 git+https://github.com/edx/django-pyfs.git@1.0.6#egg=django-pyfs
 django-simple-history==2.8.0
 django==2.2.10

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ chardet==3.0.4
 coverage==5.0.3
 ddt==1.0.0
 defusedxml==0.5.0
-django-model-utils==3.0.0
+django-model-utils==3.2.0
 git+https://github.com/edx/django-pyfs.git@1.0.6#egg=django-pyfs
 django-simple-history==2.8.0
 edx-i18n-tools==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.6.24',
+    version='2.6.25',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1453

We need to upgrade django-model-utils to 3.2.0 to get this Django2 fix: https://github.com/jazzband/django-model-utils/pull/335 


## Please do the following to make sure your changes make it all the way out the door:

- [x] Make sure your PR updates the version number in ``setup.py`` and ``package.json``
- [x] Run ``make javascript sass`` if your changes include JS/CSS changes.
- [x] Get a green Travis build for this PR
- [ ] Merge to master
- [ ] Create a release tag on GitHub https://github.com/edx/edx-ora2/releases
- [ ] Manually inspect diff at https://github.com/edx/edx-ora2/compare/0.x.n-1...0.x.n, email contributors
- [ ] Create PR to update `requirements/edx/{github.in,base.txt,development.txt,testing.txt}` in `edx-platform`.
- [ ] If manual testing of the changes against edx-platform is desired, create a sandbox (or use devstack).
- [ ] Get green build on the edx-platform PR, merge.
- [ ] Consider any feature flags that must be changed.
- [ ] Once your code has been released to production, try to test it there, too.
