### PR TITLE
EDUCATOR-4986: Implement TeamAssessmentWorkflow's start_workflow method

### DIFF
--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -339,7 +339,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
                 self.set_staff_score(new_staff_score)
                 self.save()
                 logger.info((
-                    u"Workflow for submission UUID {uuid} has updated score using {staff_type} assessment."
+                    "Workflow for submission UUID {uuid} has updated score using {staff_type} assessment."
                 ).format(uuid=self.submission_uuid, staff_type=self.STAFF_STEP_NAME))
 
                 # Update the assessment_completed_at field for all steps
@@ -616,7 +616,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
     def identifying_uuid(self):
         """
         Returns the primary identifying uuid for this workflow.
-        AssessmentWorkflow returns submission_uuid, and TeamAssessmentWorkflow returns team_submission_uuid
+        Can be overriden by child classes
         """
         return self.submission_uuid
 
@@ -737,7 +737,7 @@ class TeamAssessmentWorkflow(AssessmentWorkflow):
                 self._set_team_staff_score(new_score)
                 self.save()
                 logger.info((
-                    u"Team Workflow for team submission UUID {uuid} has updated score using team staff assessment."
+                    "Team Workflow for team submission UUID {uuid} has updated score using team staff assessment."
                 ).format(uuid=self.team_submission_uuid))
 
                 team_staff_step.assessment_completed_at = now()
@@ -762,8 +762,7 @@ class TeamAssessmentWorkflow(AssessmentWorkflow):
     def identifying_uuid(self):
         """
         Returns the primary identifying uuid for this workflow.
-        AssessmentWorkflow returns submission_uuid, and TeamAssessmentWorkflow returns team_submission_uuid
-        Needed because teams step api functions need team_submission_uuid as an input
+        Overwrites AssessmentWorkflow.identifying_uuid to return team_submission_uuid
         """
         return self.team_submission_uuid
 

--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -26,7 +26,7 @@ from model_utils.models import StatusModel, TimeStampedModel
 
 from openassessment.assessment.errors.base import AssessmentError
 from openassessment.assessment.signals import assessment_complete_signal
-from submissions import api as sub_api
+from submissions import api as sub_api, team_api as sub_team_api
 
 from .errors import AssessmentApiLoadError, AssessmentWorkflowError, AssessmentWorkflowInternalError
 
@@ -62,6 +62,8 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
     an after the fact recording of the last known state of that information so
     we can search easily.
     """
+    STAFF_STEP_NAME = 'staff'
+
     STEPS = sorted(ASSESSMENT_API_DICT.keys())
 
     STATUSES = [
@@ -152,7 +154,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
             new_list.extend(step_names)
             step_names = new_list
 
-        # Create the workflow and step models in the database
+        # Create the workflow and assessment step models in the database
         # For now, set the status to waiting; we'll modify it later
         # based on the first step in the workflow.
         workflow = cls.objects.create(
@@ -267,8 +269,8 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
                         step_requirements = None
                     else:
                         step_requirements = assessment_requirements.get(assessment_step_name, {})
-                    score = get_score_func(self.submission_uuid, step_requirements)
-                    if not score and (assessment_step_name == self.STATUS.staff):
+                    score = get_score_func(self.identifying_uuid, step_requirements)
+                    if not score and assessment_step.is_staff_step():
                         if step_requirements and step_requirements.get('required', False):
                             break  # A staff score was not found, and one is required. Return None
                         continue  # A staff score was not found, but it is not required, so try the next type of score
@@ -311,7 +313,6 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
             override_submitter_requirements (bool): If True, the presence of a new
                 staff score will cause all of the submitter's requirements to be
                 fulfilled, moving the workflow to DONE and exposing their grade.
-
         """
         if self.status == self.STATUS.cancelled:
             return
@@ -321,7 +322,10 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
 
         step_for_name = {step.name: step for step in steps}
 
