### PR TITLE
EDUCATOR-5022: Show Team Submission Count in Instructor Dashboard

### DIFF
--- a/openassessment/assessment/api/teams.py
+++ b/openassessment/assessment/api/teams.py
@@ -85,7 +85,11 @@ def on_init(team_submission_uuid):
         TeamStaffWorkflow.objects.get_or_create(
             course_id=team_submission['course_id'],
             item_id=team_submission['item_id'],
-            team_submission_uuid=team_submission_uuid
+            team_submission_uuid=team_submission_uuid,
+            # submission_uuid is currently not used in any logic in TeamStaffWorkflow, so we don't
+            # realy care which submission is chosen and it doesn't need to match the TeamAssessment Workflow.
+            # It must be filled because of the unique constraint on the field (can't have multiple '' values)
+            submission_uuid=team_submission['submission_uuids'][0],
         )
     except DatabaseError:
         error_message = (

--- a/openassessment/assessment/test/test_team.py
+++ b/openassessment/assessment/test/test_team.py
@@ -97,7 +97,8 @@ class TestTeamApi(CacheResetTest):
         mock_get_submission.return_value = {
             'team_submission_uuid': team_submission_uuid,
             'course_id': 'fake_course',
-            'item_id': 'fake_item'
+            'item_id': 'fake_item',
+            'submission_uuids': ['uuid1', 'uuid2', 'uuid3']
         }
 
         # When I initialize an assessment

--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -12,7 +12,7 @@ import six
 from django.conf import settings
 
 from openassessment.assessment.models import Assessment, AssessmentFeedback, AssessmentPart
-from openassessment.workflow.models import AssessmentWorkflow
+from openassessment.workflow.models import AssessmentWorkflow, TeamAssessmentWorkflow
 from submissions import api as sub_api
 
 
@@ -527,10 +527,15 @@ class OraAggregateData:
             }
 
         """
+
+        all_valid_ora_statuses = set()
+        all_valid_ora_statuses.update(AssessmentWorkflow().STATUS_VALUES)
+        all_valid_ora_statuses.update(TeamAssessmentWorkflow().STATUS_VALUES)
+
         if desired_statuses:
-            statuses = [st for st in AssessmentWorkflow().STATUS_VALUES if st in desired_statuses]
+            statuses = [st for st in all_valid_ora_statuses if st in desired_statuses]
         else:
-            statuses = AssessmentWorkflow().STATUS_VALUES
+            statuses = all_valid_ora_statuses
 
         items = AssessmentWorkflow.objects.filter(course_id=course_id, status__in=statuses).values('item_id', 'status')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.7.3',
+    version='2.7.4',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
[EDUCATOR-5022: Show Team Submission Count in Instructor Dashboard](https://openedx.atlassian.net/browse/EDUCATOR-5022)

@edx/masters-devs-gta 

what is says on the tin. in the instructor dashboard, show the count of ora submissions!

I also had to make some other changes that I found while testing, specifically i had to add submission_uuid to the TeamAssessmentWorkflow 