### PR TITLE
Refactor Team Assessment API

### DIFF
--- a/openassessment/assessment/api/staff.py
+++ b/openassessment/assessment/api/staff.py
@@ -6,11 +6,10 @@ from __future__ import absolute_import
 import logging
 
 from django.db import DatabaseError, transaction
-from django.utils.timezone import now
 
 from submissions import api as submissions_api
 
-from openassessment.assessment.api.staff_base import _complete_assessment, STAFF_TYPE
+from openassessment.assessment.api.staff_base import cancel_workflow, _complete_assessment, STAFF_TYPE
 from openassessment.assessment.errors import StaffAssessmentInternalError, StaffAssessmentRequestError
 from openassessment.assessment.models import Assessment, AssessmentPart, InvalidRubricSelection, StaffWorkflow
 from openassessment.assessment.serializers import InvalidRubric, full_assessment_dict, rubric_from_dict
@@ -100,8 +99,6 @@ def on_cancel(submission_uuid):
     """
     Cancel the staff workflow for submission.
 
-    Sets the cancelled_at field in staff workflow.
-
     Args:
         submission_uuid (str): The submission UUID associated with this workflow.
 
@@ -109,22 +106,7 @@ def on_cancel(submission_uuid):
         None
 
     """
-    try:
-        workflow = StaffWorkflow.objects.get(submission_uuid=submission_uuid)
-        workflow.cancelled_at = now()
-        workflow.save(update_fields=['cancelled_at'])
-    except StaffWorkflow.DoesNotExist:
-        # If we can't find a workflow, then we don't have to do anything to
-        # cancel it.
-        pass
-    except DatabaseError:
-        error_message = (
-            u"An internal error occurred while cancelling the staff"
-            u"workflow for submission {}"
-            .format(submission_uuid)
-        )
-        logger.exception(error_message)
-        raise StaffAssessmentInternalError(error_message)
+    return cancel_workflow(submission_uuid)
 
 
 def get_score(submission_uuid, staff_requirements):  # pylint: disable=unused-argument

--- a/openassessment/assessment/api/staff.py
+++ b/openassessment/assessment/api/staff.py
@@ -162,7 +162,12 @@ def get_latest_staff_assessment(submission_uuid):
     }
 
     """
-    return staff_base.get_latest_staff_assessment([submission_uuid])
+    assessment = staff_base.get_latest_staff_assessment([submission_uuid])
+
+    if assessment:
+        return full_assessment_dict(assessment)
+    else:
+        return None
 
 
 def get_assessment_scores_by_criteria(submission_uuid):

--- a/openassessment/assessment/api/staff.py
+++ b/openassessment/assessment/api/staff.py
@@ -12,7 +12,7 @@ from submissions import api as submissions_api
 from openassessment.assessment.api import staff_base
 from openassessment.assessment.errors import StaffAssessmentInternalError, StaffAssessmentRequestError
 from openassessment.assessment.models import Assessment, AssessmentPart, InvalidRubricSelection, StaffWorkflow
-from openassessment.assessment.serializers import InvalidRubric, full_assessment_dict, rubric_from_dict
+from openassessment.assessment.serializers import InvalidRubric, full_assessment_dict
 
 
 logger = logging.getLogger("openassessment.assessment.api.staff")  # pylint: disable=invalid-name
@@ -162,23 +162,7 @@ def get_latest_staff_assessment(submission_uuid):
     }
 
     """
-    try:
-        assessments = Assessment.objects.filter(
-            submission_uuid=submission_uuid,
-            score_type=staff_base.STAFF_TYPE,
-        )[:1]
-    except DatabaseError as ex:
-        msg = (
-            u"An error occurred while retrieving staff assessments "
-            u"for the submission with UUID {uuid}: {ex}"
-        ).format(uuid=submission_uuid, ex=ex)
-        logger.exception(msg)
-        raise StaffAssessmentInternalError(msg)
-
-    if assessments:
-        return full_assessment_dict(assessments[0])
-
-    return None
+    return staff_base.get_latest_staff_assessment([submission_uuid])
 
 
 def get_assessment_scores_by_criteria(submission_uuid):

--- a/openassessment/assessment/api/staff.py
+++ b/openassessment/assessment/api/staff.py
@@ -10,14 +10,13 @@ from django.utils.timezone import now
 
 from submissions import api as submissions_api
 
