### PR TITLE
EDUCATOR-5078: Team assignments look up submission uuids the wrong way

### DIFF
--- a/openassessment/workflow/serializers.py
+++ b/openassessment/workflow/serializers.py
@@ -38,6 +38,7 @@ class TeamAssessmentWorkflowSerializer(serializers.ModelSerializer):
         model = TeamAssessmentWorkflow
         fields = (
             'team_submission_uuid',
+            'submission_uuid',
             'status',
             'created',
             'modified',

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -307,7 +307,6 @@ class SubmissionMixin:
         )
 
         self.create_team_workflow(submission["team_submission_uuid"])
-        self.submission_uuid = submission["team_submission_uuid"]
         # Emit analytics event...
         self.runtime.publish(
             self,

--- a/openassessment/xblock/team_workflow_mixin.py
+++ b/openassessment/xblock/team_workflow_mixin.py
@@ -76,8 +76,8 @@ class TeamWorkflowMixin:
         """
         Gets the uuid for the team submission for this user's team.
 
-        Returns: team submission uuid if one exists, or 
-                 None none exists or there was an error looking it up
+        Returns: team submission uuid if one exists, or
+                 None if none exists or there was an error looking it up
         """
         if not self.has_team():
             return None
@@ -91,7 +91,6 @@ class TeamWorkflowMixin:
             )
         except (TeamSubmissionNotFoundError, TeamSubmissionInternalError):
             return None
-        
         return team_submission['team_submission_uuid']
 
     def get_team_workflow_status_counts(self):

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -409,6 +409,8 @@ class SubmissionTest(XBlockHandlerTestCase):
         # given a learner is on a team
         self.setup_mock_team(xblock)
 
+        xblock.get_workflow_info = Mock(return_value=None)
+
         # ... but there's an issue when submitting
         mock_submit.side_effect = SubmissionRequestError(msg="I can't shake him!")
 
@@ -450,6 +452,8 @@ class SubmissionTest(XBlockHandlerTestCase):
                 descriptionless=False,
             ),
         ])
