### PR TITLE
[BD-6] Upgrade python packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ env:
   - TOX_ENV=js
   - TOX_ENV=quality
 
-jobs:
-  allow_failures:
-  - python: 3.8
-
 before_install:
   - "pip install -U pip"
   - export BOTO_CONFIG=/dev/null
@@ -43,5 +39,6 @@ deploy:
   on:
     tags: true
     condition: "$TOXENV=quality"
+    python: 3.5
   password:
     secure: F7yrAFt9c56Y/x29pNbI3LMEATc6DPDTqEXs5WDDRwse/JwKe3MSsXRv6ois6JKzWroHQOZu4CKBbtfZ8v4fWv8lT4kwMJzAq8I4tda4qaSWulHiTdefzkR147oW9db2lTAKFOZsV/XUFFsv2sHDK/SQiJ0y+nxTgoMxEILChnw=

--- a/openassessment/fileupload/tests/test_api.py
+++ b/openassessment/fileupload/tests/test_api.py
@@ -22,7 +22,7 @@ from django.test.utils import override_settings
 
 import boto
 from boto.s3.key import Key
-from moto import mock_s3
+from moto import mock_s3_deprecated
 from pytest import raises
 from openassessment.fileupload import api, exceptions, urls
 from openassessment.fileupload import views_filesystem as views
@@ -33,7 +33,7 @@ from openassessment.fileupload.backends.filesystem import get_cache as get_files
 @ddt.ddt
 class TestFileUploadService(TestCase):
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',
@@ -45,7 +45,7 @@ class TestFileUploadService(TestCase):
         uploadUrl = api.get_upload_url("foo", "bar")
         self.assertIn("/submissions_attachments/foo", uploadUrl)
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',
@@ -60,7 +60,7 @@ class TestFileUploadService(TestCase):
         downloadUrl = api.get_download_url("foo")
         self.assertIn("/submissions_attachments/foo", downloadUrl)
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',
@@ -85,28 +85,28 @@ class TestFileUploadService(TestCase):
         with raises(exceptions.FileUploadRequestError):
             api.get_upload_url("", "bar")
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',
         FILE_UPLOAD_STORAGE_BUCKET_NAME="mybucket"
     )
     @patch.object(boto, 'connect_s3')
-    def test_get_upload_url_error(self, mock_s3):
+    def test_get_upload_url_error(self, mock_s3_deprecated):
         with raises(exceptions.FileUploadInternalError):
-            mock_s3.side_effect = Exception("Oh noes")
+            mock_s3_deprecated.side_effect = Exception("Oh noes")
             api.get_upload_url("foo", "bar")
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',
         FILE_UPLOAD_STORAGE_BUCKET_NAME="mybucket"
     )
     @patch.object(boto, 'connect_s3')
-    def test_get_download_url_error(self, mock_s3):
+    def test_get_download_url_error(self, mock_s3_deprecated):
         with raises(exceptions.FileUploadInternalError):
-            mock_s3.side_effect = Exception("Oh noes")
+            mock_s3_deprecated.side_effect = Exception("Oh noes")
             api.get_download_url("foo")
 
 

--- a/openassessment/fileupload/tests/test_file_management.py
+++ b/openassessment/fileupload/tests/test_file_management.py
@@ -4,7 +4,7 @@ import mock
 from django.db import IntegrityError
 from django.test import TestCase
 from django.test.utils import override_settings
-from moto import mock_s3
+from moto import mock_s3_deprecated
 
 from openassessment.assessment.models.base import SharedFileUpload
 from openassessment.fileupload.api import get_student_file_key, FileUpload, FileUploadManager

--- a/openassessment/management/tests/test_upload_oa_data.py
+++ b/openassessment/management/tests/test_upload_oa_data.py
@@ -31,7 +31,7 @@ class UploadDataTest(CacheResetTest):
         "submission.csv", "score.csv",
     ]
 
-    @moto.mock_s3
+    @moto.mock_s3_deprecated
     def test_upload(self):
         # Create an S3 bucket using the fake S3 implementation
         conn = boto.connect_s3()

--- a/openassessment/xblock/test/test_leaderboard.py
+++ b/openassessment/xblock/test/test_leaderboard.py
@@ -15,7 +15,7 @@ from django.test.utils import override_settings
 
 import boto
 from boto.s3.key import Key
-from moto import mock_s3
+from moto import mock_s3_deprecated
 from openassessment.fileupload import api
 from openassessment.xblock.data_conversion import create_submission_dict, prepare_submission_for_serialization
 from submissions import api as sub_api
