### PR TITLE
EDUCATOR-5059: Teams Submissions are using usernames for submission student_id rather than anonymous user ids

### DIFF
--- a/openassessment/assessment/test/test_team.py
+++ b/openassessment/assessment/test/test_team.py
@@ -36,8 +36,11 @@ class TestTeamApi(CacheResetTest):
         cls.submitting_user_id = UserFactory.create().id
         team_member_1_id = UserFactory.create().id
         team_member_2_id = UserFactory.create().id
-
-        cls.team_member_ids = [cls.submitting_user_id, team_member_1_id, team_member_2_id]
+        user_ids = [cls.submitting_user_id, team_member_1_id, team_member_2_id]
+        cls.user_id_to_anonymous_id = {
+            user_id: 'anon_id_for_' + str(user_id) for user_id in user_ids
+        }
+        cls.team_member_ids = list(cls.user_id_to_anonymous_id.values())
 
         cls.default_assessment = (
             cls.staff_user_id,  # scorer_id

--- a/openassessment/assessment/test/test_team.py
+++ b/openassessment/assessment/test/test_team.py
@@ -37,10 +37,7 @@ class TestTeamApi(CacheResetTest):
         team_member_1_id = UserFactory.create().id
         team_member_2_id = UserFactory.create().id
         user_ids = [cls.submitting_user_id, team_member_1_id, team_member_2_id]
-        cls.user_id_to_anonymous_id = {
-            user_id: 'anon_id_for_' + str(user_id) for user_id in user_ids
-        }
-        cls.team_member_ids = list(cls.user_id_to_anonymous_id.values())
+        cls.team_member_ids = ['anon_id_for_{}'.format(user_id) for user_id in user_ids]
 
         cls.default_assessment = (
             cls.staff_user_id,  # scorer_id

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -399,7 +399,7 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
         workflow_api.create_workflow(submission_uuid, steps if steps else STEPS)
         return submission
 
-    def _create_team_submission(self, course_id, item_id, team_id, team_member_ids):
+    def _create_team_submission(self, course_id, item_id, team_id, submitting_user_id, team_member_student_ids):
         """
         Create a team submission and initialize a team workflow
         """
@@ -407,8 +407,8 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
             course_id,
             item_id,
             team_id,
-            team_member_ids[0],
-            team_member_ids,
+            submitting_user_id,
+            team_member_student_ids,
             ANSWER,
         )
         team_workflow_api.create_workflow(team_submission['team_submission_uuid'])
@@ -541,7 +541,8 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
         student_id4 = self._other_student(4)
         student_id5 = self._other_student(5)
         student_ids = [STUDENT_ID, student_id2, student_id3, student_id4, student_id5]
-        student_model_ids = [UserFactory.create(username=student_id).id for student_id in student_ids]
+        student_model_1 = UserFactory.create()
+        student_model_2 = UserFactory.create()
 
         self._create_submission(dict(
             student_id=STUDENT_ID,
@@ -579,13 +580,15 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
             COURSE_ID,
             team_item_id,
             'team_1',
-            student_model_ids[:3]
+            student_model_1.id,
+            student_ids[:3],
         )
         self._create_team_submission(
             COURSE_ID,
             team_item_id,
             'team_2',
-            student_model_ids[3:]
+            student_model_2.id,
+            student_ids[3:]
         )
 
         data = OraAggregateData.collect_ora2_responses(COURSE_ID)

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -538,9 +538,12 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
 
         student_id2 = self._other_student(2)
         student_id3 = self._other_student(3)
+        team_1_ids = [STUDENT_ID, student_id2, student_id3]
+
         student_id4 = self._other_student(4)
         student_id5 = self._other_student(5)
-        student_ids = [STUDENT_ID, student_id2, student_id3, student_id4, student_id5]
+        team_2_ids = [student_id4, student_id5]
+
         student_model_1 = UserFactory.create()
         student_model_2 = UserFactory.create()
 
@@ -581,14 +584,14 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
             team_item_id,
             'team_1',
             student_model_1.id,
-            student_ids[:3],
+            team_1_ids,
         )
         self._create_team_submission(
             COURSE_ID,
             team_item_id,
             'team_2',
             student_model_2.id,
-            student_ids[3:]
+            team_2_ids
         )
 
         data = OraAggregateData.collect_ora2_responses(COURSE_ID)

--- a/openassessment/workflow/test/test_team_api.py
+++ b/openassessment/workflow/test/test_team_api.py
@@ -24,14 +24,14 @@ class TestTeamAssessmentWorkflowApi(CacheResetTest):
         Create a test team submission through the submissions api
         """
         self.users = [UserFactory.create() for _ in range(5)]
-        self.anonymous_user_ids = ['anonymous_user_id_for_' + user.username for user in self.users]
+        anonymous_user_ids = ['anonymous_user_id_for_' + user.username for user in self.users]
 
         self.team_submission_dict = sub_team_api.create_submission_for_team(
             self.course_id,
             self.item_id,
             'team-rocket',
             self.users[0].id,
-            self.anonymous_user_ids,
+            anonymous_user_ids,
             'this-is-my-answer',
         )
         self.team_submission_uuid = self.team_submission_dict['team_submission_uuid']

--- a/openassessment/workflow/test/test_team_api.py
+++ b/openassessment/workflow/test/test_team_api.py
@@ -24,12 +24,14 @@ class TestTeamAssessmentWorkflowApi(CacheResetTest):
         Create a test team submission through the submissions api
         """
         self.users = [UserFactory.create() for _ in range(5)]
+        self.anonymous_user_ids = ['anonymous_user_id_for_' + user.username for user in self.users]
+
         self.team_submission_dict = sub_team_api.create_submission_for_team(
             self.course_id,
             self.item_id,
             'team-rocket',
             self.users[0].id,
-            [user.id for user in self.users],
+            self.anonymous_user_ids,
             'this-is-my-answer',
         )
         self.team_submission_uuid = self.team_submission_dict['team_submission_uuid']

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -296,12 +296,13 @@ class SubmissionMixin:
         submitter_anonymous_user_id = self.xmodule_runtime.anonymous_student_id
         user = self.get_real_user(submitter_anonymous_user_id)
         student_item_dict = self.get_student_item_dict(anonymous_user_id=submitter_anonymous_user_id)
+        anonymous_student_ids = self.get_anonymous_user_ids_for_team()
         submission = team_api.create_submission_for_team(
             self.course_id,
             student_item_dict['item_id'],
             team_info['team_id'],
             user.id,
-            team_info['team_usernames'],
+            anonymous_student_ids,
             student_sub_dict,
         )
 

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -468,8 +468,10 @@ class SubmissionTest(XBlockHandlerTestCase):
             item_type='openassessment',
         )
 
