### PR TITLE
Togglable Mobile support

### DIFF
--- a/openassessment/xblock/config_mixin.py
+++ b/openassessment/xblock/config_mixin.py
@@ -6,16 +6,17 @@ Mixin for determining configuration and feature-toggle state relevant to an ORA 
 from django.conf import settings
 from django.utils.functional import cached_property
 
-
 WAFFLE_NAMESPACE = 'openresponseassessment'
 
-ALL_FILES_URLS = "all_files_urls"
+ALL_FILES_URLS = 'all_files_urls'
+MOBILE_SUPPORT = 'mobile_support'
 TEAM_SUBMISSIONS = 'team_submissions'
-USER_STATE_UPLOAD_DATA = "user_state_upload_data"
+USER_STATE_UPLOAD_DATA = 'user_state_upload_data'
 
 FEATURE_TOGGLES_BY_FLAG_NAME = {
-    TEAM_SUBMISSIONS: 'ENABLE_ORA_TEAM_SUBMISSIONS',
     ALL_FILES_URLS: 'ENABLE_ORA_ALL_FILE_URLS',
+    MOBILE_SUPPORT: 'ENABLE_ORA_MOBILE_SUPPORT',
+    TEAM_SUBMISSIONS: 'ENABLE_ORA_TEAM_SUBMISSIONS',
     USER_STATE_UPLOAD_DATA: 'ENABLE_ORA_USER_STATE_UPLOAD_DATA'
 }
 
@@ -111,3 +112,10 @@ class ConfigMixin:
         Returns a boolean indicating the all files urls feature flag is enabled or not.
         """
         return self.is_feature_enabled(ALL_FILES_URLS)
+
+    @cached_property
+    def is_mobile_support_waffle_enabled(self):
+        """
+        Returns a boolean indicating if the mobile support feature flag is enabled or not.
+        """
+        return self.is_feature_enabled(MOBILE_SUPPORT)

--- a/openassessment/xblock/mobile.py
+++ b/openassessment/xblock/mobile.py
@@ -1,0 +1,28 @@
+"""
+Togglable decorator used to display/hide openassessment units in mobile apps.
+"""
+from xblock.core import XBlock
+
+from openassessment.xblock.config_mixin import ConfigMixin
+
+
+class TogglableMobileSupport(ConfigMixin):
+    """
+    A class decorator used to enable/disable mobile support for
+     openassessment units.
+    """
+    def __call__(self, view):
+        """
+        Add mobile support if the feature flag is enabled.
+        """
+        try:
+            if self.is_mobile_support_waffle_enabled:
+                return XBlock.supports('multi_device')(view)
+        except ImportError:
+            # Openedx libraries are not available in testing
+            # environment.
+            pass
+        return view
+
+
+togglable_mobile_support = TogglableMobileSupport()

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -29,6 +29,7 @@ from openassessment.xblock.grade_mixin import GradeMixin
 from openassessment.xblock.leaderboard_mixin import LeaderboardMixin
 from openassessment.xblock.lms_mixin import LmsCompatibilityMixin
 from openassessment.xblock.message_mixin import MessageMixin
+from openassessment.xblock.mobile import togglable_mobile_support
 from openassessment.xblock.peer_assessment_mixin import PeerAssessmentMixin
 from openassessment.xblock.resolve_dates import DISTANT_FUTURE, DISTANT_PAST, parse_date_value, resolve_dates
 from openassessment.xblock.self_assessment_mixin import SelfAssessmentMixin
@@ -483,6 +484,7 @@ class OpenAssessmentBlock(MessageMixin,
         else:
             fragment.add_javascript_url(self.runtime.local_resource_url(self, item))
 
+    @togglable_mobile_support
     def student_view(self, context=None):  # pylint: disable=unused-argument
         """The main view of OpenAssessmentBlock, displayed when viewing courses.
 

--- a/openassessment/xblock/test/test_config_mixin.py
+++ b/openassessment/xblock/test/test_config_mixin.py
@@ -12,6 +12,7 @@ from openassessment.xblock.config_mixin import (
     ConfigMixin,
     ALL_FILES_URLS,
     FEATURE_TOGGLES_BY_FLAG_NAME,
+    MOBILE_SUPPORT,
     TEAM_SUBMISSIONS,
     USER_STATE_UPLOAD_DATA,
 )
@@ -102,6 +103,31 @@ class ConfigMixinTest(TestCase):
             mock_waffle_flag,
             mock_waffle_switch,
             'is_fetch_all_urls_waffle_enabled',