@@ -140,7 +140,7 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
             {'score': 1, 'files': []}
         ])
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',
@@ -160,7 +160,7 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
             {'score': 1, 'files': [], 'submission': ''}
         ])
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',
@@ -200,7 +200,7 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
             )}
         ])
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -15,7 +15,7 @@ from django.test.utils import override_settings
 
 import boto
 from boto.s3.key import Key
-from moto import mock_s3
+from moto import mock_s3_deprecated
 from django.contrib.auth import get_user_model
 from openassessment.fileupload import api
 from openassessment.workflow import api as workflow_api
@@ -146,7 +146,7 @@ class SubmissionTest(XBlockHandlerTestCase):
         expected_prompt = "&lt;code&gt;&lt;strong&gt;Question 123&lt;/strong&gt;&lt;/code&gt;"
         self.assertIn(expected_prompt, resp.decode('utf-8'))
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',
@@ -167,7 +167,7 @@ class SubmissionTest(XBlockHandlerTestCase):
             resp['url']
         )
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',
@@ -217,7 +217,7 @@ class SubmissionTest(XBlockHandlerTestCase):
             'fileSize': size,
         }
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',
@@ -286,7 +286,7 @@ class SubmissionTest(XBlockHandlerTestCase):
                     [meta['fileSize'] for meta in expected_file_metadata]
                 )
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',
@@ -300,7 +300,7 @@ class SubmissionTest(XBlockHandlerTestCase):
         self.assertTrue(resp['success'])
         self.assertEqual('', resp['url'])
 
