### PR TITLE
Move xblock-sdk from base.in to test.in

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,7 +6,6 @@ edx-i18n-tools
 edx-submissions
 djangorestframework
 Xblock
-xblock-sdk
 
 django
 django-simple-history

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,10 +12,10 @@ chardet==3.0.4            # via requests
 defusedxml==0.6.0         # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-submissions
 django-simple-history==2.10.0  # via -r requirements/base.in
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
+django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, edx-i18n-tools, edx-submissions, jsonfield2
 djangorestframework==3.9.4  # via -r requirements/base.in, edx-submissions
 edx-i18n-tools==0.5.3     # via -r requirements/base.in
-edx-submissions==3.1.10    # via -r requirements/base.in
+edx-submissions==3.1.10   # via -r requirements/base.in
 fs==2.0.18                # via -c requirements/constraints.txt, xblock
 html5lib==1.0.1           # via -r requirements/base.in
 idna==2.8                 # via -c requirements/constraints.txt, requests
@@ -26,7 +26,7 @@ libsass==0.20.0           # via -r requirements/base.in
 loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements/base.in
 lxml==4.5.1               # via -r requirements/base.in, xblock
 markupsafe==1.1.1         # via xblock
-more-itertools==8.3.0     # via zipp
+more-itertools==8.4.0     # via zipp
 packaging==20.4           # via bleach
 path.py==12.4.0           # via -r requirements/base.in, edx-i18n-tools
 path==13.1.0              # via path.py
@@ -44,7 +44,6 @@ voluptuous==0.11.7        # via -c requirements/constraints.txt, -r requirements
 web-fragments==0.3.2      # via xblock
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.6              # via xblock
-xblock-sdk==0.2.0         # via -r requirements/base.in
 xblock==1.3.1             # via -r requirements/base.in
 zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata
 

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -11,9 +11,9 @@ attrs==19.3.0             # via -r requirements/test.txt, jsonschema, pytest
 aws-sam-translator==1.24.0  # via -r requirements/test.txt, cfn-lint
 aws-xray-sdk==2.6.0       # via -r requirements/test.txt, moto
 bleach==3.1.5             # via -r requirements/test.txt
-boto3==1.14.1             # via -r requirements/test.txt, aws-sam-translator, moto
+boto3==1.14.3             # via -r requirements/test.txt, aws-sam-translator, moto
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/test.txt, django-pyfs, moto
-botocore==1.17.1          # via -r requirements/test.txt, aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.17.3          # via -r requirements/test.txt, aws-xray-sdk, boto3, moto, s3transfer
 certifi==2020.4.5.2       # via -r requirements/test.txt, requests
 cffi==1.14.0              # via -r requirements/test.txt, cryptography
 cfn-lint==0.33.0          # via -r requirements/test.txt, moto
@@ -35,7 +35,7 @@ docker==4.2.1             # via -r requirements/test.txt, moto
 docutils==0.15.2          # via -r requirements/test.txt, botocore
 ecdsa==0.15               # via -r requirements/test.txt, python-jose, sshpubkeys
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
-edx-submissions==3.1.10    # via -r requirements/test.txt
+edx-submissions==3.1.10   # via -r requirements/test.txt
 git+https://github.com/edx/edx-lint.git@1.3.0#egg=edx_lint  # via -r requirements/quality.in
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.1.0              # via -r requirements/test.txt, factory-boy
@@ -65,7 +65,7 @@ lxml==4.5.1               # via -r requirements/test.txt, xblock
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2, xblock
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt, moto
-more-itertools==8.3.0     # via -r requirements/test.txt, pytest, zipp
+more-itertools==8.4.0     # via -r requirements/test.txt, pytest, zipp
 moto==1.3.14              # via -r requirements/test.txt
 networkx==2.4             # via -r requirements/test.txt, cfn-lint
 packaging==20.4           # via -r requirements/test.txt, bleach, tox