-        new_staff_score = self.get_score(assessment_requirements, {'staff': step_for_name.get('staff', None)})
+        new_staff_score = self.get_score(
+            assessment_requirements,
+            {self.STAFF_STEP_NAME: step_for_name.get(self.STAFF_STEP_NAME, None)}
+        )
         if new_staff_score:
             # new_staff_score is just the most recent staff score, it may already be recorded in sub_api
             old_score = sub_api.get_latest_score_for_submission(self.submission_uuid)
@@ -335,8 +339,8 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
                 self.set_staff_score(new_staff_score)
                 self.save()
                 logger.info((
-                    u"Workflow for submission UUID {uuid} has updated score using staff assessment."
-                ).format(uuid=self.submission_uuid))
+                    u"Workflow for submission UUID {uuid} has updated score using {staff_type} assessment."
+                ).format(uuid=self.submission_uuid, staff_type=self.STAFF_STEP_NAME))
 
                 # Update the assessment_completed_at field for all steps
                 # All steps are considered "assessment complete", as the staff score will override all
@@ -479,7 +483,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
         """
         steps = self._get_steps()
         step_for_name = {step.name: step for step in steps}
-        staff_step = step_for_name.get("staff")
+        staff_step = step_for_name.get(self.STAFF_STEP_NAME)
         if staff_step is not None:
             get_latest_func = getattr(staff_step.api(), 'get_latest_assessment', None)
             if get_latest_func is not None:
@@ -511,7 +515,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
         for step in steps:
             on_cancel_func = getattr(step.api(), 'on_cancel', None)
             if on_cancel_func is not None:
-                on_cancel_func(self.submission_uuid)
+                on_cancel_func(self.identifying_uuid)
 
         try:
             score = self.get_score(assessment_requirements, step_for_name)
@@ -608,27 +612,35 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
         """
         return self.cancellations.exists()
 
+    @property
+    def identifying_uuid(self):
+        """
+        Returns the primary identifying uuid for this workflow.
+        AssessmentWorkflow returns submission_uuid, and TeamAssessmentWorkflow returns team_submission_uuid
+        """
+        return self.submission_uuid
+
 
 class TeamAssessmentWorkflow(AssessmentWorkflow):
     """
     Extends AssessmentWorkflow to support team based assessments.
     """
     # Only staff assessments are supported for teams
-    STEPS = ['staff']
-    REQUIREMENTS = {"staff": {"required": True}}
+    TEAM_STAFF_STEP_NAME = 'teams'
+
+    STEPS = [TEAM_STAFF_STEP_NAME]
+    STATUS_VALUES = STEPS + AssessmentWorkflow.STATUSES
+    STATUS = Choices(*STATUS_VALUES)  # implicit "status" field
+
+    ASSESSMENT_SCORE_PRIORITY = [TEAM_STAFF_STEP_NAME]
+
+    REQUIREMENTS = {TEAM_STAFF_STEP_NAME: {"required": True}}
 
     team_submission_uuid = models.CharField(max_length=128, unique=True, null=False)
 
     @classmethod
-    @transaction.atomic
-    def start_workflow(cls, team_submission_uuid):  # pylint: disable=arguments-differ
-        """ Start a team workflow """
-        # TODO - Implement in https://openedx.atlassian.net/browse/EDUCATOR-4986
-        workflow = {'team_submission_uuid': team_submission_uuid}
-        return workflow
-
-    @classmethod
     def get_by_team_submission_uuid(cls, team_submission_uuid):
+        """ Given a team submission uuid, return the associated workflow """
         try:
             return cls.objects.get(team_submission_uuid=team_submission_uuid)
         except cls.DoesNotExist:
@@ -640,10 +652,120 @@ class TeamAssessmentWorkflow(AssessmentWorkflow):
             logger.exception(message)
             raise AssessmentWorkflowError(message)
 