-    @mock_s3
+    @mock_s3_deprecated
     @override_settings(
         AWS_ACCESS_KEY_ID='foobar',
         AWS_SECRET_ACCESS_KEY='bizbaz',

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,7 +6,7 @@ edx-i18n-tools
 edx-submissions
 djangorestframework
 Xblock
-git+https://github.com/edx/xblock-sdk.git@74bf5d6010b37e591a687e1e227263d689412279#egg=xblock-sdk
+git+https://github.com/edx/xblock-sdk.git@446e979bad1f3bf7f891787b32d5b2e7620b2f23#egg=xblock-sdk
 
 django
 django-simple-history

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via fs
+appdirs==1.4.4            # via fs
 bleach==3.1.5             # via -r requirements/base.in
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/base.in
 certifi==2020.4.5.1       # via requests
@@ -14,15 +14,15 @@ django-model-utils==4.0.0  # via -r requirements/base.in, edx-submissions
 django-simple-history==2.10.0  # via -r requirements/base.in
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
 djangorestframework==3.9.4  # via -r requirements/base.in, edx-submissions
-edx-i18n-tools==0.5.0     # via -r requirements/base.in
-edx-submissions==3.1.3    # via -r requirements/base.in
+edx-i18n-tools==0.5.1     # via -r requirements/base.in
+edx-submissions==3.1.5    # via -r requirements/base.in
 fs==2.0.18                # via -c requirements/constraints.txt, xblock
 html5lib==1.0.1           # via -r requirements/base.in
-idna==2.9                 # via requests
+idna==2.8                 # via -c requirements/constraints.txt, requests
 importlib-metadata==1.6.0  # via path
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in, edx-submissions
 lazy==1.4                 # via -r requirements/base.in
-libsass==0.19.4           # via -r requirements/base.in
+libsass==0.20.0           # via -r requirements/base.in
 loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements/base.in
 lxml==4.5.0               # via -r requirements/base.in, xblock
 markupsafe==1.1.1         # via xblock
@@ -41,11 +41,11 @@ six==1.14.0               # via bleach, django-simple-history, edx-i18n-tools, f
 sqlparse==0.3.1           # via django
 urllib3==1.25.9           # via requests
 voluptuous==0.11.7        # via -c requirements/constraints.txt, -r requirements/base.in
-web-fragments==0.3.1      # via xblock
+web-fragments==0.3.2      # via xblock
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.6              # via xblock
-git+https://github.com/edx/xblock-sdk.git@74bf5d6010b37e591a687e1e227263d689412279#egg=xblock-sdk  # via -r requirements/base.in
-xblock==1.2.9             # via -r requirements/base.in
+git+https://github.com/edx/xblock-sdk.git@446e979bad1f3bf7f891787b32d5b2e7620b2f23#egg=xblock-sdk  # via -r requirements/base.in
+xblock==1.3.1             # via -r requirements/base.in
 zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,4 +18,4 @@ zipp==1.0.0                        # zipp 2.0.0 requires Python >= 3.6
 
 # Test dependencies
 ddt==1.0.0                          # Test failures at versions > 1.0.0
-moto==0.4.31                        # Pinned to avoid test failures
+idna<2.9.0                          # moto version moto==1.3.14 requires idna<2.9.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.1.0          # via -r requirements/pip-tools.in
+pip-tools==5.1.2          # via -r requirements/pip-tools.in
 six==1.14.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,18 +4,26 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via -r requirements/test.txt, fs, virtualenv
+appdirs==1.4.4            # via -r requirements/test.txt, fs, virtualenv
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.4.0       # via -r requirements/test.txt, pytest
-attrs==19.3.0             # via -r requirements/test.txt, pytest
+attrs==19.3.0             # via -r requirements/test.txt, jsonschema, pytest
+aws-sam-translator==1.23.0  # via -r requirements/test.txt, cfn-lint
+aws-xray-sdk==2.5.0       # via -r requirements/test.txt, moto
 bleach==3.1.5             # via -r requirements/test.txt
+boto3==1.13.7             # via -r requirements/test.txt, aws-sam-translator, moto
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/test.txt, django-pyfs, moto
+botocore==1.16.7          # via -r requirements/test.txt, aws-xray-sdk, boto3, moto, s3transfer
 certifi==2020.4.5.1       # via -r requirements/test.txt, requests
+cffi==1.14.0              # via -r requirements/test.txt, cryptography
+cfn-lint==0.30.1          # via -r requirements/test.txt, moto
 chardet==3.0.4            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
+cryptography==2.9.2       # via -r requirements/test.txt, moto, sshpubkeys
 ddt==1.0.0                # via -c requirements/constraints.txt, -r requirements/test.txt
+decorator==4.4.2          # via -r requirements/test.txt, networkx
 defusedxml==0.6.0         # via -r requirements/test.txt
 distlib==0.3.0            # via -r requirements/test.txt, virtualenv
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-submissions
@@ -23,32 +31,42 @@ git+https://github.com/edx/django-pyfs.git@1.0.6#egg=django-pyfs  # via -r requi
 django-simple-history==2.10.0  # via -r requirements/test.txt
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, django-pyfs, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
 djangorestframework==3.9.4  # via -r requirements/test.txt, edx-submissions
-edx-i18n-tools==0.5.0     # via -r requirements/test.txt
-edx-submissions==3.1.3    # via -r requirements/test.txt
+docker==4.2.0             # via -r requirements/test.txt, moto
+docutils==0.15.2          # via -r requirements/test.txt, botocore
+ecdsa==0.15               # via -r requirements/test.txt, python-jose, sshpubkeys
+edx-i18n-tools==0.5.1     # via -r requirements/test.txt
+edx-submissions==3.1.5    # via -r requirements/test.txt
 git+https://github.com/edx/edx-lint.git@1.3.0#egg=edx_lint  # via -r requirements/quality.in
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.0.3              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 freezegun==0.3.14         # via -r requirements/test.txt
 fs==2.0.18                # via -c requirements/constraints.txt, -r requirements/test.txt, django-pyfs, xblock
+future==0.18.2            # via -r requirements/test.txt, aws-xray-sdk
 html5lib==1.0.1           # via -r requirements/test.txt
-httpretty==0.8.10         # via -r requirements/test.txt, moto
-idna==2.9                 # via -r requirements/test.txt, requests
-importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, path, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
+idna==2.8                 # via -c requirements/constraints.txt, -r requirements/test.txt, moto, requests
+importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, jsonpickle, jsonschema, path, pluggy, tox, virtualenv
+importlib-resources==1.5.0  # via -r requirements/test.txt, cfn-lint, virtualenv
 isort==4.3.21             # via pylint
 jinja2==2.11.2            # via -r requirements/test.txt, moto
+jmespath==0.9.5           # via -r requirements/test.txt, boto3, botocore
+jsondiff==1.1.2           # via -r requirements/test.txt, moto
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-submissions
+jsonpatch==1.25           # via -r requirements/test.txt, cfn-lint
+jsonpickle==1.4.1         # via -r requirements/test.txt, aws-xray-sdk
+jsonpointer==2.0          # via -r requirements/test.txt, jsonpatch
+jsonschema==3.2.0         # via -r requirements/test.txt, aws-sam-translator, cfn-lint
 lazy-object-proxy==1.4.3  # via astroid
 lazy==1.4                 # via -r requirements/test.txt
-libsass==0.19.4           # via -r requirements/test.txt
+libsass==0.20.0           # via -r requirements/test.txt
 loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements/test.txt
 lxml==4.5.0               # via -r requirements/test.txt, xblock
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2, xblock
 mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt, moto
 more-itertools==8.2.0     # via -r requirements/test.txt, pytest, zipp
-moto==0.4.31              # via -c requirements/constraints.txt, -r requirements/test.txt
+moto==1.3.14              # via -r requirements/test.txt
+networkx==2.4             # via -r requirements/test.txt, cfn-lint
 packaging==20.3           # via -r requirements/test.txt, bleach, tox
 path.py==12.4.0           # via -r requirements/test.txt, edx-i18n-tools
 path==13.1.0              # via -r requirements/test.txt, path.py
@@ -56,37 +74,46 @@ pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
 py==1.8.1                 # via -r requirements/test.txt, pytest, tox
-pycodestyle==2.5.0        # via -r requirements/quality.in
+pyasn1==0.4.8             # via -r requirements/test.txt, python-jose, rsa
+pycodestyle==2.6.0        # via -r requirements/quality.in
+pycparser==2.20           # via -r requirements/test.txt, cffi
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
+pyrsistent==0.16.0        # via -r requirements/test.txt, jsonschema
 pytest-cov==2.7.1         # via -r requirements/test.txt
 pytest-django==3.7.0      # via -r requirements/test.txt
 pytest==4.5.0             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/test.txt, faker, freezegun, moto, xblock
+python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/test.txt, botocore, faker, freezegun, moto, xblock
+python-jose==3.1.0        # via -r requirements/test.txt, moto
 python-swiftclient==3.9.0  # via -c requirements/constraints.txt, -r requirements/test.txt
 pytz==2020.1              # via -r requirements/test.txt, django, edx-submissions, fs, moto, xblock
-pyyaml==5.3.1             # via -r requirements/test.txt, edx-i18n-tools, xblock
-requests==2.23.0          # via -r requirements/test.txt, moto, python-swiftclient
-six==1.14.0               # via -r requirements/test.txt, astroid, bleach, django-pyfs, django-simple-history, edx-i18n-tools, edx-lint, freezegun, fs, html5lib, libsass, mock, moto, packaging, pathlib2, pylint, pytest, python-dateutil, python-swiftclient, tox, virtualenv, xblock
+pyyaml==5.3.1             # via -r requirements/test.txt, cfn-lint, edx-i18n-tools, moto, xblock
+requests==2.23.0          # via -r requirements/test.txt, docker, moto, python-swiftclient, responses
+responses==0.10.14        # via -r requirements/test.txt, moto
+rsa==4.0                  # via -r requirements/test.txt, python-jose
+s3transfer==0.3.3         # via -r requirements/test.txt, boto3
+six==1.14.0               # via -r requirements/test.txt, astroid, aws-sam-translator, bleach, cfn-lint, cryptography, django-pyfs, django-simple-history, docker, ecdsa, edx-i18n-tools, edx-lint, freezegun, fs, html5lib, jsonschema, libsass, mock, moto, packaging, pathlib2, pylint, pyrsistent, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
 sqlparse==0.3.1           # via -r requirements/test.txt, django
+sshpubkeys==3.1.0         # via -r requirements/test.txt, moto
 testfixtures==6.14.1      # via -r requirements/test.txt
 text-unidecode==1.3       # via -r requirements/test.txt, faker
 toml==0.10.0              # via -r requirements/test.txt, tox
-tox==3.14.6               # via -r requirements/test.txt
-urllib3==1.25.9           # via -r requirements/test.txt, requests
-virtualenv==20.0.18       # via -r requirements/test.txt, tox
+tox==3.15.0               # via -r requirements/test.txt
+urllib3==1.25.9           # via -r requirements/test.txt, botocore, requests
+virtualenv==20.0.20       # via -r requirements/test.txt, tox
 voluptuous==0.11.7        # via -c requirements/constraints.txt, -r requirements/test.txt
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
-web-fragments==0.3.1      # via -r requirements/test.txt, xblock
+web-fragments==0.3.2      # via -r requirements/test.txt, xblock
 webencodings==0.5.1       # via -r requirements/test.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/test.txt, xblock
+websocket-client==0.57.0  # via -r requirements/test.txt, docker
 werkzeug==1.0.1           # via -r requirements/test.txt, moto
-wrapt==1.12.1             # via astroid
-git+https://github.com/edx/xblock-sdk.git@74bf5d6010b37e591a687e1e227263d689412279#egg=xblock-sdk  # via -r requirements/test.txt
-xblock==1.2.9             # via -r requirements/test.txt
+wrapt==1.12.1             # via -r requirements/test.txt, astroid, aws-xray-sdk
+git+https://github.com/edx/xblock-sdk.git@446e979bad1f3bf7f891787b32d5b2e7620b2f23#egg=xblock-sdk  # via -r requirements/test.txt
+xblock==1.3.1             # via -r requirements/test.txt
 xmltodict==0.12.0         # via -r requirements/test.txt, moto
 zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -4,16 +4,24 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via -r requirements/test.txt, fs, virtualenv
+appdirs==1.4.4            # via -r requirements/test.txt, fs, virtualenv
 atomicwrites==1.4.0       # via -r requirements/test.txt, pytest
-attrs==19.3.0             # via -r requirements/test.txt, pytest
+attrs==19.3.0             # via -r requirements/test.txt, jsonschema, pytest
+aws-sam-translator==1.23.0  # via -r requirements/test.txt, cfn-lint
+aws-xray-sdk==2.5.0       # via -r requirements/test.txt, moto
 bleach==3.1.5             # via -r requirements/test.txt
-bok-choy==1.0.1           # via -r requirements/test-acceptance.in
+bok-choy==1.1.1           # via -r requirements/test-acceptance.in
+boto3==1.13.7             # via -r requirements/test.txt, aws-sam-translator, moto
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/test.txt, django-pyfs, moto
+botocore==1.16.7          # via -r requirements/test.txt, aws-xray-sdk, boto3, moto, s3transfer
 certifi==2020.4.5.1       # via -r requirements/test.txt, requests
+cffi==1.14.0              # via -r requirements/test.txt, cryptography
+cfn-lint==0.30.1          # via -r requirements/test.txt, moto
 chardet==3.0.4            # via -r requirements/test.txt, requests
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
+cryptography==2.9.2       # via -r requirements/test.txt, moto, sshpubkeys
 ddt==1.0.0                # via -c requirements/constraints.txt, -r requirements/test-acceptance.in, -r requirements/test.txt
+decorator==4.4.2          # via -r requirements/test.txt, networkx
 defusedxml==0.6.0         # via -r requirements/test.txt
 distlib==0.3.0            # via -r requirements/test.txt, virtualenv
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-submissions
@@ -21,28 +29,38 @@ git+https://github.com/edx/django-pyfs.git@1.0.6#egg=django-pyfs  # via -r requi
 django-simple-history==2.10.0  # via -r requirements/test.txt
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, django-pyfs, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
 djangorestframework==3.9.4  # via -r requirements/test.txt, edx-submissions
-edx-i18n-tools==0.5.0     # via -r requirements/test.txt
-edx-submissions==3.1.3    # via -r requirements/test.txt
+docker==4.2.0             # via -r requirements/test.txt, moto
+docutils==0.15.2          # via -r requirements/test.txt, botocore
+ecdsa==0.15               # via -r requirements/test.txt, python-jose, sshpubkeys
+edx-i18n-tools==0.5.1     # via -r requirements/test.txt
+edx-submissions==3.1.5    # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.0.3              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 freezegun==0.3.14         # via -r requirements/test.txt
 fs==2.0.18                # via -c requirements/constraints.txt, -r requirements/test.txt, django-pyfs, xblock
+future==0.18.2            # via -r requirements/test.txt, aws-xray-sdk
 html5lib==1.0.1           # via -r requirements/test.txt
-httpretty==0.8.10         # via -r requirements/test.txt, moto
-idna==2.9                 # via -r requirements/test.txt, requests
-importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, path, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
+idna==2.8                 # via -c requirements/constraints.txt, -r requirements/test.txt, moto, requests
+importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, jsonpickle, jsonschema, path, pluggy, tox, virtualenv
+importlib-resources==1.5.0  # via -r requirements/test.txt, cfn-lint, virtualenv
 jinja2==2.11.2            # via -r requirements/test.txt, moto
+jmespath==0.9.5           # via -r requirements/test.txt, boto3, botocore
+jsondiff==1.1.2           # via -r requirements/test.txt, moto
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-submissions
+jsonpatch==1.25           # via -r requirements/test.txt, cfn-lint
+jsonpickle==1.4.1         # via -r requirements/test.txt, aws-xray-sdk
+jsonpointer==2.0          # via -r requirements/test.txt, jsonpatch
+jsonschema==3.2.0         # via -r requirements/test.txt, aws-sam-translator, cfn-lint
 lazy==1.4                 # via -r requirements/test.txt, bok-choy
-libsass==0.19.4           # via -r requirements/test.txt
+libsass==0.20.0           # via -r requirements/test.txt
 loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements/test.txt
 lxml==4.5.0               # via -r requirements/test.txt, xblock
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2, xblock
-mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt, moto
 more-itertools==8.2.0     # via -r requirements/test.txt, pytest, zipp
-moto==0.4.31              # via -c requirements/constraints.txt, -r requirements/test.txt
+moto==1.3.14              # via -r requirements/test.txt
+networkx==2.4             # via -r requirements/test.txt, cfn-lint
 packaging==20.3           # via -r requirements/test.txt, bleach, tox
 path.py==12.4.0           # via -r requirements/test.txt, edx-i18n-tools
 path==13.1.0              # via -r requirements/test.txt, path.py
@@ -50,34 +68,44 @@ pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
 py==1.8.1                 # via -r requirements/test.txt, pytest, tox
+pyasn1==0.4.8             # via -r requirements/test.txt, python-jose, rsa
+pycparser==2.20           # via -r requirements/test.txt, cffi
 pyinstrument-cext==0.2.2  # via pyinstrument
 pyinstrument==3.1.3       # via -r requirements/test-acceptance.in
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
+pyrsistent==0.16.0        # via -r requirements/test.txt, jsonschema
 pytest-cov==2.7.1         # via -r requirements/test.txt
 pytest-django==3.7.0      # via -r requirements/test.txt
 pytest==4.5.0             # via -r requirements/test-acceptance.in, -r requirements/test.txt, pytest-cov, pytest-django
-python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/test.txt, faker, freezegun, moto, xblock
+python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/test.txt, botocore, faker, freezegun, moto, xblock
+python-jose==3.1.0        # via -r requirements/test.txt, moto
 python-swiftclient==3.9.0  # via -c requirements/constraints.txt, -r requirements/test.txt
 pytz==2020.1              # via -r requirements/test.txt, django, edx-submissions, fs, moto, xblock
-pyyaml==5.3.1             # via -r requirements/test.txt, edx-i18n-tools, xblock
-requests==2.23.0          # via -r requirements/test.txt, moto, python-swiftclient
+pyyaml==5.3.1             # via -r requirements/test.txt, cfn-lint, edx-i18n-tools, moto, xblock
+requests==2.23.0          # via -r requirements/test.txt, docker, moto, python-swiftclient, responses
+responses==0.10.14        # via -r requirements/test.txt, moto
+rsa==4.0                  # via -r requirements/test.txt, python-jose
+s3transfer==0.3.3         # via -r requirements/test.txt, boto3
 selenium==3.141.0         # via -r requirements/test-acceptance.in, bok-choy
-six==1.14.0               # via -r requirements/test.txt, bleach, bok-choy, django-pyfs, django-simple-history, edx-i18n-tools, freezegun, fs, html5lib, libsass, mock, moto, packaging, pathlib2, pytest, python-dateutil, python-swiftclient, tox, virtualenv, xblock
+six==1.14.0               # via -r requirements/test.txt, aws-sam-translator, bleach, bok-choy, cfn-lint, cryptography, django-pyfs, django-simple-history, docker, ecdsa, edx-i18n-tools, freezegun, fs, html5lib, jsonschema, libsass, mock, moto, packaging, pathlib2, pyrsistent, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
 sqlparse==0.3.1           # via -r requirements/test.txt, django
+sshpubkeys==3.1.0         # via -r requirements/test.txt, moto
 testfixtures==6.14.1      # via -r requirements/test.txt
 text-unidecode==1.3       # via -r requirements/test.txt, faker
 toml==0.10.0              # via -r requirements/test.txt, tox
-tox==3.14.6               # via -r requirements/test.txt
-urllib3==1.25.9           # via -r requirements/test.txt, requests, selenium
-virtualenv==20.0.18       # via -r requirements/test.txt, tox
+tox==3.15.0               # via -r requirements/test.txt
+urllib3==1.25.9           # via -r requirements/test.txt, botocore, requests, selenium
+virtualenv==20.0.20       # via -r requirements/test.txt, tox
 voluptuous==0.11.7        # via -c requirements/constraints.txt, -r requirements/test.txt
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
-web-fragments==0.3.1      # via -r requirements/test.txt, xblock
+web-fragments==0.3.2      # via -r requirements/test.txt, xblock
 webencodings==0.5.1       # via -r requirements/test.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/test.txt, xblock
+websocket-client==0.57.0  # via -r requirements/test.txt, docker
 werkzeug==1.0.1           # via -r requirements/test.txt, moto
-git+https://github.com/edx/xblock-sdk.git@74bf5d6010b37e591a687e1e227263d689412279#egg=xblock-sdk  # via -r requirements/test.txt
-xblock==1.2.9             # via -r requirements/test.txt
+wrapt==1.12.1             # via -r requirements/test.txt, aws-xray-sdk
+git+https://github.com/edx/xblock-sdk.git@446e979bad1f3bf7f891787b32d5b2e7620b2f23#egg=xblock-sdk  # via -r requirements/test.txt
+xblock==1.3.1             # via -r requirements/test.txt
 xmltodict==0.12.0         # via -r requirements/test.txt, moto
 zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,42 +4,60 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via -r requirements/base.txt, fs, virtualenv
+appdirs==1.4.4            # via -r requirements/base.txt, fs, virtualenv
 atomicwrites==1.4.0       # via pytest
-attrs==19.3.0             # via pytest
+attrs==19.3.0             # via jsonschema, pytest
+aws-sam-translator==1.23.0  # via cfn-lint
+aws-xray-sdk==2.5.0       # via moto
 bleach==3.1.5             # via -r requirements/base.txt
+boto3==1.13.7             # via aws-sam-translator, moto
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/base.txt, django-pyfs, moto
+botocore==1.16.7          # via aws-xray-sdk, boto3, moto, s3transfer
 certifi==2020.4.5.1       # via -r requirements/base.txt, requests
+cffi==1.14.0              # via cryptography
+cfn-lint==0.30.1          # via moto
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coverage==5.1             # via -r requirements/test.in, pytest-cov
+cryptography==2.9.2       # via moto, sshpubkeys
 ddt==1.0.0                # via -c requirements/constraints.txt, -r requirements/test.in
+decorator==4.4.2          # via networkx
 defusedxml==0.6.0         # via -r requirements/base.txt
 distlib==0.3.0            # via virtualenv
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-submissions
 git+https://github.com/edx/django-pyfs.git@1.0.6#egg=django-pyfs  # via -r requirements/test.in
 django-simple-history==2.10.0  # via -r requirements/base.txt
-edx-i18n-tools==0.5.0     # via -r requirements/base.txt
-edx-submissions==3.1.3    # via -r requirements/base.txt
+docker==4.2.0             # via moto
+docutils==0.15.2          # via botocore
+ecdsa==0.15               # via python-jose, sshpubkeys
+edx-i18n-tools==0.5.1     # via -r requirements/base.txt
+edx-submissions==3.1.5    # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.0.3              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 freezegun==0.3.14         # via -r requirements/test.in
 fs==2.0.18                # via -c requirements/constraints.txt, -r requirements/base.txt, django-pyfs, xblock
+future==0.18.2            # via aws-xray-sdk
 html5lib==1.0.1           # via -r requirements/base.txt
-httpretty==0.8.10         # via moto
-idna==2.9                 # via -r requirements/base.txt, requests
-importlib-metadata==1.6.0  # via -r requirements/base.txt, importlib-resources, path, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
+idna==2.8                 # via -c requirements/constraints.txt, -r requirements/base.txt, moto, requests
+importlib-metadata==1.6.0  # via -r requirements/base.txt, importlib-resources, jsonpickle, jsonschema, path, pluggy, tox, virtualenv
+importlib-resources==1.5.0  # via cfn-lint, virtualenv
 jinja2==2.11.2            # via moto
+jmespath==0.9.5           # via boto3, botocore
+jsondiff==1.1.2           # via moto
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-submissions
+jsonpatch==1.25           # via cfn-lint
+jsonpickle==1.4.1         # via aws-xray-sdk
+jsonpointer==2.0          # via jsonpatch
+jsonschema==3.2.0         # via aws-sam-translator, cfn-lint
 lazy==1.4                 # via -r requirements/base.txt
-libsass==0.19.4           # via -r requirements/base.txt
+libsass==0.20.0           # via -r requirements/base.txt
 loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements/base.txt
 lxml==4.5.0               # via -r requirements/base.txt, xblock
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2, xblock
-mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in, moto
 more-itertools==8.2.0     # via -r requirements/base.txt, -r requirements/test.in, pytest, zipp
-moto==0.4.31              # via -c requirements/constraints.txt, -r requirements/test.in
+moto==1.3.14              # via -r requirements/test.in
+networkx==2.4             # via cfn-lint
 packaging==20.3           # via -r requirements/base.txt, bleach, tox
 path.py==12.4.0           # via -r requirements/base.txt, edx-i18n-tools
 path==13.1.0              # via -r requirements/base.txt, path.py
@@ -47,31 +65,41 @@ pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest, tox
 polib==1.1.0              # via -r requirements/base.txt, edx-i18n-tools
 py==1.8.1                 # via pytest, tox
+pyasn1==0.4.8             # via python-jose, rsa
+pycparser==2.20           # via cffi
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
+pyrsistent==0.16.0        # via jsonschema
 pytest-cov==2.7.1         # via -r requirements/test.in
 pytest-django==3.7.0      # via -r requirements/test.in
 pytest==4.5.0             # via -r requirements/test.in, pytest-cov, pytest-django
-python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/base.txt, faker, freezegun, moto, xblock
+python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/base.txt, botocore, faker, freezegun, moto, xblock
+python-jose==3.1.0        # via moto
 python-swiftclient==3.9.0  # via -c requirements/constraints.txt, -r requirements/base.txt
 pytz==2020.1              # via -r requirements/base.txt, django, edx-submissions, fs, moto, xblock
-pyyaml==5.3.1             # via -r requirements/base.txt, edx-i18n-tools, xblock
-requests==2.23.0          # via -r requirements/base.txt, moto, python-swiftclient
-six==1.14.0               # via -r requirements/base.txt, bleach, django-pyfs, django-simple-history, edx-i18n-tools, freezegun, fs, html5lib, libsass, mock, moto, packaging, pathlib2, pytest, python-dateutil, python-swiftclient, tox, virtualenv, xblock
+pyyaml==5.3.1             # via -r requirements/base.txt, cfn-lint, edx-i18n-tools, moto, xblock
+requests==2.23.0          # via -r requirements/base.txt, docker, moto, python-swiftclient, responses
+responses==0.10.14        # via moto
+rsa==4.0                  # via python-jose
+s3transfer==0.3.3         # via boto3
+six==1.14.0               # via -r requirements/base.txt, aws-sam-translator, bleach, cfn-lint, cryptography, django-pyfs, django-simple-history, docker, ecdsa, edx-i18n-tools, freezegun, fs, html5lib, jsonschema, libsass, mock, moto, packaging, pathlib2, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
 sqlparse==0.3.1           # via -r requirements/base.txt, django
+sshpubkeys==3.1.0         # via moto
 testfixtures==6.14.1      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
 toml==0.10.0              # via tox
-tox==3.14.6               # via -r requirements/test.in
-urllib3==1.25.9           # via -r requirements/base.txt, requests
-virtualenv==20.0.18       # via tox
+tox==3.15.0               # via -r requirements/test.in
+urllib3==1.25.9           # via -r requirements/base.txt, botocore, requests
+virtualenv==20.0.20       # via tox
 voluptuous==0.11.7        # via -c requirements/constraints.txt, -r requirements/base.txt
 wcwidth==0.1.9            # via pytest
-web-fragments==0.3.1      # via -r requirements/base.txt, xblock
+web-fragments==0.3.2      # via -r requirements/base.txt, xblock
 webencodings==0.5.1       # via -r requirements/base.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/base.txt, xblock
+websocket-client==0.57.0  # via docker
 werkzeug==1.0.1           # via moto
-git+https://github.com/edx/xblock-sdk.git@74bf5d6010b37e591a687e1e227263d689412279#egg=xblock-sdk  # via -r requirements/base.txt
-xblock==1.2.9             # via -r requirements/base.txt
+wrapt==1.12.1             # via aws-xray-sdk
+git+https://github.com/edx/xblock-sdk.git@446e979bad1f3bf7f891787b32d5b2e7620b2f23#egg=xblock-sdk  # via -r requirements/base.txt
+xblock==1.3.1             # via -r requirements/base.txt
 xmltodict==0.12.0         # via moto
 zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata, importlib-resources
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.7.2',
+    version='2.7.3',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',
@@ -52,6 +52,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
     ],
     packages=find_packages(include=['openassessment*'], exclude=['*.test', '*.tests']),
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -2,20 +2,19 @@
 envlist = py35-django{22}, py38-django{22,30}
 
 [testenv]
-whitelist_externals = make
 deps =
     coveralls
     -rrequirements/test.txt
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
 commands =
-    make test-python
+    pytest
 
 [testenv:js]
 whitelist_externals = make
 deps =
     -rrequirements/test.txt
-    django22: Django>=2.2,<2.3
+    Django>=2.2,<2.3
 commands =
     make install-js
     make javascript


### PR DESCRIPTION
Upgrade packages in order to pass python 3.8 tests.

Updated https://github.com/edx/xblock-sdk.git to the latest version, 

Unpin moto. Force js tests to use Django2.2

Create new release.

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179