+from openassessment.assessment.api.staff_base import _complete_assessment, STAFF_TYPE
 from openassessment.assessment.errors import StaffAssessmentInternalError, StaffAssessmentRequestError
 from openassessment.assessment.models import Assessment, AssessmentPart, InvalidRubricSelection, StaffWorkflow
 from openassessment.assessment.serializers import InvalidRubric, full_assessment_dict, rubric_from_dict
 
 
 logger = logging.getLogger("openassessment.assessment.api.staff")  # pylint: disable=invalid-name
-
-STAFF_TYPE = "ST"
 
 
 def submitter_is_finished(submission_uuid, staff_requirements):  # pylint: disable=unused-argument
@@ -387,63 +386,3 @@ def create_assessment(
         ).format(scorer_id)
         logger.exception(error_message)
         raise StaffAssessmentInternalError(error_message)
-
-
-@transaction.atomic
-def _complete_assessment(
-        submission_uuid,
-        scorer_id,
-        options_selected,
-        criterion_feedback,
-        overall_feedback,
-        rubric_dict,
-        scored_at,
-        scorer_workflow
-):
-    """
-    Internal function for atomic assessment creation. Creates a staff assessment
-    in a single transaction.
-
-    Args:
-        submission_uuid (str): The submission uuid for the submission being
-            assessed.
-        scorer_id (str): The user ID for the user giving this assessment. This
-            is required to create an assessment on a submission.
-        options_selected (dict): Dictionary mapping criterion names to the
-            option names the user selected for that criterion.
-        criterion_feedback (dict): Dictionary mapping criterion names to the
-            free-form text feedback the user gave for the criterion.
-            Since criterion feedback is optional, some criteria may not appear
-            in the dictionary.
-        overall_feedback (unicode): Free-form text feedback on the submission overall.
-        rubric_dict (dict): The rubric model associated with this assessment
-        scored_at (datetime): Optional argument to override the time in which
-            the assessment took place. If not specified, scored_at is set to
-            now.
-
-    Returns:
-        The Assessment model
-
-    """
-    # Get or create the rubric
-    rubric = rubric_from_dict(rubric_dict)
-
-    # Create the staff assessment
-    assessment = Assessment.create(
-        rubric,
-        scorer_id,
-        submission_uuid,
-        STAFF_TYPE,
-        scored_at=scored_at,
-        feedback=overall_feedback
-    )
-
-    # Create assessment parts for each criterion in the rubric
-    # This will raise an `InvalidRubricSelection` if the selected options do not
-    # match the rubric.
-    AssessmentPart.create_from_option_names(assessment, options_selected, feedback=criterion_feedback)
-
-    # Close the active assessment
-    if scorer_workflow is not None:
-        scorer_workflow.close_active_assessment(assessment, scorer_id)
-    return assessment

--- a/openassessment/assessment/api/staff.py
+++ b/openassessment/assessment/api/staff.py
@@ -9,7 +9,7 @@ from django.db import DatabaseError, transaction
 
 from submissions import api as submissions_api
 
-from openassessment.assessment.api.staff_base import cancel_workflow, _complete_assessment, STAFF_TYPE
+from openassessment.assessment.api import staff_base
 from openassessment.assessment.errors import StaffAssessmentInternalError, StaffAssessmentRequestError
 from openassessment.assessment.models import Assessment, AssessmentPart, InvalidRubricSelection, StaffWorkflow
 from openassessment.assessment.serializers import InvalidRubric, full_assessment_dict, rubric_from_dict