+    @classmethod
+    @transaction.atomic
+    def start_workflow(cls, team_submission_uuid):  # pylint: disable=arguments-differ
+        """ Start a team workflow """
+        team_submission_dict = sub_team_api.get_team_submission(team_submission_uuid)
+        try:
+            referrence_learner_submission_uuid = team_submission_dict['submission_uuids'][0]
+        except IndexError:
+            msg = 'No individual submission found for team submisison uuid {}'.format(team_submission_uuid)
+            logger.exception(msg)
+            raise AssessmentWorkflowInternalError(msg)
+
+        # Create the workflow in the database
+        # For now, set the status to waiting; we'll modify it later
+        team_workflow = cls.objects.create(
+            team_submission_uuid=team_submission_uuid,
+            submission_uuid=referrence_learner_submission_uuid,
+            status=TeamAssessmentWorkflow.STATUS.waiting,
+            course_id=team_submission_dict['course_id'],
+            item_id=team_submission_dict['item_id']
+        )
+        team_staff_step = AssessmentWorkflowStep.objects.create(
+            workflow=team_workflow, name=cls.TEAM_STAFF_STEP_NAME, order_num=0
+        )
+        team_workflow.steps.add(team_staff_step)
+
+        team_assessment_api = team_staff_step.api()
+        team_assessment_api.on_init(team_submission_uuid)
+
+        team_workflow.status = TeamAssessmentWorkflow.STATUS.teams
+        team_workflow.save()
+
+        return team_workflow
+
+    @property
+    def _team_staff_step(self):
+        return self._get_steps()[0]
+
+    def _get_steps(self):
+        """
+        Simple helper function for retrieving all the steps in the given
+        TeamAssessmentWorkflow. In this case, it's somewhat trivial, since a
+        TeamAssessmentWorkflow can only ever have a single 'teams' step.
+        """
+
+        if self.steps.count() != 1:
+            err_msg = 'Team Assessment Workflow {} should have exactly one single "teams" step: {}'.format(
+                self.uuid,
+                self.steps.all()
+            )
+            logger.error(err_msg)
+            raise AssessmentWorkflowInternalError(err_msg)
+        step = self.steps.first()
+        if step.name != TeamAssessmentWorkflow.STATUS.teams:
+            err_msg = 'Team Assessment Workflow {} has a "{}" step rather than a teams step'.format(
+                self.uuid,
+                step.name
+            )
+            logger.error(err_msg)
+            raise AssessmentWorkflowInternalError(err_msg)
+        return [step]
+
     def update_from_assessments(self):  # pylint: disable=arguments-differ
-        """ Update status from the assessments. For teams, only the staff assessment """
-        # TODO - Implement in https://openedx.atlassian.net/browse/EDUCATOR-4986
-        pass
+        """
+        Update the workflow with potential new scores from assessments.
+        """
+        if self.status == self.STATUS.cancelled:
+            return
+
+        team_staff_step = self._team_staff_step
+        team_staff_api = team_staff_step.api()
+        new_score = team_staff_api.get_score(self.team_submission_uuid, self.REQUIREMENTS)
+        if new_score:
+            # new_score is just the most recent team score, it may already be recorded in sub_api
+            old_score = sub_api.get_latest_score_for_submission(self.submission_uuid)
+            if (
+                    # Does a prior score exist?  Do the points earned match?
+                    not old_score or self.STAFF_ANNOTATION_TYPE not in [
+                        annotation['annotation_type'] for annotation in old_score['annotations']
+                    ] or old_score['points_earned'] != new_score['points_earned']
+            ):
+                # Set the team staff score using team submissions api, and log that fact
+                self._set_team_staff_score(new_score)
+                self.save()
+                logger.info((
+                    u"Team Workflow for team submission UUID {uuid} has updated score using team staff assessment."
+                ).format(uuid=self.team_submission_uuid))
+
+                team_staff_step.assessment_completed_at = now()
+                team_staff_step.save()
+
+            team_staff_step.update(self.team_submission_uuid, self.REQUIREMENTS)
+            self.status = self.STATUS.done
+            self.save()
+
+    def _set_team_staff_score(self, score):
+        reason = "A staff member has defined the score for this submission"
+        sub_team_api.set_score(
+            self.team_submission_uuid,
+            score["points_earned"],
+            score["points_possible"],
+            annotation_creator=score["staff_id"],
+            annotation_type=self.STAFF_ANNOTATION_TYPE,
+            annotation_reason=reason
+        )
+
+    @property
+    def identifying_uuid(self):
+        """
+        Returns the primary identifying uuid for this workflow.
+        AssessmentWorkflow returns submission_uuid, and TeamAssessmentWorkflow returns team_submission_uuid
+        Needed because teams step api functions need team_submission_uuid as an input
+        """
+        return self.team_submission_uuid
 
 
 class AssessmentWorkflowStep(models.Model):