@@ -74,7 +74,7 @@ path==13.1.0              # via -r requirements/test.txt, path.py
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
-py==1.8.1                 # via -r requirements/test.txt, pytest, tox
+py==1.8.2                 # via -r requirements/test.txt, pytest, tox
 pyasn1==0.4.8             # via -r requirements/test.txt, python-jose, rsa
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via -r requirements/test.txt, cffi
@@ -94,7 +94,7 @@ pytz==2020.1              # via -r requirements/test.txt, django, edx-submission
 pyyaml==5.3.1             # via -r requirements/test.txt, cfn-lint, edx-i18n-tools, moto, xblock
 requests==2.23.0          # via -r requirements/test.txt, docker, moto, python-swiftclient, responses
 responses==0.10.15        # via -r requirements/test.txt, moto
-rsa==4.2                  # via -r requirements/test.txt, python-jose
+rsa==4.6                  # via -r requirements/test.txt, python-jose
 s3transfer==0.3.3         # via -r requirements/test.txt, boto3
 six==1.15.0               # via -r requirements/test.txt, astroid, aws-sam-translator, bleach, cfn-lint, cryptography, django-pyfs, django-simple-history, docker, ecdsa, edx-i18n-tools, edx-lint, freezegun, fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pathlib2, pylint, pyrsistent, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
 sqlparse==0.3.1           # via -r requirements/test.txt, django
@@ -104,7 +104,7 @@ text-unidecode==1.3       # via -r requirements/test.txt, faker
 toml==0.10.1              # via -r requirements/test.txt, tox
 tox==3.15.2               # via -r requirements/test.txt
 urllib3==1.25.9           # via -r requirements/test.txt, botocore, requests
-virtualenv==20.0.21       # via -r requirements/test.txt, tox
+virtualenv==20.0.23       # via -r requirements/test.txt, tox
 voluptuous==0.11.7        # via -c requirements/constraints.txt, -r requirements/test.txt
 wcwidth==0.2.4            # via -r requirements/test.txt, pytest
 web-fragments==0.3.2      # via -r requirements/test.txt, xblock

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -11,9 +11,9 @@ aws-sam-translator==1.24.0  # via -r requirements/test.txt, cfn-lint
 aws-xray-sdk==2.6.0       # via -r requirements/test.txt, moto
 bleach==3.1.5             # via -r requirements/test.txt
 bok-choy==1.1.1           # via -r requirements/test-acceptance.in
-boto3==1.14.1             # via -r requirements/test.txt, aws-sam-translator, moto
+boto3==1.14.3             # via -r requirements/test.txt, aws-sam-translator, moto
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/test.txt, django-pyfs, moto
-botocore==1.17.1          # via -r requirements/test.txt, aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.17.3          # via -r requirements/test.txt, aws-xray-sdk, boto3, moto, s3transfer
 certifi==2020.4.5.2       # via -r requirements/test.txt, requests
 cffi==1.14.0              # via -r requirements/test.txt, cryptography
 cfn-lint==0.33.0          # via -r requirements/test.txt, moto
@@ -33,7 +33,7 @@ docker==4.2.1             # via -r requirements/test.txt, moto
 docutils==0.15.2          # via -r requirements/test.txt, botocore
 ecdsa==0.15               # via -r requirements/test.txt, python-jose, sshpubkeys
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
-edx-submissions==3.1.10    # via -r requirements/test.txt
+edx-submissions==3.1.10   # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.1.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
@@ -59,7 +59,7 @@ loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements
 lxml==4.5.1               # via -r requirements/test.txt, xblock
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2, xblock
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt, moto
-more-itertools==8.3.0     # via -r requirements/test.txt, pytest, zipp
+more-itertools==8.4.0     # via -r requirements/test.txt, pytest, zipp
 moto==1.3.14              # via -r requirements/test.txt
 networkx==2.4             # via -r requirements/test.txt, cfn-lint
 packaging==20.4           # via -r requirements/test.txt, bleach, tox
@@ -68,7 +68,7 @@ path==13.1.0              # via -r requirements/test.txt, path.py
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
-py==1.8.1                 # via -r requirements/test.txt, pytest, tox
+py==1.8.2                 # via -r requirements/test.txt, pytest, tox
 pyasn1==0.4.8             # via -r requirements/test.txt, python-jose, rsa
 pycparser==2.20           # via -r requirements/test.txt, cffi
 pyinstrument-cext==0.2.2  # via pyinstrument
