### PR TITLE
EDUCATOR-4984: Implement TeamStaffWorkflow methods

### DIFF
--- a/openassessment/assessment/models/staff.py
+++ b/openassessment/assessment/models/staff.py
@@ -100,15 +100,12 @@ class StaffWorkflow(models.Model):
         completely graded, or is actively being reviewed by other staff members.
 
         Args:
-            submission_uuid (str): The submission UUID from the student
-                requesting a submission for assessment. This is used to explicitly
-                avoid giving the student their own submission, and determines the
-                associated Peer Workflow.
+            course_id (str): The course that we would like to retrieve submissions for,
             item_id (str): The student_item that we would like to retrieve submissions for.
             scorer_id (str): The user id of the staff member scoring this submission
 
         Returns:
-            submission_uuid (str): The submission_uuid for the submission to review.
+            identifying_uuid (str): The identifying_uuid for the (team or individual) submission to review.
 
         Raises:
             StaffAssessmentInternalError: Raised when there is an error retrieving

--- a/openassessment/assessment/test/test_staff.py
+++ b/openassessment/assessment/test/test_staff.py
@@ -646,12 +646,12 @@ class BaseStaffWorkflowModelTestMixin(object):
         When getting a submission to review, prioritize submissions
         that the reviewer has previously worked on
         """
-        #Create three ungraded
+        # Create three ungraded
         self._create_ungraded()
         self._create_ungraded()
         self._create_ungraded()
 
-        #Create graded and in-progress for graders 1 and 2
+        # Create graded and in-progress for graders 1 and 2
         self._create_graded(scorer_id=self.scorer_1_id)
         in_progress_scorer_1 = self._create_in_progress(scorer_id=self.scorer_1_id)
 
@@ -660,10 +660,9 @@ class BaseStaffWorkflowModelTestMixin(object):
 
         self._get_and_assert_workflow(in_progress_scorer_1)
 
-
     def test_get_submission_for_review_no_scorer(self):
         """
-        When getting a submission to review, if there are no workflows the 
+        When getting a submission to review, if there are no workflows the
         reviewer has worked on, get one that has no scorer (or has timed out)
         """
         self._create_graded(scorer_id=self.scorer_1_id)
@@ -672,15 +671,14 @@ class BaseStaffWorkflowModelTestMixin(object):
 
         self._get_and_assert_workflow(no_scorer)
 
-
     def test_get_submission_for_review_in_progress_past_timeout(self):
         """
