### PR TITLE
[BD-5] [BB-2619] Change ORA Report to Include Problem Name and Location

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -431,9 +431,9 @@ class OraAggregateData:
     @classmethod
     def _map_block_usage_keys_to_display_names(cls, course_id):
         """
-        Fetches all course blocks and filters out those of them, whoose
-        category not equal to ``openassessment``. Then builds
-        mapping between block usage key string and block display name.
+        Fetches all course blocks and build mapping between block usage key
+        string and block display name for those ones, whoose category is equal
+        to ``openassessment``.
 
         Args:
             course_id (string or CourseLocator instance) - id of course
@@ -455,21 +455,12 @@ class OraAggregateData:
         # Passing an empty block structure transformer here to avoid user access checks
         blocks = get_course_blocks(None, course_usage_key, BlockStructureTransformers())
 
-        block_keys_to_remove = []
-
-        for block_key in blocks:
-            block_type = blocks.get_xblock_field(block_key, 'category')
-            if block_type != 'openassessment':
-                block_keys_to_remove.append(block_key)
-
-        for block_key in block_keys_to_remove:
-            blocks.remove_block(block_key, keep_descendants=True)
-
         block_display_name_map = {}
 
         for block_key in blocks:
-            block_key_str = str(block_key)
-            block_display_name_map[block_key_str] = blocks.get_xblock_field(block_key, 'display_name')
+            block_type = blocks.get_xblock_field(block_key, 'category')
+            if block_type == 'openassessment':
+                block_display_name_map[str(block_key)] = blocks.get_xblock_field(block_key, 'display_name')
 
         return block_display_name_map
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.8.5',
+    version='2.8.6',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
Added:
1. New `Location` column to ORA data report with block's location.
1. New `Problem Name` column to ORA data report with `display_name` of block, for which answer has been submitted.

[New report example](https://github.com/edx/edx-ora2/files/4792228/TEST3_TEST3_TEST3_ORA_data_2020-06-17-1139.csv.tar.gz).


**JIRA tickets**:
- [TNL-7281](https://openedx.atlassian.net/browse/TNL-7281)
- [OSPR-4723](https://openedx.atlassian.net/browse/OSPR-4723)

**Discussions**: None

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. Go to `$devstack_root/src`.
1. Clone OpenCraft's ORA repo form here:
    ```sh
    git clone https://github.com/open-craft/edx-ora2
    ```
1. Checkout cloned ORA to this branch:
    ```sh
    cd edx-ora2 & git checkout 0x29a/bb-2619/include_problem_name_and_location
    ```
1. Go back to `$devstack_root/src`.
1. Install the ORA in the platforms containers:
    ```sh
    # From the devstack folder $devstack_root/devstack:
    make lms-shell
    > pip install -e /edx/src/edx-ora2
    # Then exit the shell and run
    make studio-shell
    > pip install -e /edx/src/edx-ora2
    ```
1. Restart `lms` service, if it didn't restart automatically.
1. Create course with `ORA` block or add it to any existing course.
1. Respond to questions in this block with a few users.
1. As a course staff, go to `<Your course>` -> `Instructor` -> `Data Download` (it's a tab in `Instructor Dashboard`) -> click `Generate ORA Data Report` button.
1. If you're testing this using docker devstack, you're unable to download report from the interface. You can find it inside container, in `/tmp/edx-s3/grades/` directory.
1. In downloaded report, you should see new columns `Location` and `Problem Name`. 

**Reviewers**
- [ ] @giovannicimolin
- [ ] edX reviewer[s] TBD