@@ -85,7 +85,7 @@ pytz==2020.1              # via -r requirements/test.txt, django, edx-submission
 pyyaml==5.3.1             # via -r requirements/test.txt, cfn-lint, edx-i18n-tools, moto, xblock
 requests==2.23.0          # via -r requirements/test.txt, docker, moto, python-swiftclient, responses
 responses==0.10.15        # via -r requirements/test.txt, moto
-rsa==4.2                  # via -r requirements/test.txt, python-jose
+rsa==4.6                  # via -r requirements/test.txt, python-jose
 s3transfer==0.3.3         # via -r requirements/test.txt, boto3
 selenium==3.141.0         # via -r requirements/test-acceptance.in, bok-choy
 six==1.15.0               # via -r requirements/test.txt, aws-sam-translator, bleach, bok-choy, cfn-lint, cryptography, django-pyfs, django-simple-history, docker, ecdsa, edx-i18n-tools, freezegun, fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pathlib2, pyrsistent, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
@@ -96,7 +96,7 @@ text-unidecode==1.3       # via -r requirements/test.txt, faker
 toml==0.10.1              # via -r requirements/test.txt, tox
 tox==3.15.2               # via -r requirements/test.txt
 urllib3==1.25.9           # via -r requirements/test.txt, botocore, requests, selenium
-virtualenv==20.0.21       # via -r requirements/test.txt, tox
+virtualenv==20.0.23       # via -r requirements/test.txt, tox
 voluptuous==0.11.7        # via -c requirements/constraints.txt, -r requirements/test.txt
 wcwidth==0.2.4            # via -r requirements/test.txt, pytest
 web-fragments==0.3.2      # via -r requirements/test.txt, xblock

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -15,5 +15,6 @@ moto
 testfixtures                        # Provides a LogCapture utility to be used by tests
 tox
 more-itertools
+xblock-sdk
 
 git+https://github.com/edx/django-pyfs.git@1.0.6#egg=django-pyfs

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,9 +10,9 @@ attrs==19.3.0             # via jsonschema, pytest
 aws-sam-translator==1.24.0  # via cfn-lint
 aws-xray-sdk==2.6.0       # via moto
 bleach==3.1.5             # via -r requirements/base.txt
-boto3==1.14.1             # via aws-sam-translator, moto
+boto3==1.14.3             # via aws-sam-translator, moto
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/base.txt, django-pyfs, moto
-botocore==1.17.1          # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.17.3          # via aws-xray-sdk, boto3, moto, s3transfer
 certifi==2020.4.5.2       # via -r requirements/base.txt, requests
 cffi==1.14.0              # via cryptography
 cfn-lint==0.33.0          # via moto
@@ -30,7 +30,7 @@ docker==4.2.1             # via moto
 docutils==0.15.2          # via botocore
 ecdsa==0.15               # via python-jose, sshpubkeys
 edx-i18n-tools==0.5.3     # via -r requirements/base.txt
-edx-submissions==3.1.10    # via -r requirements/base.txt
+edx-submissions==3.1.10   # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.1.0              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
@@ -56,7 +56,7 @@ loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements
 lxml==4.5.1               # via -r requirements/base.txt, xblock
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2, xblock
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in, moto
-more-itertools==8.3.0     # via -r requirements/base.txt, -r requirements/test.in, pytest, zipp
+more-itertools==8.4.0     # via -r requirements/base.txt, -r requirements/test.in, pytest, zipp
 moto==1.3.14              # via -r requirements/test.in
 networkx==2.4             # via cfn-lint
 packaging==20.4           # via -r requirements/base.txt, bleach, tox
@@ -65,7 +65,7 @@ path==13.1.0              # via -r requirements/base.txt, path.py
 pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest, tox
 polib==1.1.0              # via -r requirements/base.txt, edx-i18n-tools
