### PR TITLE
EDUCATOR-5185: Team Final Grade not appearing in "Manage Team Responses" for staff graded Team ORA

### DIFF
--- a/openassessment/xblock/team_mixin.py
+++ b/openassessment/xblock/team_mixin.py
@@ -4,6 +4,8 @@ import logging
 from django.utils.functional import cached_property
 from django.core.exceptions import ObjectDoesNotExist
 from xblock.exceptions import NoSuchServiceError
+from submissions.team_api import get_team_submission_from_individual_submission
+
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -125,3 +127,10 @@ class TeamMixin:
 
             return self.teams_service.get_anonymous_user_ids_for_team(user, self.team)
         return None
+
+    def get_team_submission_uuid_from_individual_submission_uuid(self, individual_submission_uuid):
+        """
+        Given an individual submission uuid, return the uuid of the related team submission
+        """
+        team_submission = get_team_submission_from_individual_submission(individual_submission_uuid)
+        return team_submission['team_submission_uuid']

--- a/openassessment/xblock/workflow_mixin.py
+++ b/openassessment/xblock/workflow_mixin.py
@@ -126,7 +126,11 @@ class WorkflowMixin:
             AssessmentWorkflowError
         """
         if self.is_team_assignment():
-            return self.get_team_workflow_info()
+            if submission_uuid:
+                team_submission_uuid = self.get_team_submission_uuid_from_individual_submission_uuid(submission_uuid)
+            else:
+                team_submission_uuid = None
+            return self.get_team_workflow_info(team_submission_uuid)
 
         if submission_uuid is None:
             submission_uuid = self.get_submission_uuid()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.8.10',
+    version='2.8.11',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** Fix a bug where a Team's Final Grade sometimes doesn't show up in the staff area even when the staff assessment has been done

**What changed?**

- added function `get_team_submission_uuid_from_individual_submission_uuid` to `team_mixin` which basically just calls `get_team_submission_from_individual_submission` in the team submission api
- Previously, in `get_workflow_info`, we checked if the ORA was a team ORA and if it was, we called `get_team_workflow info` with no arguments. That works in the case where it's a student loading the ORA, but when it's a staff member, they can't "derive" the correct `team_submission_id`.
- Now, if `get_workflow_info` is called with a `submission_uuid` (as it is when the staff area is loading the workflow) and it's a team ORA, we take the `submission_uuid` and look up the associated `team_submission_uuid` and pass that to `get_team_workflow info`, which allows us to correctly look up the workflow.

**Developer Checklist**
- [x] Reviewed the [release process](./release_process.md)
- [x] Translations up to date
- [x] JS minified, SASS compiled
- [x] Test suites passing on Jenkins
- [x] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

JIRA: [EDUCATOR-5185](https://openedx.atlassian.net/browse/EDUCATOR-5185)

FIY: @edx/masters-devs-gta