@@ -663,6 +785,8 @@ class AssessmentWorkflowStep(models.Model):
     assessment_completed_at = models.DateTimeField(default=None, null=True)
     order_num = models.PositiveIntegerField()
 
+    staff_step_types = [AssessmentWorkflow.STAFF_STEP_NAME, TeamAssessmentWorkflow.TEAM_STAFF_STEP_NAME]
+
     class Meta:
         ordering = ["workflow", "order_num"]
         app_label = "workflow"
@@ -680,6 +804,9 @@ class AssessmentWorkflowStep(models.Model):
         """
         return self.assessment_completed_at is not None
 
+    def is_staff_step(self):
+        return self.name in self.staff_step_types
+
     def api(self):
         """
         Returns an API associated with this workflow step. If no API is
@@ -694,9 +821,14 @@ class AssessmentWorkflowStep(models.Model):
         api_path = getattr(
             settings, 'ORA2_ASSESSMENTS', DEFAULT_ASSESSMENT_API_DICT
         ).get(self.name)
-        # Staff API should always be available
-        if self.name == 'staff' and not api_path:
-            api_path = 'openassessment.assessment.api.staff'
+        # Staff APIs should always be available
+        if self.is_staff_step() and not api_path:
+            if self.name == AssessmentWorkflow.STAFF_STEP_NAME:
+                api_path = 'openassessment.assessment.api.staff'
+            elif self.name == TeamAssessmentWorkflow.TEAM_STAFF_STEP_NAME:
+                api_path = 'openassessment.assessment.api.teams'
+            else:
+                raise AssessmentWorkflowInternalError('Staff step type {} has no associated api'.format(self.name))
         if api_path is not None:
             try:
                 return importlib.import_module(api_path)

--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -154,7 +154,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
             new_list.extend(step_names)
             step_names = new_list
 
