### PR TITLE
Fix bug where resetting state for a team does not allow resubmission

### DIFF
--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -512,7 +512,7 @@ class StaffAreaMixin:
         )
         # Tell the submissions API to orphan the submissions to prevent them from being accessed
         from submissions import team_api as team_submissions_api
-        team_submissions_api.reset_scores(team_submission_uuid)
+        team_submissions_api.reset_scores(team_submission_uuid, clear_state=True)
 
     @XBlock.json_handler
     @require_course_staff("STUDENT_INFO", with_json_handler=True)

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -866,6 +866,7 @@ class TestCourseStaff(XBlockHandlerTestCase):
 
     @scenario('data/team_submission.xml', user_id='Bob')
     def test_staff_delete_student_state_for_team_assessment(self, xblock):
+        # Given a team with a submission
         self._setup_xblock_and_create_submission(xblock, team=True)
 
         status_counts, total_submissions = xblock.get_team_workflow_status_counts()
@@ -873,12 +874,17 @@ class TestCourseStaff(XBlockHandlerTestCase):
         status_counts = self._parse_workflow_status_counts(status_counts)
         self.assertEqual(status_counts['teams'], 1)
 
+        # When I clear the team's state
         xblock.clear_student_state('Bob', 'test_course', xblock.scope_ids.usage_id, STUDENT_ITEM['student_id'])
 
+        # Then the submission goes into cancelled state
         status_counts, total_submissions = xblock.get_team_workflow_status_counts()
         self.assertEqual(total_submissions, 1)
         status_counts = self._parse_workflow_status_counts(status_counts)
         self.assertEqual(status_counts['cancelled'], 1)
+
+        # And the submissions are cleared to allow a new submission workflow
+        self.assertEqual(xblock.get_team_workflow_info(), {})
 
     def _parse_workflow_status_counts(self, status_counts):
         """ Helper to transform status counts from a list of dicts to a single dict """

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.8.11",
+  "version": "2.8.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.8.9",
+  "version": "2.8.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.8.11",
+  "version": "2.8.12",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.8.10',
+    version='2.8.11',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.8.11',
+    version='2.8.12',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** clear submissions from context when resetting state for teams.

**Notes:**
This commit adds just the correct clear submissions flag and won't be fully demonstrable until integrated with the [updated team cancellation workflow work](https://github.com/muselesscreator/edx-ora2/tree/teams_cancellation_workflow) and [reset student state work](https://github.com/edx/edx-platform/pull/24187/).

**Developer Checklist**
- [x] Reviewed the [release process](./release_process.md)
- [x] Test suites passing on Jenkins
- [x] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

JIRA: [EDUCATOR-5183](https://openedx.atlassian.net/browse/EDUCATOR-5183)

FIY: @edx/masters-devs-gta