-py==1.8.1                 # via pytest, tox
+py==1.8.2                 # via pytest, tox
 pyasn1==0.4.8             # via python-jose, rsa
 pycparser==2.20           # via cffi
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
@@ -80,7 +80,7 @@ pytz==2020.1              # via -r requirements/base.txt, django, edx-submission
 pyyaml==5.3.1             # via -r requirements/base.txt, cfn-lint, edx-i18n-tools, moto, xblock
 requests==2.23.0          # via -r requirements/base.txt, docker, moto, python-swiftclient, responses
 responses==0.10.15        # via moto
-rsa==4.2                  # via python-jose
+rsa==4.6                  # via python-jose
 s3transfer==0.3.3         # via boto3
 six==1.15.0               # via -r requirements/base.txt, aws-sam-translator, bleach, cfn-lint, cryptography, django-pyfs, django-simple-history, docker, ecdsa, edx-i18n-tools, freezegun, fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pathlib2, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
 sqlparse==0.3.1           # via -r requirements/base.txt, django
@@ -90,7 +90,7 @@ text-unidecode==1.3       # via faker
 toml==0.10.1              # via tox
 tox==3.15.2               # via -r requirements/test.in
 urllib3==1.25.9           # via -r requirements/base.txt, botocore, requests
-virtualenv==20.0.21       # via tox
+virtualenv==20.0.23       # via tox
 voluptuous==0.11.7        # via -c requirements/constraints.txt, -r requirements/base.txt
 wcwidth==0.2.4            # via pytest
 web-fragments==0.3.2      # via -r requirements/base.txt, xblock
@@ -99,7 +99,7 @@ webob==1.8.6              # via -r requirements/base.txt, xblock
 websocket-client==0.57.0  # via docker
 werkzeug==1.0.1           # via moto
 wrapt==1.12.1             # via aws-xray-sdk
-xblock-sdk==0.2.0         # via -r requirements/base.txt
+xblock-sdk==0.2.0         # via -r requirements/test.in
 xblock==1.3.1             # via -r requirements/base.txt
 xmltodict==0.12.0         # via moto
 zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata, importlib-resources

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -8,14 +8,14 @@ appdirs==1.4.4            # via virtualenv
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 importlib-metadata==1.6.1  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
-more-itertools==8.3.0     # via zipp
+importlib-resources==2.0.1  # via virtualenv
+more-itertools==8.4.0     # via zipp
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
-py==1.8.1                 # via tox
+py==1.8.2                 # via tox
 pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox==3.15.2               # via -r requirements/tox.in
-virtualenv==20.0.21       # via tox
+virtualenv==20.0.23       # via tox
 zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -14,16 +14,16 @@ docopt==0.6.2             # via coveralls
 filelock==3.0.12          # via -r requirements/tox.txt, tox, virtualenv
 idna==2.8                 # via -c requirements/constraints.txt, requests
 importlib-metadata==1.6.1  # via -r requirements/tox.txt, importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/tox.txt, virtualenv
-more-itertools==8.3.0     # via -r requirements/tox.txt, zipp
+importlib-resources==2.0.1  # via -r requirements/tox.txt, virtualenv
+more-itertools==8.4.0     # via -r requirements/tox.txt, zipp
 packaging==20.4           # via -r requirements/tox.txt, tox
 pluggy==0.13.1            # via -r requirements/tox.txt, tox
-py==1.8.1                 # via -r requirements/tox.txt, tox
+py==1.8.2                 # via -r requirements/tox.txt, tox
 pyparsing==2.4.7          # via -r requirements/tox.txt, packaging
 requests==2.23.0          # via coveralls
 six==1.15.0               # via -r requirements/tox.txt, packaging, tox, virtualenv
 toml==0.10.1              # via -r requirements/tox.txt, tox
 tox==3.15.2               # via -r requirements/tox.txt
 urllib3==1.25.9           # via requests
-virtualenv==20.0.21       # via -r requirements/tox.txt, tox
+virtualenv==20.0.23       # via -r requirements/tox.txt, tox
 zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/tox.txt, importlib-metadata, importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.8.2',
+    version='2.8.3',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
See https://github.com/edx/edx-platform/pull/24227
`xblock-sdk` being in `base.in` is installed with ora2 which causes server error on platform. It should only be installed in testing environment.