-        # Create the workflow and assessment step models in the database
+        # Create the workflow and step models in the database
         # For now, set the status to waiting; we'll modify it later
         # based on the first step in the workflow.
         workflow = cls.objects.create(

--- a/openassessment/workflow/test/factories.py
+++ b/openassessment/workflow/test/factories.py
@@ -1,0 +1,27 @@
+""" Factories for testing workflow models """
+
+import factory
+from factory.django import DjangoModelFactory
+
+from openassessment.workflow.models import TeamAssessmentWorkflow, AssessmentWorkflowStep
+
+
+class TeamAssessmentWorkflowFactory(DjangoModelFactory):
+    """ Create mock TeamAssessmentWorkflow models. """
+    class Meta:
+        model = TeamAssessmentWorkflow
+
+    team_submission_uuid = factory.Faker('sha1')
+    submission_uuid = factory.Faker('sha1')
+    course_id = factory.Sequence(lambda n: 'default_course_{}'.format(n))  # pylint: disable=unnecessary-lambda
+    item_id = factory.Sequence(lambda n: 'default_course_{}'.format(n))  # pylint: disable=unnecessary-lambda
+
+
+class AssessmentWorkflowStepFactory(DjangoModelFactory):
+    """ Create mock AssessmentWorkflowStep models. """
+    class Meta:
+        model = AssessmentWorkflowStep
+
+    workflow = factory.SubFactory(TeamAssessmentWorkflowFactory)
+    name = 'staff'
+    order_num = 1

--- a/openassessment/workflow/test/test_models.py
+++ b/openassessment/workflow/test/test_models.py
@@ -1,0 +1,166 @@
+""" Tests for ORA workflow models """
+
+from contextlib import contextmanager
+import ddt
+import mock
+from freezegun import freeze_time
+
+from django.utils.timezone import now
+
+from openassessment.test_utils import CacheResetTest
+from openassessment.workflow.errors import AssessmentWorkflowInternalError
+from openassessment.workflow.models import TeamAssessmentWorkflow, AssessmentWorkflowStep
+from openassessment.workflow.test.factories import AssessmentWorkflowStepFactory
+
+
+@ddt.ddt
+class TeamAssessmentTest(CacheResetTest):
+    """ Tests for the TeamAssessmentWorkflow model """
+    team_submission_uuid = 'team-submission-uuid'
+    submission_uuids = ['submission-uuid-' + str(i) for i in range(5)]
+    course_id = 'edx/Teamwork/Cooperation'
+    item_id = 'this-is-an-item-id-i-guess'
+    MOCK_TEAM_SUBMISSION = {
+        'team_submission_uuid': team_submission_uuid,
+        'submission_uuids': submission_uuids,
+        'course_id': course_id,
+        'item_id': item_id
+    }
+
+    def setUp(self):
+        super(TeamAssessmentTest, self).setUp()
+        self.workflow_step_api_patcher = mock.patch.object(AssessmentWorkflowStep, 'api')
+        mocked_workflow_api = self.workflow_step_api_patcher.start()
+        self.mock_assessment_api = mock.Mock()
+        mocked_workflow_api.return_value = self.mock_assessment_api
+
+    def tearDown(self):
+        super(TeamAssessmentTest, self).tearDown()
+        self.workflow_step_api_patcher.stop()
+
+    @contextmanager
+    def mock_submissions_api_get(self, return_value=None):
+        return_value = return_value or self.MOCK_TEAM_SUBMISSION
+        with mock.patch(
+            'openassessment.workflow.models.sub_team_api.get_team_submission',
+            return_value=return_value
+        ):
+            yield
+
+    def test_start_workflow(self):
+        with self.mock_submissions_api_get():
+            team_workflow = TeamAssessmentWorkflow.start_workflow(self.team_submission_uuid)
+        self.assertEqual(team_workflow.team_submission_uuid, self.team_submission_uuid)
+        self.assertIn(team_workflow.submission_uuid, self.submission_uuids)
+        self.assertEqual(team_workflow.status, TeamAssessmentWorkflow.STATUS.teams)
+        self.assertEqual(team_workflow.course_id, self.course_id)
+        self.assertEqual(team_workflow.item_id, self.item_id)
+
+        step_names = [step.name for step in team_workflow.steps.all()]
+        self.assertEqual(step_names, ['teams'])
+
+        self.mock_assessment_api.on_init.assert_called_once()
+
+    def test_start_workflow_no_individual_submissions(self):
+        submission = dict(self.MOCK_TEAM_SUBMISSION)
+        submission['submission_uuids'] = []
+        with self.assertRaises(AssessmentWorkflowInternalError):
+            with self.mock_submissions_api_get(submission):
+                TeamAssessmentWorkflow.start_workflow(self.team_submission_uuid)
+
+    def test_get_steps(self):
+        with self.mock_submissions_api_get():
+            workflow = TeamAssessmentWorkflow.start_workflow(self.team_submission_uuid)
+        steps = workflow._get_steps()  # pylint: disable=protected-access
+        self.assertEqual(len(steps), 1)
+        self.assertEqual(steps[0].name, TeamAssessmentWorkflow.TEAM_STAFF_STEP_NAME)
+
+    def test_get_steps_multiple_step_error(self):
+        with self.mock_submissions_api_get():
+            workflow = TeamAssessmentWorkflow.start_workflow(self.team_submission_uuid)
+        AssessmentWorkflowStepFactory.create(workflow=workflow)
+        workflow.refresh_from_db()
+        with self.assertRaises(AssessmentWorkflowInternalError):
+            workflow._get_steps()  # pylint: disable=protected-access
+
+    def test_get_steps_wrong_type(self):
+        with self.mock_submissions_api_get():
+            workflow = TeamAssessmentWorkflow.start_workflow(self.team_submission_uuid)
+        step = workflow._get_steps()[0]  # pylint: disable=protected-access
+        step.name = 'peer'
+        step.save()
+        with self.assertRaises(AssessmentWorkflowInternalError):
+            workflow._get_steps()  # pylint: disable=protected-access
+
+    def _update_from_assessments(self, workflow, submissions_api_fake_score, assessment_api_fake_score):
+        self.mock_assessment_api.get_score.return_value = assessment_api_fake_score
+        with mock.patch(
+            'openassessment.workflow.models.sub_api.get_latest_score_for_submission',
+            return_value=submissions_api_fake_score
+        ):
+            workflow.update_from_assessments()
+
+    @freeze_time("2020-05-03")
+    @ddt.data(None, 5)
+    @mock.patch('openassessment.workflow.models.sub_team_api.set_score')
+    def test_update_from_assessments(self, old_score_points_earned, mock_set_team_score):
+        """
+        There is no score recorded in the submissions api, or the score is different than the one we
+        have gotten from the assessment module
+        """
+        submissions_api_fake_score = None
+        if old_score_points_earned:
+            submissions_api_fake_score = {
+                'annotations': [{'annotation_type': TeamAssessmentWorkflow.STAFF_ANNOTATION_TYPE}],
+                'points_earned': old_score_points_earned
+            }
+
+        assessment_api_fake_score = {
+            "points_earned": 9,
+            "points_possible": 10,
+            "contributing_assessments": ['assessment_1_id'],
+            "staff_id": 'staff_id',
+        }
+
+        with self.mock_submissions_api_get():
+            workflow = TeamAssessmentWorkflow.start_workflow(self.team_submission_uuid)
+
+        self.mock_assessment_api.assessment_is_finished.return_value = True
+        self._update_from_assessments(workflow, submissions_api_fake_score, assessment_api_fake_score)
+
+        workflow.refresh_from_db()
+        self.assertEqual(workflow.status, TeamAssessmentWorkflow.STATUS.done)
+        self.assertEqual(workflow._team_staff_step.assessment_completed_at, now())  # pylint: disable=protected-access
+        mock_set_team_score.assert_called_with(
+            self.team_submission_uuid,
+            9,
+            10,
+            annotation_creator='staff_id',
+            annotation_type=TeamAssessmentWorkflow.STAFF_ANNOTATION_TYPE,
+            annotation_reason='A staff member has defined the score for this submission'
+        )
+
+    @freeze_time("2020-05-03")
+    @mock.patch('openassessment.workflow.models.sub_team_api.set_score')
+    def test_update_from_assessments_old_and_new_points_equal(self, mock_set_team_score):
+        """ There is already an equal score recorded in the submissions API """
+        submissions_api_fake_score = {
+            'annotations': [{'annotation_type': TeamAssessmentWorkflow.STAFF_ANNOTATION_TYPE}],
+            'points_earned': 9
+        }
+        assessment_api_fake_score = {
+            "points_earned": 9,
+            "points_possible": 10,
+            "contributing_assessments": ['assessment_1_id'],
+            "staff_id": 'staff_id',
+        }
+        with self.mock_submissions_api_get():
+            workflow = TeamAssessmentWorkflow.start_workflow(self.team_submission_uuid)
+
+        self.mock_assessment_api.assessment_is_finished.return_value = True
+        self._update_from_assessments(workflow, submissions_api_fake_score, assessment_api_fake_score)
+        workflow.refresh_from_db()
+
+        self.assertEqual(workflow.status, TeamAssessmentWorkflow.STATUS.done)
+        self.assertEqual(workflow._team_staff_step.assessment_completed_at, now())  # pylint: disable=protected-access
+        mock_set_team_score.assert_not_called()

--- a/openassessment/workflow/test/test_models.py
+++ b/openassessment/workflow/test/test_models.py
@@ -28,14 +28,14 @@ class TeamAssessmentTest(CacheResetTest):
     }
 
     def setUp(self):
