### PR TITLE
[BD-05][TNL-7311] Add ORA aggregated data API - WIP

### DIFF
--- a/openassessment/api.py
+++ b/openassessment/api.py
@@ -1,0 +1,59 @@
+"""
+Open Response Assesments APIs - Internal Python APIs
+"""
+import six
+from django.urls import reverse
+
+from xmodule.modulestore.django import modulestore
+
+from openassessment.data import OraAggregateData
+
+
+def get_open_assessment_blocks_for_course(course_key):
+    """
+    Returns all open assesment blocks from the modulestore
+    """
+    openassessment_blocks = modulestore().get_items(
+        course_key, qualifiers={'category': 'openassessment'}
+    )
+
+    # filter out orphaned openassessment blocks
+    openassessment_blocks = [
+        block for block in openassessment_blocks if block.parent is not None
+    ]
+
+    return openassessment_blocks
+
+
+def retrieve_assessment_data(course_key):
+    """
+    Return all formatted data to Open Responses section on Instructor Dashboard.
+    """
+    ora_items = []
+    parents = {}
+    course_key_str = six.text_type(course_key)
+
+    # Retrieve aggregated response data for course.
+    responses = OraAggregateData.collect_ora2_responses(course_key_str)
+
+    # Retrieve all `openassesment` block's metadata
+    openassessment_blocks = get_open_assessment_blocks_for_course(course_key)
+
+    # Loop over each block and aggregate data
+    for block in openassessment_blocks:
+        block_parent_id = six.text_type(block.parent)
+        result_item_id = six.text_type(block.location)
+        if block_parent_id not in parents:
+            parents[block_parent_id] = modulestore().get_item(block.parent)
+        assessment_name = _("Team") + " : " + block.display_name if block.teams_enabled else block.display_name
+        ora_items.append({
+            'id': result_item_id,
+            'name': assessment_name,
+            'parent_id': block_parent_id,
+            'parent_name': parents[block_parent_id].display_name,
+            'staff_assessment': 'staff-assessment' in block.assessment_steps,
+            # Append aggregated reponse data to each item
+            'responses': responses[result_item_id]
+        })
+
+    return ora_items

--- a/openassessment/serializers.py
+++ b/openassessment/serializers.py
@@ -1,0 +1,31 @@
+"""
+ORA Assessment Data Serializers.
+"""
+from rest_framework import serializers
+
+
+class OraResponsesSerializer(serializers.Serializer):
+    """
+    Serializer for the ORA Assessment Data shown in instructor dashboard.
+    """
+    peer_assessment = serializers.IntegerField(source='peer')
+    waiting = serializers.IntegerField()
+    training = serializers.IntegerField()
+    self_assessment = serializers.IntegerField(source='self')
+    staff_assessment = serializers.IntegerField(source='staff')
+    cancelled = serializers.IntegerField()
+    done = serializers.IntegerField()
+    teams = serializers.IntegerField()
+    total = serializers.IntegerField()
+
+
+class OraAssesmentDataSerializer(serializers.Serializer):
+    """
+    Serializer for the ORA Assessment Data shown in instructor dashboard.
+    """
+    id = serializers.CharField()
+    name = serializers.CharField()
+    parent_id = serializers.CharField()
+    parent_name = serializers.CharField()
+    staff_assessment = serializers.BooleanField()
+    responses = OraResponsesSerializer()

--- a/openassessment/urls.py
+++ b/openassessment/urls.py
@@ -1,0 +1,15 @@
+"""
+Urls for base ORA API views.
+"""
+from django.conf import settings
+from django.conf.urls import url
+
+from openassessment.views.api import OpenAssesmentAggregatedData
+
+urlpatterns = [
+    url(
+        r'^assessment_data/{course_id}/$'.format(course_id=settings.COURSE_ID_PATTERN),
+        OpenAssesmentAggregatedData.as_view(),
+        name='ora_aggregated_assessment_data'
+    ),
+]

--- a/openassessment/views/api.py
+++ b/openassessment/views/api.py
@@ -1,0 +1,52 @@
+"""
+ORA APIs
+"""
+
+from rest_framework.generics import RetrieveAPIView
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from edx_django_utils import monitoring as monitoring_utils
+from django.urls import reverse
+from opaque_keys.edx.keys import CourseKey
+
+from openassessment.api import (
+    get_open_assessment_blocks_for_course,
+    retrieve_assessment_data,
+)
+from openassessment.serializers import OraAssesmentDataSerializer
+
+
+class OpenAssesmentAggregatedData(RetrieveAPIView):
+    """
+    **Use Cases**
+
+        Returns all ORA problems for a given course.
+
+    **Example Requests**
+
+        GET api/ora/v1/instructor_dashboard/assesment_data/{course_key}
+
+    **Response Values**
+
+
+    **Returns**
+
+        * 200 on success with above fields.
+        * 403 if the user is not authenticated.
+        * 404 if the course is not available or cannot be seen.
+
+    """
+
+    permission_classes = (IsAuthenticated,)
+    serializer_class = OraAssesmentDataSerializer
+    queryset = []
+
+    def get(self, request, *args, **kwargs):
+        course_key_string = kwargs.get('course_id')
+        course_key = CourseKey.from_string(course_key_string)
+
+        ora_data = retrieve_assessment_data(course_key)
+
+        serializer = self.get_serializer_class()(ora_data, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
**TL;DR -** This PR adds internal python APIs and endpoints to be used by the upcoming ORA instructor dashboard rework.

**JIRA Tickets:**
- [TNL-7311](https://openedx.atlassian.net/browse/TNL-7311)

**What changed?**

WIP

**Testing instructions:**

1. Checkout this branch.
2. Add this to your `lms/urls.py`:
```
# ORA API views
urlpatterns += [
    url(r'^api/v1/openassessment/', include('openassessment.urls')),
]
```
3. Restart LMS.
4. TBD

**Developer Checklist**
- [ ] Reviewed the [release process](./release_process.md)
- [ ] Translations up to date
- [ ] JS minified, SASS compiled
- [ ] Test suites passing on Jenkins
- [ ] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

FIY: @edx/masters-devs-gta