@@ -106,7 +106,7 @@ def on_cancel(submission_uuid):
         None
 
     """
-    return cancel_workflow(submission_uuid)
+    return staff_base.cancel_workflow(submission_uuid)
 
 
 def get_score(submission_uuid, staff_requirements):  # pylint: disable=unused-argument
@@ -165,7 +165,7 @@ def get_latest_staff_assessment(submission_uuid):
     try:
         assessments = Assessment.objects.filter(
             submission_uuid=submission_uuid,
-            score_type=STAFF_TYPE,
+            score_type=staff_base.STAFF_TYPE,
         )[:1]
     except DatabaseError as ex:
         msg = (
@@ -200,7 +200,8 @@ def get_assessment_scores_by_criteria(submission_uuid):
         # This will always create a list of length 1
         assessments = list(
             Assessment.objects.filter(
-                score_type=STAFF_TYPE, submission_uuid=submission_uuid
+                score_type=staff_base.STAFF_TYPE,
+                submission_uuid=submission_uuid
             )[:1]
         )
         scores = Assessment.scores_by_criterion(assessments)
@@ -342,7 +343,7 @@ def create_assessment(
         except StaffWorkflow.DoesNotExist:
             scorer_workflow = None
 
-        assessment = _complete_assessment(
+        assessment = staff_base._complete_assessment(
             submission_uuid,
             scorer_id,
             options_selected,

--- a/openassessment/assessment/api/staff_base.py
+++ b/openassessment/assessment/api/staff_base.py
@@ -1,0 +1,76 @@
+"""
+Shared funcitons/logic for staff and team API
+"""
+from __future__ import absolute_import
+
+import logging
+
+from django.db import transaction
+
+from openassessment.assessment.models import Assessment, AssessmentPart, InvalidRubricSelection
+from openassessment.assessment.serializers import InvalidRubric, rubric_from_dict
+
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+STAFF_TYPE = "ST"
+
+
+@transaction.atomic
+def _complete_assessment(
+        submission_uuid,
+        scorer_id,
+        options_selected,
+        criterion_feedback,
+        overall_feedback,
+        rubric_dict,
+        scored_at,
+        scorer_workflow
+):
+    """
+    Internal function for atomic assessment creation. Creates a staff assessment
+    in a single transaction.
+
+    Args:
+        submission_uuid (str): The submission uuid for the submission being
+            assessed.
+        scorer_id (str): The user ID for the user giving this assessment. This
+            is required to create an assessment on a submission.
+        options_selected (dict): Dictionary mapping criterion names to the
+            option names the user selected for that criterion.
+        criterion_feedback (dict): Dictionary mapping criterion names to the
+            free-form text feedback the user gave for the criterion.
+            Since criterion feedback is optional, some criteria may not appear
+            in the dictionary.
+        overall_feedback (unicode): Free-form text feedback on the submission overall.
+        rubric_dict (dict): The rubric model associated with this assessment
+        scored_at (datetime): Optional argument to override the time in which
+            the assessment took place. If not specified, scored_at is set to
+            now.
+
+    Returns:
+        The Assessment model
+
+    """
+    # Get or create the rubric
+    rubric = rubric_from_dict(rubric_dict)
+
+    # Create the staff assessment
+    assessment = Assessment.create(
+        rubric,
+        scorer_id,
+        submission_uuid,
+        STAFF_TYPE,
+        scored_at=scored_at,
+        feedback=overall_feedback
+    )
+
+    # Create assessment parts for each criterion in the rubric
+    # This will raise an `InvalidRubricSelection` if the selected options do not
+    # match the rubric.
+    AssessmentPart.create_from_option_names(assessment, options_selected, feedback=criterion_feedback)
+
+    # Close the active assessment
+    if scorer_workflow is not None:
+        scorer_workflow.close_active_assessment(assessment, scorer_id)
+    return assessment

--- a/openassessment/assessment/api/staff_base.py
+++ b/openassessment/assessment/api/staff_base.py
@@ -86,10 +86,7 @@ def get_latest_staff_assessment(submission_uuids):
         logger.exception(msg)
         raise StaffAssessmentInternalError(msg)
 
-    if assessment:
-        return full_assessment_dict(assessment)
-
-    return None
+    return assessment
 
 
 @transaction.atomic

--- a/openassessment/assessment/api/teams.py
+++ b/openassessment/assessment/api/teams.py
@@ -10,15 +10,13 @@ from django.utils.timezone import now
 
 from submissions import team_api as team_submissions_api
 
-from openassessment.assessment.api.staff import _complete_assessment
+from openassessment.assessment.api.staff import _complete_assessment, STAFF_TYPE
 from openassessment.assessment.errors import StaffAssessmentInternalError, StaffAssessmentRequestError
 from openassessment.assessment.models import Assessment, TeamStaffWorkflow, InvalidRubricSelection
 from openassessment.assessment.serializers import InvalidRubric, full_assessment_dict
 
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
-
-STAFF_TYPE = "ST"
 
 
 def submitter_is_finished(team_submission_uuid, team_requirements):  # pylint: disable=unused-argument

--- a/openassessment/assessment/api/teams.py
+++ b/openassessment/assessment/api/teams.py
@@ -159,27 +159,10 @@ def get_latest_staff_assessment(team_submission_uuid):
     }
 
     """
-    try:
-        # Get the reference submissions
-        team_submission = team_submissions_api.get_team_submission(team_submission_uuid)
+    # Get the reference submissions
+    submission_uuids = team_submissions_api.get_team_submission(team_submission_uuid)['submission_uuids']
 
