### PR TITLE
[BD-5] [BB-2503] ORA v3 - Change ORA Report Download to include Usernames along with anonymous IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.7.11",
+  "version": "2.8.0",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/settings/base.py
+++ b/settings/base.py
@@ -155,4 +155,8 @@ FEATURES = {
     # A "work-around" feature toggle meant to pull file upload data our of user state, rather than Submission records.
     # See: https://openedx.atlassian.net/browse/EDUCATOR-4951
     'ENABLE_ORA_USER_STATE_UPLOAD_DATA': False,
+
+    # Set to True to add deanonymized usernames to ORA data report
+    # See: https://openedx.atlassian.net/browse/TNL-7273
+    'ENABLE_ORA_USERNAMES_ON_DATA_EXPORT': False,
 }

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.7.11',
+    version='2.8.0',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py35-django{22}, py38-django{22,30}
 [testenv]
 deps =
     -rrequirements/test.txt
-    django22: Django>=2.2,<2.3
+    django22: Django>=2.2,!=2.2.13,<2.4
     django30: Django>=3.0,<3.1
 commands =
     pytest


### PR DESCRIPTION
This PR adds `Username` field to the `ORA` data report, and `scorer_username` to the `Assessment Details` cells content.

[Report example before this change.](https://github.com/edx/edx-ora2/files/4734332/TEST3_TEST3_TEST3_ORA_data_2020-06-05-0636.csv.tar.gz)

[Report example after this change.](https://github.com/edx/edx-ora2/files/4734293/TEST3_TEST3_TEST3_ORA_data_2020-06-04-1918.csv.tar.gz)

**JIRA tickets**:
- [TNL-7273](https://openedx.atlassian.net/browse/TNL-7273)
- [OSPR-4655](https://openedx.atlassian.net/browse/OSPR-4655)

**Discussions**: there was [another PR](https://github.com/edx/edx-platform/pull/24128) for `edx-platform`, but we decided to close it [for this reason](https://github.com/edx/edx-platform/pull/24128#issuecomment-638822472).

**Dependencies**: None
**Merge deadline**: None

**Sandbox URL**: https://bb2503.opencraft.hosting/

**Testing instructions**:

1. Go to `$devstack_root/src`.
1. Clone OpenCraft's ORA repo form here:
    ```sh
    git clone https://github.com/open-craft/edx-ora2
    ```
1. Checkout cloned ORA to this branch:
    ```sh
    cd edx-ora2 & git checkout 0x29a/bb-2503/deanonymize_students_and_scorers_in_report
    ```
1. Go back to `$devstack_root/src`.
1. Install the ORA in the platforms containers:
    ```sh
    # From the devstack folder $devstack_root/devstack:
    make lms-shell
    > pip install -e /edx/src/edx-ora2
    # Then exit the shell and run
    make studio-shell
    > pip install -e /edx/src/edx-ora2
    ```
1. Add new key `ENABLE_ORA_USERNAMES_ON_DATA_EXPORT` with value `True` in `platform/lms/envs/common.py::FEATURES` dict to enable this new feature.
1. Restart `lms` service, if it didn't restart automatically.
1. Create course with `ORA` block or add it to any existing course.
1. Respond to questions in this block with a few users.
1. As a course staff, go to `<Your course>` -> `Instructor` -> `Data Download` (it's a tab in `Instructor Dashboard`) -> click `Generate ORA Data Report` button.
1. If you're testing this using docker devstack, you're unable to download report from the interface. You can find it inside container, in `/tmp/edx-s3/grades/` directory.
1. In downloaded report, you should see new column, `Username`, and also `scorer_username` above `scorer_id` in `Assessment Details` cells.

**Reviewers**
- [ ] @giovannicimolin 
- [ ] edX reviewer[s] TBD