### PR TITLE
[BD-5] BB-2504: Add grade status summary page. [WIP]

### DIFF
--- a/openassessment/templates/openassessmentblock/grade/oa_grade_complete.html
+++ b/openassessment/templates/openassessmentblock/grade/oa_grade_complete.html
@@ -44,6 +44,12 @@
 
                     <article class="submission__peer-evaluations step__content__section">
                         <h5 class="submission__peer-evaluations__title">{% trans "Assessments of Your Response" %}</h5>
+                        
+                        <hr>
+                        <div class="step__message message message--complete">
+                            <h5 class="message__title">{% trans "Status" %}</h5>
+                            <div class="message__content">{{ score_explanation }}</div>
+                        </div>
 
                         <ol class="list submission__peer-evaluations__questions">
                             {% for criterion in grade_details.criteria %}

--- a/openassessment/xblock/test/data/grade_scenario_peer_only.xml
+++ b/openassessment/xblock/test/data/grade_scenario_peer_only.xml
@@ -1,0 +1,48 @@
+<openassessment>
+    <title>Open Assessment Test</title>
+    <prompts>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat poverty?</description>
+        </prompt>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat pollution?</description>
+        </prompt>
+    </prompts>
+    <rubric>
+        <criterion>
+            <name>𝓒𝓸𝓷𝓬𝓲𝓼𝓮</name>
+            <prompt>How concise is it?</prompt>
+            <option points="3">
+                <name>ﻉซƈﻉɭɭﻉกՇ</name>
+                <explanation>Extremely concise</explanation>
+            </option>
+            <option points="2">
+                <name>Ġööḋ</name>
+                <explanation>Concise</explanation>
+            </option>
+            <option points="1">
+                <name>ק๏๏г</name>
+                <explanation>Wordy</explanation>
+            </option>
+        </criterion>
+        <criterion>
+            <name>Form</name>
+            <prompt>How well-formed is it?</prompt>
+            <option points="3">
+                <name>Good</name>
+                <explanation>Good</explanation>
+            </option>
+            <option points="2">
+                <name>Fair</name>
+                <explanation>Fair</explanation>
+            </option>
+            <option points="1">
+                <name>Poor</name>
+                <explanation>Poor</explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="peer-assessment" must_grade="2" must_be_graded_by="2" />
+    </assessments>
+</openassessment>

--- a/openassessment/xblock/test/data/grade_scenario_self_staff.xml
+++ b/openassessment/xblock/test/data/grade_scenario_self_staff.xml
@@ -1,0 +1,49 @@
+<openassessment>
+    <title>Open Assessment Test</title>
+    <prompts>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat poverty?</description>
+        </prompt>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat pollution?</description>
+        </prompt>
+    </prompts>
+    <rubric>
+        <criterion>
+            <name>𝓒𝓸𝓷𝓬𝓲𝓼𝓮</name>
+            <prompt>How concise is it?</prompt>
+            <option points="3">
+                <name>ﻉซƈﻉɭɭﻉกՇ</name>
+                <explanation>Extremely concise</explanation>
+            </option>
+            <option points="2">
+                <name>Ġööḋ</name>
+                <explanation>Concise</explanation>
+            </option>
+            <option points="1">
+                <name>ק๏๏г</name>
+                <explanation>Wordy</explanation>
+            </option>
+        </criterion>
+        <criterion>
+            <name>Form</name>
+            <prompt>How well-formed is it?</prompt>
+            <option points="3">
+                <name>Good</name>
+                <explanation>Good</explanation>
+            </option>
+            <option points="2">
+                <name>Fair</name>
+                <explanation>Fair</explanation>
+            </option>
+            <option points="1">
+                <name>Poor</name>
+                <explanation>Poor</explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="self-assessment" />
+        <assessment name="staff-assessment" required="true"/>
+    </assessments>
+</openassessment>

--- a/openassessment/xblock/test/data/grade_scenario_self_staff_peer.xml
+++ b/openassessment/xblock/test/data/grade_scenario_self_staff_peer.xml
@@ -1,0 +1,50 @@
+<openassessment>
+    <title>Open Assessment Test</title>
+    <prompts>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat poverty?</description>
+        </prompt>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat pollution?</description>
+        </prompt>
+    </prompts>
+    <rubric>
+        <criterion>
+            <name>𝓒𝓸𝓷𝓬𝓲𝓼𝓮</name>
+            <prompt>How concise is it?</prompt>
+            <option points="3">
+                <name>ﻉซƈﻉɭɭﻉกՇ</name>
+                <explanation>Extremely concise</explanation>
+            </option>
+            <option points="2">
+                <name>Ġööḋ</name>
+                <explanation>Concise</explanation>
+            </option>
+            <option points="1">
+                <name>ק๏๏г</name>
+                <explanation>Wordy</explanation>
+            </option>
+        </criterion>
+        <criterion>
+            <name>Form</name>
+            <prompt>How well-formed is it?</prompt>
+            <option points="3">
+                <name>Good</name>
+                <explanation>Good</explanation>
+            </option>
+            <option points="2">
+                <name>Fair</name>
+                <explanation>Fair</explanation>
+            </option>
+            <option points="1">
+                <name>Poor</name>
+                <explanation>Poor</explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="peer-assessment" must_grade="2" must_be_graded_by="2" />
+        <assessment name="self-assessment" />
+        <assessment name="staff-assessment" required="true"/>
+    </assessments>
+</openassessment>