-        # Return the most-recently graded assessment for any team member's submisison
-        assessment = Assessment.objects.filter(
-            submission_uuid__in=team_submission['submission_uuids'],
-            score_type=staff_base.STAFF_TYPE,
-        ).first()
-    except StaffAssessmentInternalError as ex:
-        msg = (
-            "An error occurred while retrieving staff assessments "
-            "for the team submission with UUID {uuid}: {ex}"
-        ).format(uuid=team_submission_uuid, ex=ex)
-        logger.exception(msg)
-        raise StaffAssessmentInternalError(msg)
-
-    if assessment:
-        return full_assessment_dict(assessment)
-
-    return None
+    return staff_base.get_latest_staff_assessment(submission_uuids)
 
 
 def get_assessment_scores_by_criteria(team_submission_uuid):

--- a/openassessment/assessment/api/teams.py
+++ b/openassessment/assessment/api/teams.py
@@ -162,7 +162,12 @@ def get_latest_staff_assessment(team_submission_uuid):
     # Get the reference submissions
     submission_uuids = team_submissions_api.get_team_submission(team_submission_uuid)['submission_uuids']
 
-    return staff_base.get_latest_staff_assessment(submission_uuids)
+    assessment = staff_base.get_latest_staff_assessment(submission_uuids)
+
+    if assessment:
+        return full_assessment_dict(assessment)
+    else:
+        return None
 
 
 def get_assessment_scores_by_criteria(team_submission_uuid):
@@ -182,15 +187,10 @@ def get_assessment_scores_by_criteria(team_submission_uuid):
     """
     try:
         # Get most recently graded assessment for a team submission
-        team_submission = team_submissions_api.get_team_submission(team_submission_uuid)
-        assessments = list(
-            Assessment.objects.filter(
-                submission_uuid__in=team_submission['submission_uuids'],
-                score_type=staff_base.STAFF_TYPE,
-            )[:1]
-        )
+        submission_uuids = team_submissions_api.get_team_submission(team_submission_uuid)['submission_uuids']
+        assessment = staff_base.get_latest_staff_assessment(submission_uuids)
 
-        scores = Assessment.scores_by_criterion(assessments)
+        scores = Assessment.scores_by_criterion([assessment])
         # Since this is only being sent one score, the median score will be the
         # same as the only score.
         return Assessment.get_median_score_dict(scores)

--- a/openassessment/assessment/models/staff.py
+++ b/openassessment/assessment/models/staff.py
@@ -157,6 +157,18 @@ class StaffWorkflow(models.Model):
         self.grading_completed_at = now()
         self.save()
 
+    @classmethod
+    def get_by_identifying_uuid(cls, uuid):
+        """
+        Get a staff workflow by submission UUID or None
+        """
+        try:
+            staff_workflow = cls.objects.get(submission_uuid=uuid)
+        except cls.DoesNotExist:
+            staff_workflow = None
+
+        return staff_workflow
+
 
 class TeamStaffWorkflow(StaffWorkflow):
     """
@@ -171,3 +183,15 @@ class TeamStaffWorkflow(StaffWorkflow):
         (submission_uuid for StaffWorkflow, team_submission_uuid for TeamStaffWorkflow)
         """
         return self.team_submission_uuid
+
+    @classmethod
+    def get_by_identifying_uuid(cls, uuid):
+        """
+        Get a team staff workflow by submission UUID or None
+        """
+        try:
+            team_staff_workflow = cls.objects.get(team_submission_uuid=uuid)
+        except cls.DoesNotExist:
+            team_staff_workflow = None
+
+        return team_staff_workflow

--- a/openassessment/assessment/test/test_staff.py
+++ b/openassessment/assessment/test/test_staff.py
@@ -380,7 +380,7 @@ class TestStaffAssessment(CacheResetTest):
         self.assertEqual(
             str(context_manager.exception),
             (
-                u"An error occurred while retrieving staff assessments for the submission with UUID {uuid}: {ex}"
+                u"An error occurred while retrieving staff assessments for the submission with UUID ['{uuid}']: {ex}"
             ).format(uuid=tim_sub["uuid"], ex="KABOOM!")
         )
 


### PR DESCRIPTION
**TL;DR -** Created a `staff_base` file to house some shared logic between team and staff assessment APIs with the goal of reducing duplicate code.

**What changed?**
- New `staff_base` file
- Extended `Team/StaffWorkflow` to allow for getting by `identifying_uuid`
- Genericized workflow cancellations and get of latest assessment
- Move atomic assessment creation code into `staff_base`

**Notes**
- For the sake of time I haven't given **every** function a generic, shared version. There's more refactoring that can be done, but this change set includes some quick-wins.
- Unlike the pre-refactor code, this touches staff assessment code which increases risk of regression.

FYI @edx/masters-devs-gta 
Related to #1393