+        submission_user_ids = set()
         # assert that the content of each teammate's submission is identical.
         for submission in all_submissions:
+            submission_user_ids.add(submission['student_id'])
             answer = submission['answer']
             self.assertEqual(['file-1', 'file-5'], answer['files_descriptions'])
             self.assertEqual(['file-1.pdf', 'file-5.pdf'], answer['files_names'])
@@ -478,6 +480,8 @@ class SubmissionTest(XBlockHandlerTestCase):
                 {'text': 'This is my answer to the first prompt!'},
                 {'text': 'This is my answer to the second prompt!'},
             ], answer['parts'])
+
+        self.assertEqual(submission_user_ids, {'rl', 'r5', 'r2'})
 
     @scenario('data/submission_open.xml', user_id="Bob")
     def test_get_download_urls_from_submission(self, xblock):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ django-simple-history==2.10.0  # via -r requirements/base.in
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
 djangorestframework==3.9.4  # via -r requirements/base.in, edx-submissions
 edx-i18n-tools==0.5.1     # via -r requirements/base.in
-edx-submissions==3.1.5    # via -r requirements/base.in
+edx-submissions==3.1.7    # via -r requirements/base.in
 fs==2.0.18                # via -c requirements/constraints.txt, xblock
 html5lib==1.0.1           # via -r requirements/base.in
 idna==2.8                 # via -c requirements/constraints.txt, requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -35,7 +35,7 @@ docker==4.2.0             # via -r requirements/test.txt, moto
 docutils==0.15.2          # via -r requirements/test.txt, botocore
 ecdsa==0.15               # via -r requirements/test.txt, python-jose, sshpubkeys
 edx-i18n-tools==0.5.1     # via -r requirements/test.txt
-edx-submissions==3.1.5    # via -r requirements/test.txt
+edx-submissions==3.1.7    # via -r requirements/test.txt
 git+https://github.com/edx/edx-lint.git@1.3.0#egg=edx_lint  # via -r requirements/quality.in
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.0.3              # via -r requirements/test.txt, factory-boy

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -33,7 +33,7 @@ docker==4.2.0             # via -r requirements/test.txt, moto
 docutils==0.15.2          # via -r requirements/test.txt, botocore
 ecdsa==0.15               # via -r requirements/test.txt, python-jose, sshpubkeys
 edx-i18n-tools==0.5.1     # via -r requirements/test.txt
-edx-submissions==3.1.5    # via -r requirements/test.txt
+edx-submissions==3.1.7    # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.0.3              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -30,7 +30,7 @@ docker==4.2.0             # via moto
 docutils==0.15.2          # via botocore
 ecdsa==0.15               # via python-jose, sshpubkeys
 edx-i18n-tools==0.5.1     # via -r requirements/base.txt
-edx-submissions==3.1.5    # via -r requirements/base.txt
+edx-submissions==3.1.7    # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.0.3              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.7.5',
+    version='2.7.6',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** When creating team submissions, use anonymous_ids rather than usernames or model ids

JIRA: [EDUCATOR-5059](https://openedx.atlassian.net/browse/EDUCATOR-5059)

FIY: @edx/masters-devs-gta
