### PR TITLE
EDUCATOR-5048 - Adjusted configuration from production to devstack 

### DIFF
--- a/scripts/install-test-course.sh
+++ b/scripts/install-test-course.sh
@@ -36,5 +36,5 @@ echo "Done"
 
 echo "Importing test course..."
 SERVICE_VARIANT=cms python $EDX_PLATFORM/manage.py cms \
-    import $COURSE_DATA $COURSE_RUN --settings production
+    import $COURSE_DATA $COURSE_RUN --settings devstack
 echo "Done"


### PR DESCRIPTION
**TL;DR -** ORA2 test course now imports successfully in devstack

**What changed?**
Adjusted configuration from prouduction to devstack and the test course now successfully imports in devstack.

**Developer Checklist**
- [ ] Test suites passing on Jenkins

JIRA: [EDUCATOR-5048](https://openedx.atlassian.net/browse/EDUCATOR-5048)

FIY: @edx/masters-devs-gta