--- a/openassessment/xblock/test/data/grade_scenario_staff_only.xml
+++ b/openassessment/xblock/test/data/grade_scenario_staff_only.xml
@@ -1,0 +1,48 @@
+<openassessment>
+    <title>Open Assessment Test</title>
+    <prompts>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat poverty?</description>
+        </prompt>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat pollution?</description>
+        </prompt>
+    </prompts>
+    <rubric>
+        <criterion>
+            <name>𝓒𝓸𝓷𝓬𝓲𝓼𝓮</name>
+            <prompt>How concise is it?</prompt>
+            <option points="3">
+                <name>ﻉซƈﻉɭɭﻉกՇ</name>
+                <explanation>Extremely concise</explanation>
+            </option>
+            <option points="2">
+                <name>Ġööḋ</name>
+                <explanation>Concise</explanation>
+            </option>
+            <option points="1">
+                <name>ק๏๏г</name>
+                <explanation>Wordy</explanation>
+            </option>
+        </criterion>
+        <criterion>
+            <name>Form</name>
+            <prompt>How well-formed is it?</prompt>
+            <option points="3">
+                <name>Good</name>
+                <explanation>Good</explanation>
+            </option>
+            <option points="2">
+                <name>Fair</name>
+                <explanation>Fair</explanation>
+            </option>
+            <option points="1">
+                <name>Poor</name>
+                <explanation>Poor</explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="staff-assessment" required="true"/>
+    </assessments>
+</openassessment>

--- a/openassessment/xblock/test/data/grade_scenario_staff_peer.xml
+++ b/openassessment/xblock/test/data/grade_scenario_staff_peer.xml
@@ -1,0 +1,49 @@
+<openassessment>
+    <title>Open Assessment Test</title>
+    <prompts>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat poverty?</description>
+        </prompt>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat pollution?</description>
+        </prompt>
+    </prompts>
+    <rubric>
+        <criterion>
+            <name>𝓒𝓸𝓷𝓬𝓲𝓼𝓮</name>
+            <prompt>How concise is it?</prompt>
+            <option points="3">
+                <name>ﻉซƈﻉɭɭﻉกՇ</name>
+                <explanation>Extremely concise</explanation>
+            </option>
+            <option points="2">
+                <name>Ġööḋ</name>
+                <explanation>Concise</explanation>
+            </option>
+            <option points="1">
+                <name>ק๏๏г</name>
+                <explanation>Wordy</explanation>
+            </option>
+        </criterion>
+        <criterion>
+            <name>Form</name>
+            <prompt>How well-formed is it?</prompt>
+            <option points="3">
+                <name>Good</name>
+                <explanation>Good</explanation>
+            </option>
+            <option points="2">
+                <name>Fair</name>
+                <explanation>Fair</explanation>
+            </option>
+            <option points="1">
+                <name>Poor</name>
+                <explanation>Poor</explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="peer-assessment" must_grade="2" must_be_graded_by="2" />
+        <assessment name="staff-assessment" required="true"/>
+    </assessments>
+</openassessment>