-        When getting a submission to review, if there are no workflows the 
+        When getting a submission to review, if there are no workflows the
         reviewer has worked on, get one that has timed out (or has no scorer)
         """
         self._create_graded(scorer_id=self.scorer_1_id)
         self._create_in_progress(scorer_id=self.scorer_2_id)
-        
+
         hour_past_time_limit_td = self.model.TIME_LIMIT + timedelta(hours=1)
         grading_start = datetime.now() - hour_past_time_limit_td
         timed_out = self._create_ungraded(scorer_id=self.scorer_2_id, grading_started_at=grading_start)

--- a/openassessment/assessment/test/test_staff.py
+++ b/openassessment/assessment/test/test_staff.py
@@ -5,7 +5,7 @@ Tests for staff assessments.
 from __future__ import absolute_import
 
 import copy
-from datetime import timedelta
+from datetime import timedelta, datetime
 
 from ddt import data, ddt, unpack
 import mock
@@ -18,8 +18,9 @@ from openassessment.assessment.api import staff as staff_api
 from openassessment.assessment.api.peer import create_assessment as peer_assess
 from openassessment.assessment.api.self import create_assessment as self_assess
 from openassessment.assessment.errors import StaffAssessmentInternalError, StaffAssessmentRequestError
-from openassessment.assessment.models import Assessment, StaffWorkflow
+from openassessment.assessment.models import Assessment, StaffWorkflow, TeamStaffWorkflow
 from openassessment.test_utils import CacheResetTest
+from openassessment.tests.factories import StaffWorkflowFactory, TeamStaffWorkflowFactory, AssessmentFactory
 from openassessment.workflow import api as workflow_api
 from submissions import api as sub_api
 
@@ -522,3 +523,227 @@ class TestStaffAssessment(CacheResetTest):
             peer_api.on_start(submission["uuid"])
         workflow_api.create_workflow(submission["uuid"], steps, init_params)
         return submission, new_student_item
+
+
+@ddt
+class BaseStaffWorkflowModelTestMixin(object):
+    item_id = 'itemitemitemimitem'
+    other_item_id = 'other_item_id'
+    course_id = 'edx/TestCourse/CourseRun2'
+    other_course_id = 'edx/SomeOtherCourse/CourseRun15'
+    scorer_1_id = 'scorer1'
+    scorer_2_id = 'scorer2'
+
+    @classmethod
+    def setUpTestData(cls):
+        """
+        Make some graded, ungraded and in-progress workflows for another item in this
+        course and in another course, just for some noise
+        """
+        for _ in range(2):
+            cls._create_in_progress(
+                course_id=cls.other_course_id,
+                item_id=cls.other_item_id,
+                scorer_id=cls.scorer_2_id)
+            cls._create_ungraded(course_id=cls.other_course_id, item_id=cls.other_item_id)
+            cls._create_graded(course_id=cls.other_course_id, item_id=cls.other_item_id, scorer_id=cls.scorer_1_id)
+
+            cls._create_in_progress(item_id=cls.other_item_id, scorer_id=cls.scorer_2_id)
+            cls._create_ungraded(item_id=cls.other_item_id)
+            cls._create_graded(item_id=cls.other_item_id, scorer_id=cls.scorer_1_id)
+
+    @classmethod
+    def _create_in_progress(cls, course_id=None, item_id=None, scorer_id=''):
+        """
+        """
+        # pylint: disable=unexpected-keyword-arg
+        return cls.create_workflow(
+            course_id=course_id or cls.course_id,
+            item_id=item_id or cls.item_id,
+            scorer_id=scorer_id,
+            grading_completed_at=None,
+            cancelled_at=None,
+            grading_started_at=datetime.now(),
+        )
+
+    @classmethod
+    def _create_ungraded(cls, course_id=None, item_id=None, scorer_id='', grading_started_at=None):
+        """
+        Create an ungraded workflow with the given fields.
+
+        A workflow can still be ungraded if it has a scorer_id and grading_started_at,
+        as long as grading_started_at is before the timeout. This function doesn't actually do
+        that validation, beware.
+        """
+        # pylint: disable=unexpected-keyword-arg
+        return cls.create_workflow(
+            course_id=course_id or cls.course_id,
+            item_id=item_id or cls.item_id,
+            grading_completed_at=None,
+            cancelled_at=None,
+            scorer_id=scorer_id,
+            grading_started_at=grading_started_at,
+        )
+
+    @classmethod
+    def _create_graded(cls, course_id=None, item_id=None, scorer_id=''):
+        """
+        """
+        # pylint: disable=unexpected-keyword-arg
+        return cls.create_workflow(
+            course_id=course_id or cls.course_id,
+            item_id=item_id or cls.item_id,
+            scorer_id=scorer_id,
+            cancelled_at=None,
+            grading_completed_at=datetime.now()
+        )
+
+    def test_cancelled(self):
+        workflow = self.create_workflow()
+        self.assertFalse(workflow.is_cancelled)
+        workflow.cancelled_at = datetime.now()
+        self.assertTrue(workflow.is_cancelled)
+
+    @unpack
+    @data(
+        (0, 5, 7),
+        (3, 0, 4),
+        (5, 2, 0),
+        (0, 0, 0),
+    )
+    def test_get_workflow_statistics(self, expected_graded, expected_ungraded, expected_in_progress):
+        for _ in range(expected_graded):
+            self._create_graded()
+        for _ in range(expected_ungraded):
+            self._create_ungraded()
+        for _ in range(expected_in_progress):
+            self._create_in_progress()
+        stats = self.model.get_workflow_statistics(self.course_id, self.item_id)
+        self.assertDictEqual(
+            {
+                'graded': expected_graded,
+                'ungraded': expected_ungraded,
+                'in-progress': expected_in_progress,
+            },
+            stats
+        )
+
+    def _get_and_assert_workflow(self, expected_workflow):
+        submission_uuid = self.model.get_submission_for_review(self.course_id, self.item_id, self.scorer_1_id)
+        selected_workflow = self.get_workflow_by_identifying_uuid(submission_uuid)
+
+        # Check that the workflow is the workflow we expect, and that scorer_id was updated, and that
+        # grading_started_at was set no more than a second ago.
+        self.assertEqual(expected_workflow.id, selected_workflow.id)
+        self.assertEqual(self.scorer_1_id, selected_workflow.scorer_id)
+
+        now = datetime.now(tz=selected_workflow.grading_started_at.tzinfo)
+        timediff = now - selected_workflow.grading_started_at
+        self.assertTrue(timediff < timedelta(seconds=1))
+
+    def test_get_submission_for_review_previously_graded(self):
+        """
+        When getting a submission to review, prioritize submissions
+        that the reviewer has previously worked on
+        """
+        #Create three ungraded
+        self._create_ungraded()
+        self._create_ungraded()
+        self._create_ungraded()
+
+        #Create graded and in-progress for graders 1 and 2
+        self._create_graded(scorer_id=self.scorer_1_id)
+        in_progress_scorer_1 = self._create_in_progress(scorer_id=self.scorer_1_id)
+
+        self._create_graded(scorer_id=self.scorer_2_id)
+        self._create_in_progress(scorer_id=self.scorer_2_id)
+
+        self._get_and_assert_workflow(in_progress_scorer_1)
+
+
+    def test_get_submission_for_review_no_scorer(self):
+        """
+        When getting a submission to review, if there are no workflows the 
+        reviewer has worked on, get one that has no scorer (or has timed out)
+        """
+        self._create_graded(scorer_id=self.scorer_1_id)
+        self._create_in_progress(scorer_id=self.scorer_2_id)
+        no_scorer = self._create_ungraded()
+
+        self._get_and_assert_workflow(no_scorer)
+
+
+    def test_get_submission_for_review_in_progress_past_timeout(self):
+        """
+        When getting a submission to review, if there are no workflows the 
+        reviewer has worked on, get one that has timed out (or has no scorer)
+        """
+        self._create_graded(scorer_id=self.scorer_1_id)
+        self._create_in_progress(scorer_id=self.scorer_2_id)
+        
+        hour_past_time_limit_td = self.model.TIME_LIMIT + timedelta(hours=1)
+        grading_start = datetime.now() - hour_past_time_limit_td
+        timed_out = self._create_ungraded(scorer_id=self.scorer_2_id, grading_started_at=grading_start)
+
+        self._get_and_assert_workflow(timed_out)
+
+    def test_get_submission_for_review_no_available(self):
+        self._create_graded(scorer_id=self.scorer_1_id)
+        self._create_graded(scorer_id=self.scorer_2_id)
+        self._create_in_progress(scorer_id=self.scorer_2_id)
+
+        submission_uuid = self.model.get_submission_for_review(self.course_id, self.item_id, self.scorer_1_id)
+        self.assertIsNone(submission_uuid)
+
+    def test_database_error(self):
+        self._create_ungraded()
+        with mock.patch.object(self.model, 'save') as mocked_save:
+            mocked_save.side_effect = DatabaseError
+            with self.assertRaises(StaffAssessmentInternalError):
+                self.model.get_submission_for_review(self.course_id, self.item_id, self.scorer_1_id)
+
+    def test_close_active_assessment(self):
+        workflow = self.create_workflow()
+        self.assertIsNone(workflow.assessment)
+        self.assertEqual('', workflow.scorer_id)
+        self.assertIsNone(workflow.grading_completed_at)
+
+        assessment = AssessmentFactory.create()
+        workflow.close_active_assessment(assessment, self.scorer_1_id)
+
+        self.assertEqual(assessment.id, workflow.assessment)
+        self.assertEqual(self.scorer_1_id, workflow.scorer_id)
+        self.assertIsNotNone(workflow.grading_completed_at)
+
+
+class StaffWorkflowModelTest(BaseStaffWorkflowModelTestMixin, CacheResetTest):
+
+    model = StaffWorkflow
+
+    @classmethod
+    def create_workflow(cls, **kwargs):
+        return StaffWorkflowFactory.create(**kwargs)
+
+    def get_workflow_by_identifying_uuid(self, uuid):
+        return StaffWorkflow.objects.get(submission_uuid=uuid)
+
+    def test_identifying_uuid(self):
+        workflow = self.create_workflow()
+        self.assertEqual(workflow.submission_uuid, workflow.identifying_uuid)
+
+
+class TeamStaffWorkflowModelTest(BaseStaffWorkflowModelTestMixin, CacheResetTest):
+
+    model = TeamStaffWorkflow
+
+    @classmethod
+    def create_workflow(cls, **kwargs):
+        return TeamStaffWorkflowFactory.create(**kwargs)
+
+    def get_workflow_by_identifying_uuid(self, uuid):
+        return TeamStaffWorkflow.objects.get(team_submission_uuid=uuid)
+
+    def test_identifying_uuid(self):
+        workflow = self.create_workflow()
+        self.assertNotEqual(workflow.submission_uuid, workflow.identifying_uuid)
+        self.assertEqual(workflow.team_submission_uuid, workflow.identifying_uuid)

--- a/openassessment/assessment/test/test_staff.py
+++ b/openassessment/assessment/test/test_staff.py
@@ -526,7 +526,10 @@ class TestStaffAssessment(CacheResetTest):
 
 
 @ddt
-class BaseStaffWorkflowModelTestMixin(object):
+class BaseStaffWorkflowModelTestMixin():
+    """
+    Common tests and test data for StaffWorkflowTest and TeamStaffWorkflowTest
+    """
     item_id = 'itemitemitemimitem'
     other_item_id = 'other_item_id'
     course_id = 'edx/TestCourse/CourseRun2'
@@ -555,6 +558,7 @@ class BaseStaffWorkflowModelTestMixin(object):
     @classmethod
     def _create_in_progress(cls, course_id=None, item_id=None, scorer_id=''):
         """
