### PR TITLE
Set submission_uuid for team submissions

### DIFF
--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -307,6 +307,7 @@ class SubmissionMixin:
         )
 
         self.create_team_workflow(submission["team_submission_uuid"])
+        self.submission_uuid = submission["team_submission_uuid"]
         # Emit analytics event...
         self.runtime.publish(
             self,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.7.6",
+  "version": "2.7.7",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.7.6',
+    version='2.7.7',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
We need to set submission_uuid for team submissions after the call to submissions api returns.

**Developer Checklist**
- [ ] Reviewed the [release process](./release_process.md)
- [ ] Translations up to date
- [ ] JS minified, SASS compiled
- [ ] Test suites passing on Jenkins
- [ ] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

FIY: @edx/masters-devs-gta