-        super(TeamAssessmentTest, self).setUp()
+        super().setUp()
         self.workflow_step_api_patcher = mock.patch.object(AssessmentWorkflowStep, 'api')
         mocked_workflow_api = self.workflow_step_api_patcher.start()
         self.mock_assessment_api = mock.Mock()
         mocked_workflow_api.return_value = self.mock_assessment_api
 
     def tearDown(self):
-        super(TeamAssessmentTest, self).tearDown()
+        super().tearDown()
         self.workflow_step_api_patcher.stop()
 
     @contextmanager

--- a/openassessment/workflow/test/test_team_api.py
+++ b/openassessment/workflow/test/test_team_api.py
@@ -1,35 +1,66 @@
 """ Test Cases for Team Workflow API """
 import uuid
 
-from openassessment.workflow.models import TeamAssessmentWorkflow
+from submissions import team_api as sub_team_api
+
+from openassessment.workflow.models import TeamAssessmentWorkflow, AssessmentWorkflowStep
 from openassessment.test_utils import CacheResetTest
 from openassessment.workflow import team_api
+from openassessment.tests.factories import UserFactory
 
 
 class TestTeamAssessmentWorkflowApi(CacheResetTest):
     """ Test team assessment workflow API """
 
-    def test_create_workflow(self):
-        # Given a test UUID
-        # When I create a workflow
-        team_workflow = team_api.create_workflow('foo')
+    course_id = 'edx/Teamwork/Cooperation'
+    item_id = 'this-is-an-item-id-i-guess'
+    users = []
+    team_submission_dict = {}
+    team_submission_uuid = None
+    submission_uuids = []
 
