### PR TITLE
Bump submissions to 3.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.7.11",
+  "version": "2.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.8.1",
+  "version": "2.8.4",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ django-simple-history==2.10.0  # via -r requirements/base.in
 django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, edx-i18n-tools, edx-submissions, jsonfield2
 djangorestframework==3.9.4  # via -r requirements/base.in, edx-submissions
 edx-i18n-tools==0.5.3     # via -r requirements/base.in
-edx-submissions==3.1.10   # via -r requirements/base.in
+edx-submissions==3.1.11   # via -r requirements/base.in
 fs==2.0.18                # via -c requirements/constraints.txt, xblock
 html5lib==1.0.1           # via -r requirements/base.in
 idna==2.8                 # via -c requirements/constraints.txt, requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -35,7 +35,7 @@ docker==4.2.1             # via -r requirements/test.txt, moto
 docutils==0.15.2          # via -r requirements/test.txt, botocore
 ecdsa==0.15               # via -r requirements/test.txt, python-jose, sshpubkeys
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
-edx-submissions==3.1.10   # via -r requirements/test.txt
+edx-submissions==3.1.11   # via -r requirements/test.txt
 git+https://github.com/edx/edx-lint.git@1.3.0#egg=edx_lint  # via -r requirements/quality.in
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.1.0              # via -r requirements/test.txt, factory-boy

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -33,7 +33,7 @@ docker==4.2.1             # via -r requirements/test.txt, moto
 docutils==0.15.2          # via -r requirements/test.txt, botocore
 ecdsa==0.15               # via -r requirements/test.txt, python-jose, sshpubkeys
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
-edx-submissions==3.1.10   # via -r requirements/test.txt
+edx-submissions==3.1.11   # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.1.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -30,7 +30,7 @@ docker==4.2.1             # via moto
 docutils==0.15.2          # via botocore
 ecdsa==0.15               # via python-jose, sshpubkeys
 edx-i18n-tools==0.5.3     # via -r requirements/base.txt
-edx-submissions==3.1.10   # via -r requirements/base.txt
+edx-submissions==3.1.11   # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.1.0              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.8.3',
+    version='2.8.4',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** Update submissions to 3.1.11

**What changed?**
- Bump `edx-submissions` to 3.1.11
- Bump `edx-ora2` to 2.4.8

**Developer Checklist**
- [x] Test suites passing on Jenkins
- [x] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

JIRA: [EDUCATOR-5017](https://openedx.atlassian.net/browse/EDUCATOR-5017)

FIY: @edx/masters-devs-gta