+
+        xblock.get_workflow_info = Mock(return_value=None)
 
         # when the learner submits an open assessment response
         response = self.request(

--- a/openassessment/xblock/test/test_team_workflow_mixin.py
+++ b/openassessment/xblock/test/test_team_workflow_mixin.py
@@ -4,8 +4,29 @@ Contract tests for calling team_workflow_api from team_workflow_mixin
 
 from __future__ import absolute_import
 from unittest import TestCase
-from mock import patch
+from mock import patch, Mock
+from submissions.errors import TeamSubmissionNotFoundError
 from openassessment.xblock.team_workflow_mixin import TeamWorkflowMixin
+
+STUDENT_ITEM_DICT = dict(
+    student_id='student_id_1',
+    item_id='item1',
+    course_id='course1',
+    item_type='openassessment'
+)
+
+class TestBlock(TeamWorkflowMixin):
+    """ Dummy class for testing TeamWorkflowMixin """
+
+    team = Mock()
+
+    def get_student_item_dict(self):
+        return STUDENT_ITEM_DICT
+
+    _has_team = True
+    def has_team(self):
+        return self._has_team
+
 
 
 class TestTeamWorkflowMixin(TestCase):
@@ -15,29 +36,49 @@ class TestTeamWorkflowMixin(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.team_mixin = TeamWorkflowMixin()
+        self.test_block = TestBlock()
 
     @patch('openassessment.xblock.team_workflow_mixin.team_workflow_api')
     def test_get_team_workflow_info(self, api_mock):
         submission_uuid = "sub_uuid"
-        self.team_mixin.get_team_workflow_info(submission_uuid)
+        self.test_block.get_team_workflow_info(submission_uuid)
         api_mock.get_workflow_for_submission.assert_called_with(submission_uuid)
 
     @patch('openassessment.xblock.team_workflow_mixin.team_workflow_api')
     def test_create_team_workflow(self, api_mock):
         submission_uuid = "sub_uuid"
-        self.team_mixin.create_team_workflow(submission_uuid)
+        self.test_block.create_team_workflow(submission_uuid)
         api_mock.create_workflow.assert_called_with(submission_uuid)
 
     @patch('openassessment.xblock.team_workflow_mixin.team_workflow_api')
     def test_get_team_workflow_status_counts(self, api_mock):
-        with patch.object(TeamWorkflowMixin, 'get_student_item_dict', create=True) as mock:
-            student_item_dict = dict(
-                student_id='student_id_1',
-                item_id='item1',
-                course_id='course1',
-                item_type='openassessment'
-            )
-            mock.return_value = student_item_dict
-            self.team_mixin.get_team_workflow_status_counts()
-            api_mock.get_status_counts.assert_called()
+        self.test_block.get_team_workflow_status_counts()
+        api_mock.get_status_counts.assert_called()
+
+    @patch('openassessment.xblock.team_workflow_mixin.team_sub_api.get_team_submission_for_team')
+    def test_get_team_submission_uuid(self, mock_get_team_sub):
+        team_submission_uuid =  'this-is-the-uuid'
+        mock_get_team_sub.return_value = {'team_submission_uuid': team_submission_uuid}
+
+        self.assertEqual(self.test_block.get_team_submission_uuid(), team_submission_uuid)
+        mock_get_team_sub.assert_called_with(
+            STUDENT_ITEM_DICT['course_id'],
+            STUDENT_ITEM_DICT['item_id'],
+            self.test_block.team.team_id
+        )
+
+    @patch('openassessment.xblock.team_workflow_mixin.team_sub_api.get_team_submission_for_team')
+    def test_get_team_submission_uuid_no_team(self, mock_get_team_sub):
+        self.test_block._has_team = False
+        self.assertIsNone(self.test_block.get_team_submission_uuid())
+        mock_get_team_sub.assert_not_called()
+
+    @patch('openassessment.xblock.team_workflow_mixin.team_sub_api.get_team_submission_for_team')
+    def test_get_team_submission_uuid_error(self, mock_get_team_sub):
+        mock_get_team_sub.side_effect = TeamSubmissionNotFoundError()
+        self.assertIsNone(self.test_block.get_team_submission_uuid())
+        mock_get_team_sub.assert_called_with(
+            STUDENT_ITEM_DICT['course_id'],
+            STUDENT_ITEM_DICT['item_id'],
+            self.test_block.team.team_id
+        )

--- a/openassessment/xblock/test/test_team_workflow_mixin.py
+++ b/openassessment/xblock/test/test_team_workflow_mixin.py
@@ -15,6 +15,7 @@ STUDENT_ITEM_DICT = dict(
     item_type='openassessment'
 )
 
+
 class TestBlock(TeamWorkflowMixin):
     """ Dummy class for testing TeamWorkflowMixin """
 
@@ -24,9 +25,9 @@ class TestBlock(TeamWorkflowMixin):
         return STUDENT_ITEM_DICT
 
     _has_team = True
+
     def has_team(self):
         return self._has_team
-
 
 
 class TestTeamWorkflowMixin(TestCase):
@@ -57,7 +58,7 @@ class TestTeamWorkflowMixin(TestCase):
 
     @patch('openassessment.xblock.team_workflow_mixin.team_sub_api.get_team_submission_for_team')
     def test_get_team_submission_uuid(self, mock_get_team_sub):
-        team_submission_uuid =  'this-is-the-uuid'
+        team_submission_uuid = 'this-is-the-uuid'
         mock_get_team_sub.return_value = {'team_submission_uuid': team_submission_uuid}
 
         self.assertEqual(self.test_block.get_team_submission_uuid(), team_submission_uuid)
@@ -69,7 +70,7 @@ class TestTeamWorkflowMixin(TestCase):
 
     @patch('openassessment.xblock.team_workflow_mixin.team_sub_api.get_team_submission_for_team')
     def test_get_team_submission_uuid_no_team(self, mock_get_team_sub):
-        self.test_block._has_team = False
+        self.test_block._has_team = False  # pylint: disable=protected-access
         self.assertIsNone(self.test_block.get_team_submission_uuid())
         mock_get_team_sub.assert_not_called()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.7.7",
+  "version": "2.7.8",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.7.7',
+    version='2.7.8',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** change how ora mixins look up submission uuids and workflows

**What changed?**

- revert a change to workflowmixin - if we are a team assignment, look up our submission from the submissions api
- teamworkflow mixin was returning an individual submission uuid rather than the team submission uuid
- if we're a team submission, have get_workflow_info call get_team_workflow_info
- have the team assessment workflow serializer return the submission uuid (the 'canonical' individual submission) which is required for rendering.

**Developer Checklist**
- [x] Reviewed the [release process](./release_process.md)
- [x] Translations up to date
- [x] JS minified, SASS compiled
- [x] Test suites passing on Jenkins
- [x] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

JIRA: [EDUCATOR-5078](https://openedx.atlassian.net/browse/EDUCATOR-5078)

FIY: @edx/masters-devs-gta
