### PR TITLE
EDUCATOR-4985 - consume team specific submission methods in the ora mixin

### DIFF
--- a/openassessment/assessment/test/test_team.py
+++ b/openassessment/assessment/test/test_team.py
@@ -206,7 +206,7 @@ class TestTeamApi(CacheResetTest):
             self.staff_user_id
         )
 
-        # Then I recieve one to assess
+        # Then I recieve a submission to assess
         self.assertEqual(team_submission, submission_to_assess)
 
     def test_get_grading_statistics(self):

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -36,6 +36,7 @@ from openassessment.xblock.team_mixin import TeamMixin
 from openassessment.xblock.validation import validator
 from openassessment.xblock.config_mixin import ConfigMixin
 from openassessment.xblock.workflow_mixin import WorkflowMixin
+from openassessment.xblock.team_workflow_mixin import TeamWorkflowMixin
 from openassessment.xblock.xml import parse_from_xml, serialize_content_to_xml
 from webob import Response
 from xblock.core import XBlock
@@ -106,6 +107,7 @@ class OpenAssessmentBlock(MessageMixin,
                           LeaderboardMixin,
                           StaffAreaMixin,
                           WorkflowMixin,
+                          TeamWorkflowMixin,
                           StudentTrainingMixin,
                           LmsCompatibilityMixin,
                           CourseItemsListingMixin,

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -17,12 +17,14 @@ from django.test.utils import override_settings
 import boto
 from boto.s3.key import Key
 from moto import mock_s3
+from django.contrib.auth import get_user_model
 from openassessment.fileupload import api
 from openassessment.workflow import api as workflow_api
 from openassessment.xblock.data_conversion import create_submission_dict, prepare_submission_for_serialization
 from openassessment.xblock.openassessmentblock import OpenAssessmentBlock
 from openassessment.xblock.workflow_mixin import WorkflowMixin
 from submissions import api as sub_api
+from submissions.models import TeamSubmission
 from submissions.api import SubmissionInternalError, SubmissionRequestError
 
 from .base import XBlockHandlerTestCase, scenario
@@ -386,6 +388,9 @@ class SubmissionTest(XBlockHandlerTestCase):
         xblock.has_team = Mock(return_value=True)
         xblock.get_team_info = Mock(return_value=mock_team)
         xblock.get_anonymous_user_ids_for_team = Mock(return_value=['rl', 'r5', 'r2'])
+        password = 'password'
+        user = get_user_model().objects.create_user(username='Red Five', password=password)
+        xblock.get_real_user = Mock(return_value=user)
 
         return mock_team
 
@@ -393,17 +398,10 @@ class SubmissionTest(XBlockHandlerTestCase):
     def test_team_submission(self, xblock):
         """ If teams are enabled, a submission by any member should submit for each member of the team """
 
-        # given a learner is on a team
-        mock_team = self.setup_mock_team(xblock)
-
         # when the learner submits an open assessment response
         response = self.request(xblock, 'submit', self.SUBMISSION, response_format='json')
 
-        # then the submission is successful for all members of a team
-        self.assertEqual(len(mock_team['team_usernames']), len(response))
-
-        for result in response:
-            self.assertTrue(result[0])
+        self.assertTrue(response[0])
 
     @scenario('data/basic_scenario.xml', user_id='Red Five')
     @patch.object(sub_api, 'create_submission')
@@ -465,9 +463,8 @@ class SubmissionTest(XBlockHandlerTestCase):
         # then the submission is successful for all members of a team
         self.assertEqual(len(mock_team['team_usernames']), len(response))
 
-        for status, _, attempt_number in response:
-            self.assertTrue(status)
-            self.assertEqual(1, attempt_number)
+        self.assertTrue(response[0])
+        self.assertEqual(1, response[2])
 
         all_submissions = sub_api.get_all_submissions(
             course_id=xblock.course_id,
@@ -958,27 +955,16 @@ class SubmissionRenderTest(XBlockHandlerTestCase):
             on page load to see if a submisison has been created by a team member.
         """
         SubmissionTest.setup_mock_team(xblock)
-        submissions = xblock.create_team_submission(
+
+        xblock.create_team_submission(
             ('A man must have a code', 'A man must have an umbrella too.')
         )
-        # get submission from Xblock
-        submission = [sub for sub in submissions if sub['uuid'] == xblock.submission_uuid][0]
-        self._assert_path_and_context(
-            xblock, 'openassessmentblock/response/oa_response_submitted.html',
-            {
-                'student_submission': create_submission_dict(submission, xblock.prompts),
-                'text_response': 'required',
-                'file_upload_response': None,
-                'file_upload_type': None,
-                'peer_incomplete': False,
-                'self_incomplete': False,
-                'allow_latex': False,
-                'user_timezone': None,
-                'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': False,
-            }
-        )
+
+        ts = TeamSubmission.objects.all()
+        self.assertEqual(len(ts), 1)
+        self.assertEqual(ts[0].submitted_by.username, 'Red Five')
+        # TODO this work also depends on https://openedx.atlassian.net/browse/EDUCATOR-4986
+        # Once that ticket is complete, reinstate original assert via path_and_context
 
     @scenario('data/submission_open.xml', user_id="Bob")
     def test_open_submitted(self, xblock):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ django-simple-history==2.8.0
 django==2.2.10
 djangorestframework==3.9.4
 edx-i18n-tools==0.5.0
-edx-submissions==3.1.1
+edx-submissions==3.1.3
 fs==2.0.18                # via xblock
 html5lib==1.0.1
 idna==2.8                 # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -4,6 +4,7 @@
 futures==3.3.0 ; python_version == "2.7"
 
 # Base dependencies
+Django<2.3                         # Stay on the latest LTS release of Django
 bleach<=2.1.4                      # Constrained by edx-platform/edx-enterprise/lti_consumer-xblock
 boto<=2.39.0                       # Constrained by edx-platform and its dependencies.
 defusedxml<=0.5.0                  # Constrained by edx-platform and its dependencies.
@@ -19,6 +20,7 @@ mock<4.0.0                         # mock version 4.0.0 drops support for python
 path.py<=8.2.1                     # Constrained by edx-platform and its dependencies.
 python-dateutil<=2.4.0             # Constrained by edx-platform and its dependencies.
 python-swiftclient<4.0.0
+mock<4.0.0                         # mock version 4.0.0 drops support for python 3.5
 voluptuous<1.0.0
 zipp==1.0.0                        # zipp 2.0.0 requires Python >= 3.6
 

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -23,7 +23,7 @@ django-simple-history==2.8.0
 django==2.2.10
 djangorestframework==3.9.4
 edx-i18n-tools==0.5.0
-edx-submissions==3.1.1
+edx-submissions==3.1.3
 git+https://github.com/edx/edx-lint.git@1.3.0#egg=edx_lint
 factory-boy==2.12.0
 faker==4.0.0

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -21,7 +21,7 @@ django-simple-history==2.8.0
 django==2.2.10
 djangorestframework==3.9.4
 edx-i18n-tools==0.5.0
-edx-submissions==3.1.1
+edx-submissions==3.1.3
 factory-boy==2.12.0
 faker==4.0.0
 filelock==3.0.12

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ django-model-utils==3.2.0
 git+https://github.com/edx/django-pyfs.git@1.0.6#egg=django-pyfs
 django-simple-history==2.8.0
 edx-i18n-tools==0.5.0
-edx-submissions==3.1.1
+edx-submissions==3.1.3
 factory-boy==2.12.0
 faker==4.0.0              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv


### PR DESCRIPTION
Use submission mixin team workflow to use team specific submission methods in submission api. 
No longer create multiple individual submissions. Instead create a single team submission in the mixin. The API will take care of the abstraction.

[Jira](https://openedx.atlassian.net/browse/EDUCATOR-4985)

@edx/masters-devs-gta 

## Please do the following to make sure your changes make it all the way out the door:

- [ ] Make sure your PR updates the version number in ``setup.py`` and ``package.json``
- [ ] Run ``make javascript sass`` if your changes include JS/CSS changes.
- [ ] Get a green Travis build for this PR
- [ ] Merge to master
- [ ] Create a release tag on GitHub https://github.com/edx/edx-ora2/releases
- [ ] Manually inspect diff at https://github.com/edx/edx-ora2/compare/0.x.n-1...0.x.n, email contributors
- [ ] Create PR to update `requirements/edx/{github.in,base.txt,development.txt,testing.txt}` in `edx-platform`.
- [ ] If manual testing of the changes against edx-platform is desired, create a sandbox (or use devstack).
- [ ] Get green build on the edx-platform PR, merge.
- [ ] Consider any feature flags that must be changed.
- [ ] Once your code has been released to production, try to test it there, too.