+        Create an in-progress workflow
         """
         # pylint: disable=unexpected-keyword-arg
         return cls.create_workflow(
@@ -588,6 +592,7 @@ class BaseStaffWorkflowModelTestMixin(object):
     @classmethod
     def _create_graded(cls, course_id=None, item_id=None, scorer_id=''):
         """
+        Create a completed, graded workflow (no assessment is created)
         """
         # pylint: disable=unexpected-keyword-arg
         return cls.create_workflow(
@@ -629,6 +634,12 @@ class BaseStaffWorkflowModelTestMixin(object):
         )
 
     def _get_and_assert_workflow(self, expected_workflow):
+        """
+        Call get_submission_for_review for course_id, item_id, and scorer_1_id
+        Verify the identifying uuid returned is the expected workflow, and
+        check that scorer_id and grading_started_at were updated
+        """
+
         submission_uuid = self.model.get_submission_for_review(self.course_id, self.item_id, self.scorer_1_id)
         selected_workflow = self.get_workflow_by_identifying_uuid(submission_uuid)
 
@@ -637,9 +648,9 @@ class BaseStaffWorkflowModelTestMixin(object):
         self.assertEqual(expected_workflow.id, selected_workflow.id)
         self.assertEqual(self.scorer_1_id, selected_workflow.scorer_id)
 
-        now = datetime.now(tz=selected_workflow.grading_started_at.tzinfo)
-        timediff = now - selected_workflow.grading_started_at
-        self.assertTrue(timediff < timedelta(seconds=1))
+        now_with_tz = datetime.now(tz=selected_workflow.grading_started_at.tzinfo)
+        timediff = now_with_tz - selected_workflow.grading_started_at
+        self.assertLess(timediff, timedelta(seconds=1))
 
     def test_get_submission_for_review_previously_graded(self):
         """