+        )
+
+    @ddt.data(
+        *list(itertools.product([True, False], repeat=3))
+    )
+    @ddt.unpack
+    @mock.patch('openassessment.xblock.config_mixin.import_waffle_switch', autospec=True)
+    @mock.patch('openassessment.xblock.config_mixin.import_course_waffle_flag', autospec=True)
+    def test_mobile_support_enabled(
+            self, waffle_switch_input, waffle_flag_input, settings_input, mock_waffle_flag, mock_waffle_switch
+    ):
+        """
+        The "ora mobile support" workaround is expected to be enabled if at least one of the following conditions holds:
+          1) The all_files_urls waffle switch is enabled.
+          2) The all_files_urls course waffle flag is enabled.
+          3) The settings.FEATURES['ENABLE_ORA_MOBILE_SUPPORT'] value is True.
+        """
+        self._run_feature_toggle_test(
+            MOBILE_SUPPORT,
+            waffle_switch_input,
+            waffle_flag_input,
+            settings_input,
+            mock_waffle_flag,
+            mock_waffle_switch,
+            'is_mobile_support_waffle_enabled',
         )
 
     def _run_feature_toggle_test(

--- a/openassessment/xblock/test/test_mobile.py
+++ b/openassessment/xblock/test/test_mobile.py
@@ -1,0 +1,47 @@
+""" Tests mobile support. """
+
+from unittest import mock
+from django.test import TestCase
+
+from openassessment.xblock.mobile import togglable_mobile_support
+
+
+class MobileSupportTest(TestCase):
+    """ Test mobile support decorator. """
+
+    @mock.patch('xblock.core.XBlock.supports')
+    @mock.patch(
+        'openassessment.xblock.config_mixin.ConfigMixin.is_mobile_support_waffle_enabled',
+        new_callable=mock.PropertyMock
+    )
+    def test_mobile_support_enabled(self, config_mixin_mock, xblock_mock):
+        """
+        Test that when mobile support feature flag is enabled, the
+        XBlock decorator gets called.
+        """
+        some_function = mock.Mock()
+        config_mixin_mock.return_value = True
+        xblock_decorator = mock.Mock()
+        xblock_mock.return_value = xblock_decorator
+
+        togglable_mobile_support(some_function)
+
+        xblock_mock.assert_called_once_with('multi_device')
+        xblock_decorator.assert_called_once_with(some_function)
+
+    @mock.patch('xblock.core.XBlock.supports')
+    @mock.patch(
+        'openassessment.xblock.config_mixin.ConfigMixin.is_mobile_support_waffle_enabled',
+        new_callable=mock.PropertyMock
+    )
+    def test_mobile_support_disabled(self, config_mixin_mock, xblock_mock):
+        """
+        Test that when mobile support feature flag is not enabled, the
+        XBlock decorator does not get called.
+        """
+        some_function = mock.Mock()
+        config_mixin_mock.return_value = False
+
+        togglable_mobile_support(some_function)
+
+        xblock_mock.assert_not_called()

--- a/settings/base.py
+++ b/settings/base.py
@@ -2,8 +2,6 @@
 Base settings for ORA2.
 """
 
-
-
 import os
 
 DEBUG = True
@@ -159,4 +157,7 @@ FEATURES = {
     # Set to True to add deanonymized usernames to ORA data report
     # See: https://openedx.atlassian.net/browse/TNL-7273
     'ENABLE_ORA_USERNAMES_ON_DATA_EXPORT': False,
+
+    # Set to True to enable this Xblock in mobile apps.
+    'ENABLE_ORA_MOBILE_SUPPORT': False,
 }

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.9.18',
+    version='2.10.0',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** [ Display openassessment units in mobile apps. ]

This is the same of https://github.com/edx/edx-ora2/pull/1134, but rebased on top of master and now, the feature is togglable through a  feature flag.


**Currently when we try to display an ora2 unit in mobile:**

![image](https://user-images.githubusercontent.com/22335041/86628995-bae93000-bf98-11ea-8215-a923aa0403c4.png)

**Once this change gets installed in edx-platform**
![out](https://user-images.githubusercontent.com/22335041/86629957-254ea000-bf9a-11ea-9f29-e4e3f788012c.gif)


## Context

This is the piece of code of edx-platform that checks if an xblock supports mobile apps: https://github.com/edx/edx-platform/blob/61e1eda20df2825a409db3e2d36c69d7c36d3e2d/lms/djangoapps/course_api/blocks/transformers/student_view.py#L54

**What changed?**

- openassessment unit now will be displayed in the mobile apps if any of the feature flags for that are enabled (openresponseassessment.mobile_support waffle switch or ENABLE_ORA_MOBILE_SUPPORT edx-platform feature )

**How to test?**

* Install this xblock in edx-platform
* Configure the platform properly to support mobile apps
* turn on openresponseassessment.mobile_support waffle switch
* Build a mobile app that uses that sandboxed environment
* Test that a unit with an openassessment unit gets rendered in the app.

**Developer Checklist**
- [ ] Reviewed the [release process](./release_process.md)
- [x] ~Translations up to date~ (NA)
- [x] ~JS minified, SASS compiled~ (NA)
- [ ] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)