-        # TODO - Complete in https://openedx.atlassian.net/browse/EDUCATOR-4986
-        assert team_workflow is not None
+    def _create_submission(self):
+        """
+        Create a test team submission through the submissions api
+        """
+        self.users = [UserFactory.create() for _ in range(5)]
+        self.team_submission_dict = sub_team_api.create_submission_for_team(
+            self.course_id,
+            self.item_id,
+            'team-rocket',
+            self.users[0].id,
+            [user.id for user in self.users],
+            'this-is-my-answer',
+        )
+        self.team_submission_uuid = self.team_submission_dict['team_submission_uuid']
+        self.submission_uuids = self.team_submission_dict['submission_uuids']
+
+    def test_create_workflow(self):
+        self._create_submission()
+        team_workflow = team_api.create_workflow(self.team_submission_uuid)
+
+        self.assertEqual(team_workflow.team_submission_uuid, self.team_submission_uuid)
+        self.assertIn(team_workflow.submission_uuid, self.submission_uuids)
+        self.assertEqual(team_workflow.status, TeamAssessmentWorkflow.STATUS.teams)
+        self.assertEqual(team_workflow.course_id, self.course_id)
+        self.assertEqual(team_workflow.item_id, self.item_id)
+
+        step_names = [step.name for step in team_workflow.steps.all()]
+        self.assertEqual(step_names, ['teams'])
 
     def test_get_workflow(self):
-        # Given a workflow
-        self._create_test_workflow('foo')
+        self._create_submission()
+        team_api.create_workflow(self.team_submission_uuid)
 
         # When I get the workflow
-        team_workflow = team_api.get_workflow_for_submission('foo')
+        team_workflow = team_api.get_workflow_for_submission(self.team_submission_uuid)
 
         # It is updated and returns a correctly serialized version
-        assert team_workflow['team_submission_uuid'] == 'foo'
-        assert 'staff' in team_workflow['status_details']
+        assert team_workflow['team_submission_uuid'] == self.team_submission_uuid
+        assert 'teams' in team_workflow['status_details']
 
     def test_get_status_counts(self):