@@ -715,6 +726,7 @@ class BaseStaffWorkflowModelTestMixin(object):
 
 
 class StaffWorkflowModelTest(BaseStaffWorkflowModelTestMixin, CacheResetTest):
+    """ Tests for the StaffWorkflow model """
 
     model = StaffWorkflow
 
@@ -731,6 +743,7 @@ class StaffWorkflowModelTest(BaseStaffWorkflowModelTestMixin, CacheResetTest):
 
 
 class TeamStaffWorkflowModelTest(BaseStaffWorkflowModelTestMixin, CacheResetTest):
+    """ Tests for the TeamStaffWorkflow model """
 
     model = TeamStaffWorkflow
 

--- a/openassessment/tests/factories.py
+++ b/openassessment/tests/factories.py
@@ -7,7 +7,7 @@ import factory
 from factory.django import DjangoModelFactory
 
 from openassessment.assessment.models import (Assessment, AssessmentFeedback, AssessmentFeedbackOption, AssessmentPart,
-                                              Criterion, CriterionOption, Rubric)
+                                              Criterion, CriterionOption, Rubric, StaffWorkflow, TeamStaffWorkflow)
 
 
 class RubricFactory(DjangoModelFactory):
@@ -115,3 +115,26 @@ class AssessmentFeedbackFactory(DjangoModelFactory):
         if extracted:
             for option in extracted:
                 self.options.add(option)  # pylint: disable=no-member
