### PR TITLE
[BD-05] [TNL-7308] Add method to collect attachments data to OraAggregateData

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.9.1',
+    version='2.9.2',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
This PR adds `collect_ora2_attachments` method, which collects all submission attachments and represents them in a way useful to create attachments zip archive.

**JIRA tickets**:
- [TNL-7308](https://openedx.atlassian.net/browse/TNL-7308)
- [BLENDED-473](https://openedx.atlassian.net/browse/BLENDED-473)

**Dependencies**:
This PR is a dependency for https://github.com/edx/edx-platform/pull/24541.

**Merge deadline**: None

**Testing instructions**:

Since there are just one new method and it's covered with test, I think CI pass is enough to consider this tested. If not, this method can be tested in dependent pull request.

**Reviewers**
- [ ] @xitij2000 
- [ ] edX reviewer[s] TBD