-        expected_steps = ['staff', 'waiting', 'done', 'cancelled']
+        expected_steps = ['teams', 'waiting', 'done', 'cancelled']
 
         # Initially, counts for all expected steps should be 0
         initial_counts = team_api.get_status_counts('test course', 'test item')
@@ -38,7 +69,7 @@ class TestTeamAssessmentWorkflowApi(CacheResetTest):
             assert {'status': step, 'count': 0} in initial_counts
 
         # Given some assessments
-        self._create_test_workflow('foo', 'staff')
+        self._create_test_workflow('foo', 'teams')
         self._create_test_workflow('bar', 'waiting')
         self._create_test_workflow('baz', 'done')
         self._create_test_workflow('biz', 'cancelled')
@@ -51,19 +82,19 @@ class TestTeamAssessmentWorkflowApi(CacheResetTest):
 
     def test_cancel_workflow(self):
         # Given a workflow
-        team_submission_uuid = 'foo'
-        team_workflow = self._create_test_workflow(team_submission_uuid)
+        self._create_submission()
+        team_workflow = team_api.create_workflow(self.team_submission_uuid)
 
         # When I cancel the workflow
         team_api.cancel_workflow(
-            team_submission_uuid=team_submission_uuid,
+            team_submission_uuid=self.team_submission_uuid,
             comments='cancelled',
             cancelled_by_id='my-id'
         )
 
         # The workflow status should be cancelled...
-        team_workflow = team_api.get_workflow_for_submission(team_submission_uuid)
-        self.assertTrue(team_api.is_workflow_cancelled(team_submission_uuid))
+        team_workflow = team_api.get_workflow_for_submission(self.team_submission_uuid)
+        self.assertTrue(team_api.is_workflow_cancelled(self.team_submission_uuid))
         self.assertEqual(team_workflow['status'], 'cancelled')
 
         # and the points/score should be 0
@@ -71,16 +102,16 @@ class TestTeamAssessmentWorkflowApi(CacheResetTest):
 
     def test_get_workflow_cancellation(self):
         # Given a cancelled workflow
-        team_submission_uuid = 'foo'
-        self._create_test_workflow(team_submission_uuid)
+        self._create_submission()
+        team_api.create_workflow(self.team_submission_uuid)
         team_api.cancel_workflow(
-            team_submission_uuid=team_submission_uuid,
+            team_submission_uuid=self.team_submission_uuid,
             comments='cancelled',
             cancelled_by_id='my-id'
         )
 
         # When I query for a cancelled flow
-        cancellation = team_api.get_assessment_workflow_cancellation(team_submission_uuid)
+        cancellation = team_api.get_assessment_workflow_cancellation(self.team_submission_uuid)
 
         # Then I get serialized info from the cancellation
         self.assertEqual(cancellation['comments'], 'cancelled')
@@ -88,10 +119,16 @@ class TestTeamAssessmentWorkflowApi(CacheResetTest):
 
     def _create_test_workflow(self, team_submission_uuid, status=TeamAssessmentWorkflow.STATUS.waiting):
         """ Create a team workflow with filler values """
-        return TeamAssessmentWorkflow.objects.create(
+        workflow = TeamAssessmentWorkflow.objects.create(
             team_submission_uuid=team_submission_uuid,
             submission_uuid=uuid.uuid4(),  # generated to fulfill unique constraint
             status=status,
             course_id='test course',
             item_id='test item'
         )
+        AssessmentWorkflowStep.objects.create(
+            workflow=workflow,
+            name='teams',
+            order_num=1
+        )
+        return workflow

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.6.30",
+  "version": "2.7.1",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.7.0',
+    version='2.7.1',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
[EDUCATOR-4986: Implement TeamAssessmentWorkflow's start_workflow method
](https://openedx.atlassian.net/browse/EDUCATOR-4986)

@edx/masters-devs-gta 

Implement several methods on TeamAssessmentWorkflow.

This links together the Team Assessment Workflow API and the teams assessment api, so there were some test changes that also needed to be made.

- [x] Make sure your PR updates the version number in ``setup.py`` and ``package.json``