+
+
+class StaffWorkflowFactory(DjangoModelFactory):
+    class Meta:
+        model = StaffWorkflow
+
+    scorer_id = ''
+    course_id = factory.Sequence(lambda n: 'default_course_{}'.format(n))
+    item_id = factory.Sequence(lambda n: 'default_item_{}'.format(n))
+    submission_uuid = factory.Faker('sha1')
+    assessment = None
+
+
+class TeamStaffWorkflowFactory(DjangoModelFactory):
+    class Meta:
+        model = TeamStaffWorkflow
+
+    scorer_id = ''
+    course_id = factory.Sequence(lambda n: 'default_course_{}'.format(n))
+    item_id = factory.Sequence(lambda n: 'default_item_{}'.format(n))
+    submission_uuid = factory.Faker('sha1')
+    assessment = None
+    team_submission_uuid = factory.Faker('sha1')

--- a/openassessment/tests/factories.py
+++ b/openassessment/tests/factories.py
@@ -118,23 +118,25 @@ class AssessmentFeedbackFactory(DjangoModelFactory):
 
 
 class StaffWorkflowFactory(DjangoModelFactory):
+    """ Create StaffWorkflow models for testing """
     class Meta:
         model = StaffWorkflow
 
     scorer_id = ''
-    course_id = factory.Sequence(lambda n: 'default_course_{}'.format(n))
-    item_id = factory.Sequence(lambda n: 'default_item_{}'.format(n))
+    course_id = factory.Sequence(lambda n: 'default_course_{}'.format(n))  # pylint: disable=unnecessary-lambda
+    item_id = factory.Sequence(lambda n: 'default_item_{}'.format(n))  # pylint: disable=unnecessary-lambda
     submission_uuid = factory.Faker('sha1')
     assessment = None
 
 
 class TeamStaffWorkflowFactory(DjangoModelFactory):
+    """ Create StaffWorkflow models for testing """
     class Meta:
         model = TeamStaffWorkflow
 
     scorer_id = ''
-    course_id = factory.Sequence(lambda n: 'default_course_{}'.format(n))
-    item_id = factory.Sequence(lambda n: 'default_item_{}'.format(n))
+    course_id = factory.Sequence(lambda n: 'default_course_{}'.format(n))  # pylint: disable=unnecessary-lambda
+    item_id = factory.Sequence(lambda n: 'default_item_{}'.format(n))  # pylint: disable=unnecessary-lambda
     submission_uuid = factory.Faker('sha1')
     assessment = None
     team_submission_uuid = factory.Faker('sha1')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.26",
+  "version": "2.6.27",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.6.26',
+    version='2.6.27',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
@edx/masters-devs-gta 
[EDUCATOR-4984](https://openedx.atlassian.net/browse/EDUCATOR-4984
)

If we just modify a classmethod on StaffWorkflow, we barely have to make any changes.

I added a property on Team- and StaffWorkflow called `identifying_uuid`, which for TeamStaffWorkflow, returns the team submission uuid, and for StaffWorkflow returns the submission uuid. this allows minimal changes and reuse of code, but if anyone strongly opposes please let me know.

Most of this PR is just adding some explicit model tests for the workflows. There are tests that cover the model functions, but I thought it would be good to have an explicit suite.

- [x] gotta update version