--- a/openassessment/xblock/test/test_grade_explanation.py
+++ b/openassessment/xblock/test/test_grade_explanation.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for grade explanation in Open Response Assessment XBlock.
+"""
+from __future__ import absolute_import
+
+import json
+
+from .base import (PEER_ASSESSMENTS, SELF_ASSESSMENT, STAFF_GOOD_ASSESSMENT,
+                   SubmitAssessmentsMixin, XBlockHandlerTestCase, scenario)
+
+
+class TestGradeExplanation(XBlockHandlerTestCase, SubmitAssessmentsMixin):
+    """
+    Tests for grade explanation in Open Response Assessment XBlock.
+    """
+
+    @scenario('data/grade_scenario_self_only.xml', user_id='Greggs')
+    def test_render_grade_explanation_self_only(self, xblock):
+        # Submit, assess, and render the grade view
+        self.create_submission_and_assessments(
+            xblock, self.SUBMISSION, [], [], SELF_ASSESSMENT,
+            waiting_for_peer=True
+        )
+        resp = self.request(xblock, 'render_grade', json.dumps(dict()))
+
+        self.assertIn('The grade for this problem is determined by your Self Assessment.', resp.decode('utf-8'))
+
+    @scenario('data/grade_scenario_staff_only.xml', user_id='Bernard')
+    def test_render_explanation_grade_staff_only(self, xblock):
+        student_item = xblock.get_student_item_dict()
+        submission = xblock.create_submission(student_item, self.SUBMISSION)
+        assessment = STAFF_GOOD_ASSESSMENT
+
+        self.submit_staff_assessment(xblock, submission, assessment)
+
+        resp = self.request(xblock, 'render_grade', json.dumps(dict()))
+        self.assertIn('The grade for this problem is determined by your Staff Grade.', resp.decode('utf-8'))
+
+    @scenario('data/grade_scenario_peer_only.xml', user_id='Bernard')
+    def test_render_grade_explanation_peer_only(self, xblock):
+        # Submit, assess, and render the grade view
+        self.create_submission_and_assessments(
+            xblock, self.SUBMISSION, self.PEERS, PEER_ASSESSMENTS, None
+        )
+        resp = self.request(xblock, 'render_grade', json.dumps(dict()))
+
+        self.assertIn(
+            'The grade for this problem is determined by the average overall score of your Peer Assessments.',
+            resp.decode('utf-8')
+        )
+
+    @scenario('data/grade_scenario.xml', user_id='Bernard')
+    def test_render_grade_explanation_self_and_peer(self, xblock):
+        # Submit, assess, and render the grade view
+        self.create_submission_and_assessments(
+            xblock, self.SUBMISSION, self.PEERS, PEER_ASSESSMENTS, SELF_ASSESSMENT,
+        )
+        resp = self.request(xblock, 'render_grade', json.dumps(dict()))
+
+        self.assertIn(
+            'The grade for this problem is determined by the average overall score of your Peer Assessments.',
+            resp.decode('utf-8')
+        )
+
+    @scenario('data/grade_scenario_self_staff.xml', user_id='Bernard')
+    def test_render_grade_explanation_self_and_staff(self, xblock):
+        # Submit, assess, and render the grade view
+        submission = self.create_submission_and_assessments(
+            xblock, self.SUBMISSION, [], [], SELF_ASSESSMENT
+        )
+        assessment = STAFF_GOOD_ASSESSMENT
+
+        self.submit_staff_assessment(xblock, submission, assessment)
+
+        resp = self.request(xblock, 'render_grade', json.dumps(dict()))
+        self.assertIn('The grade for this problem is determined by your Staff Grade.', resp.decode('utf-8'))
+
+    @scenario('data/grade_scenario_staff_peer.xml', user_id='Bernard')
+    def test_render_grade_explanation_staff_and_peer(self, xblock):
+        # Submit, assess, and render the grade view
+        submission = self.create_submission_and_assessments(
+            xblock, self.SUBMISSION, self.PEERS, PEER_ASSESSMENTS, None
+        )
+        assessment = STAFF_GOOD_ASSESSMENT
+
+        self.submit_staff_assessment(xblock, submission, assessment)
+
+        resp = self.request(xblock, 'render_grade', json.dumps(dict()))
+        self.assertIn('The grade for this problem is determined by your Staff Grade.', resp.decode('utf-8'))
+
+    @scenario('data/grade_scenario_self_staff_peer.xml', user_id='Greggs')
+    def test_render_grade_explanation_self_staff_and_peer(self, xblock):
+        # Submit, assess, and render the grade view
+        submission = self.create_submission_and_assessments(
+            xblock, self.SUBMISSION, self.PEERS, PEER_ASSESSMENTS, SELF_ASSESSMENT
+        )
+        assessment = STAFF_GOOD_ASSESSMENT
+
+        self.submit_staff_assessment(xblock, submission, assessment)
+
+        resp = self.request(xblock, 'render_grade', json.dumps(dict()))
+        self.assertIn('The grade for this problem is determined by your Staff Grade.', resp.decode('utf-8'))

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ def load_requirements(*requirements_paths):
 
 
 setup(
-    name='ora2',
-    version='2.7.10',
+    name='ora2'
+    version='2.8.0',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
Add a status message on the “Your grade” step explaining how the final grade is calculated/determined.

**JIRA tickets**: 
* https://openedx.atlassian.net/browse/TNL-7274
* https://openedx.atlassian.net/browse/OSPR-4624

**Dependencies**: None

**Screenshots**: Always include screenshots if there is any change to the UI.

**Merge deadline**: None

**Testing instructions**:

1. Create a sample course.
2. Create ORA (Open Response Assessment) one for each assessment type e.g **self**, **peer**, **staff**, **self** + **peer**, ....., etc.
3. Create student and enroll them into the created course.
4. Get them to attempt the ORA assessments and get them to grading page.
5. Check the output HTML whether the grade explanation message appears or not.

**Author notes and concerns**:

1. There is some strings missing and for them I have added pseudo strings. I will replace them with actual ones once I get them from upstream.

**Reviewers**
- [ ] @giovannicimolin
- [ ] edX reviewer[s] TBD