### PR TITLE
link team submission view to team workflow

### DIFF
--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -684,7 +684,7 @@ class SubmissionMixin:
             and `context` (dict) is the template context.
 
         """
-        workflow = self.get_workflow_info()
+        workflow = self.get_team_workflow_info() if self.teams_enabled else self.get_workflow_info()
         problem_closed, reason, start_date, due_date = self.is_closed('submission')
         user_preferences = get_user_preferences(self.runtime.service(self, 'user'))
 
@@ -766,7 +766,12 @@ class SubmissionMixin:
             context['submit_enabled'] = submit_enabled
             path = "openassessmentblock/response/oa_response.html"
         elif workflow["status"] == "cancelled":
-            context["workflow_cancellation"] = self.get_workflow_cancellation_info(self.submission_uuid)
+            if self.teams_enabled:
+                context["workflow_cancellation"] = self.get_team_workflow_cancellation_info(
+                    workflow["team_submission_uuid"])
+            else:
+                context["workflow_cancellation"] = self.get_workflow_cancellation_info(
+                    self.submission_uuid)
             context["student_submission"] = self.get_user_submission(
                 workflow["submission_uuid"]
             )

--- a/openassessment/xblock/team_workflow_mixin.py
+++ b/openassessment/xblock/team_workflow_mixin.py
@@ -115,11 +115,12 @@ class TeamWorkflowMixin:
 
         :param team_submission_uuid: The team_submission identifier associated with the
         sumbission to return information for.
-        :return: The cancellation information, or None if the submission has
+        :return: The cancellation information, or None if the team submission has
         not been cancelled.
         """
         cancellation_info = team_workflow_api.get_assessment_workflow_cancellation(
-            team_submission_uuid)
+            team_submission_uuid
+        )
         if not cancellation_info:
             return None
 
@@ -130,7 +131,8 @@ class TeamWorkflowMixin:
         del cancellation_info['created_at']
         workflow = team_workflow_api.get_workflow_for_submission(team_submission_uuid)
         cancellation_model = AssessmentWorkflowCancellation.get_latest_workflow_cancellation(
-            workflow['submission_uuid'])
+            workflow['submission_uuid']
+        )
         if cancellation_model:
             cancellation_info['cancelled_at'] = cancellation_model.created_at
 

--- a/openassessment/xblock/team_workflow_mixin.py
+++ b/openassessment/xblock/team_workflow_mixin.py
@@ -8,6 +8,7 @@ from xblock.core import XBlock
 from submissions import team_api as team_sub_api
 from submissions.errors import TeamSubmissionNotFoundError, TeamSubmissionInternalError
 from openassessment.workflow import team_api as team_workflow_api
+from openassessment.workflow.models import AssessmentWorkflowCancellation
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -62,12 +63,12 @@ class TeamWorkflowMixin:
         Raises:
             AssessmentWorkflowError
         """
-
         if team_submission_uuid is None:
             team_submission_uuid = self.get_team_submission_uuid()
 
         if team_submission_uuid is None:
             return {}
+
         return team_workflow_api.get_workflow_for_submission(team_submission_uuid)
 
     def get_team_submission_uuid(self):
@@ -107,3 +108,30 @@ class TeamWorkflowMixin:
         )
         num_submissions = sum(item['count'] for item in status_counts)
         return status_counts, num_submissions
+
+    def get_team_workflow_cancellation_info(self, team_submission_uuid):
+        """
+        Returns cancellation information for a particular team submission.
+
+        :param team_submission_uuid: The team_submission identifier associated with the
+        sumbission to return information for.
+        :return: The cancellation information, or None if the submission has
+        not been cancelled.
+        """
+        cancellation_info = team_workflow_api.get_assessment_workflow_cancellation(
+            team_submission_uuid)
+        if not cancellation_info:
+            return None
+
+        # Add the username of the staff member who cancelled the submission
+        cancellation_info['cancelled_by'] = self.get_username(cancellation_info['cancelled_by_id'])
+
+        # Add the date that the workflow was cancelled (in preference to the serialized date string)
+        del cancellation_info['created_at']
+        workflow = team_workflow_api.get_workflow_for_submission(team_submission_uuid)
+        cancellation_model = AssessmentWorkflowCancellation.get_latest_workflow_cancellation(
+            workflow['submission_uuid'])
+        if cancellation_model:
+            cancellation_info['cancelled_at'] = cancellation_model.created_at
+
+        return cancellation_info

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -3,8 +3,6 @@
 Test submission to the OpenAssessment XBlock.
 """
 
-import logging
-
 import datetime as dt
 import json
 
@@ -17,14 +15,10 @@ import boto
 from boto.s3.key import Key
 from moto import mock_s3_deprecated
 from django.contrib.auth import get_user_model
-from submissions import (
-    api as sub_api,
-    team_api as team_sub_api
-)
+from submissions import api as sub_api
 from submissions.api import SubmissionInternalError, SubmissionRequestError
 from submissions.models import TeamSubmission
 from openassessment.fileupload import api
-from openassessment.tests.factories import UserFactory
 from openassessment.workflow import (
     api as workflow_api,
     team_api as team_workflow_api
@@ -33,10 +27,10 @@ from openassessment.xblock.data_conversion import create_submission_dict, prepar
 from openassessment.xblock.openassessmentblock import OpenAssessmentBlock
 from openassessment.xblock.workflow_mixin import WorkflowMixin
 
-from openassessment.xblock.test.test_team import MockTeamsService, MOCK_TEAM_MEMBERS, MOCK_TEAM_NAME, MOCK_TEAM_ID
+from openassessment.xblock.test.test_team import MockTeamsService, MOCK_TEAM_ID
 
 from .base import XBlockHandlerTestCase, scenario
-from .test_staff_area import NullUserService, UserStateService, STUDENT_ITEM
+from .test_staff_area import NullUserService, UserStateService
 
 
 class SubmissionXBlockHandlerTestCase(XBlockHandlerTestCase):
@@ -1048,7 +1042,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
 
     @scenario('data/team_submission.xml', user_id="Red Five")
     def test_cancelled_team_submission(self, xblock):
-        team = self.setup_mock_team(xblock)
+        self.setup_mock_team(xblock)
 
         # pylint: disable=protected-access
         xblock.runtime._services['user'] = NullUserService()

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -1061,14 +1061,16 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         team_submission = xblock.create_team_submission(
             ('a man must have a code', 'a man must also have a towel')
         )
-        student_submission = dict(sub_api.get_submissions(
+        student_submissions = sub_api.get_submissions(
             dict(
                 student_id="Chris",
                 item_id=usage_id,
                 course_id='test_course',
                 item_type='openassessment'
             ),
-            1)[0])
+            1
+        )
+        student_submission = dict(student_submissions[0])
 
         comments = "Cancelled by staff"
         staff_id = "Andy"
@@ -1088,6 +1090,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'file_upload_response': None,
                 'file_upload_type': None,
                 'allow_latex': False,
+                # date listed in xml scenario.
                 'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
                 'student_submission': student_submission,
                 'workflow_cancellation': {

--- a/openassessment/xblock/test/test_team_workflow_mixin.py
+++ b/openassessment/xblock/test/test_team_workflow_mixin.py
@@ -2,11 +2,15 @@
 Contract tests for calling team_workflow_api from team_workflow_mixin
 """
 
+import logging
 
+from types import SimpleNamespace
+from copy import copy
 from unittest import TestCase
 from mock import patch, Mock
 from submissions.errors import TeamSubmissionNotFoundError
 from openassessment.xblock.team_workflow_mixin import TeamWorkflowMixin
+
 
 STUDENT_ITEM_DICT = dict(
     student_id='student_id_1',
@@ -14,6 +18,22 @@ STUDENT_ITEM_DICT = dict(
     course_id='course1',
     item_type='openassessment'
 )
+
+SUBMISSION_UUID = 'submission 1'
+TEAM_SUB_ID_1 = 'team_submission 1'
+TEAM_SUB_ID_2 = 'team_submission 2'
+USER_ID = 'fake_UsEr'
+USERNAME = 'usEr naMe'
+MODULE = 'openassessment.xblock.team_workflow_mixin'
+TEAM_WORKFLOW = {
+    'submission_uuid': SUBMISSION_UUID
+}
+CREATED_AT = 12
+MODEL_CREATED_AT = 13
+CANCELLATION_INFO = {
+    "created_at": 12,
+    "cancelled_by_id": USER_ID,
+}
 
 
 class TestBlock(TeamWorkflowMixin):
@@ -28,6 +48,12 @@ class TestBlock(TeamWorkflowMixin):
 
     def has_team(self):
         return self._has_team
+
+
+def _mock_get_cancellation_info(team_submission_uuid):
+    if team_submission_uuid == TEAM_SUB_ID_1:
+        return None
+    return copy(CANCELLATION_INFO)
 
 
 class TestTeamWorkflowMixin(TestCase):
@@ -82,4 +108,48 @@ class TestTeamWorkflowMixin(TestCase):
             STUDENT_ITEM_DICT['course_id'],
             STUDENT_ITEM_DICT['item_id'],
             self.test_block.team.team_id
+        )
+
+    @patch('{}.team_workflow_api.get_assessment_workflow_cancellation'.format(MODULE))
+    def test_get_team_workflow_cancellation_info_no_info(self, mock_get_cancellation):
+        mock_get_cancellation.side_effect = _mock_get_cancellation_info
+        info = self.test_block.get_team_workflow_cancellation_info(TEAM_SUB_ID_1)
+        self.assertIsNone(info)
+
+    @patch('{}.AssessmentWorkflowCancellation.get_latest_workflow_cancellation'.format(MODULE))
+    @patch('{}.team_workflow_api.get_assessment_workflow_cancellation'.format(MODULE))
+    @patch('{}.team_workflow_api.get_workflow_for_submission'.format(MODULE), return_value=TEAM_WORKFLOW)
+    def test_get_team_workflow_cancellation_info_no_model(
+            self,
+            mock_get_workflow,
+            mock_get_cancellation,
+            mock_get_workflow_cancellation):
+        mock_get_cancellation.side_effect = _mock_get_cancellation_info
+        self.test_block.get_username = Mock(return_value=USERNAME)
+        mock_get_workflow_cancellation.return_value = None
+        info = self.test_block.get_team_workflow_cancellation_info(TEAM_SUB_ID_2)
+        self.assertEqual(
+            info,
+            {"cancelled_by_id": USER_ID, "cancelled_by": USERNAME}
+        )
+
+    @patch('{}.AssessmentWorkflowCancellation.get_latest_workflow_cancellation'.format(MODULE))
+    @patch('{}.team_workflow_api.get_assessment_workflow_cancellation'.format(MODULE))
+    @patch('{}.team_workflow_api.get_workflow_for_submission'.format(MODULE), return_value=TEAM_WORKFLOW)
+    def test_get_team_workflow_cancellation_info_with_model(
+            self,
+            mock_get_workflow,
+            mock_get_cancellation,
+            mock_get_workflow_cancellation):
+        mock_get_cancellation.side_effect = _mock_get_cancellation_info
+        self.test_block.get_username = Mock(return_value=USERNAME)
+        mock_get_workflow_cancellation.return_value = SimpleNamespace(**{"created_at": MODEL_CREATED_AT})
+        info = self.test_block.get_team_workflow_cancellation_info(TEAM_SUB_ID_2)
+        self.assertEqual(
+            info,
+            {
+                "cancelled_by_id": USER_ID,
+                "cancelled_by": USERNAME,
+                "cancelled_at": MODEL_CREATED_AT
+            }
         )

--- a/openassessment/xblock/test/test_team_workflow_mixin.py
+++ b/openassessment/xblock/test/test_team_workflow_mixin.py
@@ -47,6 +47,7 @@ class TestBlock(TeamWorkflowMixin):
     def has_team(self):
         return self._has_team
 
+    # pylint: disable=unused-argument
     def get_username(self, user):
         return USERNAME
 

--- a/openassessment/xblock/test/test_team_workflow_mixin.py
+++ b/openassessment/xblock/test/test_team_workflow_mixin.py
@@ -2,8 +2,6 @@
 Contract tests for calling team_workflow_api from team_workflow_mixin
 """
 
-import logging
-
 from types import SimpleNamespace
 from copy import copy
 from unittest import TestCase
@@ -48,6 +46,9 @@ class TestBlock(TeamWorkflowMixin):
 
     def has_team(self):
         return self._has_team
+
+    def get_username(self, user):
+        return USERNAME
 
 
 def _mock_get_cancellation_info(team_submission_uuid):
@@ -118,14 +119,14 @@ class TestTeamWorkflowMixin(TestCase):
 
     @patch('{}.AssessmentWorkflowCancellation.get_latest_workflow_cancellation'.format(MODULE))
     @patch('{}.team_workflow_api.get_assessment_workflow_cancellation'.format(MODULE))
-    @patch('{}.team_workflow_api.get_workflow_for_submission'.format(MODULE), return_value=TEAM_WORKFLOW)
+    @patch('{}.team_workflow_api.get_workflow_for_submission'.format(MODULE))
     def test_get_team_workflow_cancellation_info_no_model(
             self,
             mock_get_workflow,
             mock_get_cancellation,
             mock_get_workflow_cancellation):
+        mock_get_workflow.return_value = TEAM_WORKFLOW
         mock_get_cancellation.side_effect = _mock_get_cancellation_info
-        self.test_block.get_username = Mock(return_value=USERNAME)
         mock_get_workflow_cancellation.return_value = None
         info = self.test_block.get_team_workflow_cancellation_info(TEAM_SUB_ID_2)
         self.assertEqual(
@@ -135,14 +136,14 @@ class TestTeamWorkflowMixin(TestCase):
 
     @patch('{}.AssessmentWorkflowCancellation.get_latest_workflow_cancellation'.format(MODULE))
     @patch('{}.team_workflow_api.get_assessment_workflow_cancellation'.format(MODULE))
-    @patch('{}.team_workflow_api.get_workflow_for_submission'.format(MODULE), return_value=TEAM_WORKFLOW)
+    @patch('{}.team_workflow_api.get_workflow_for_submission'.format(MODULE))
     def test_get_team_workflow_cancellation_info_with_model(
             self,
             mock_get_workflow,
             mock_get_cancellation,
             mock_get_workflow_cancellation):
+        mock_get_workflow.return_value = TEAM_WORKFLOW
         mock_get_cancellation.side_effect = _mock_get_cancellation_info
-        self.test_block.get_username = Mock(return_value=USERNAME)
         mock_get_workflow_cancellation.return_value = SimpleNamespace(**{"created_at": MODEL_CREATED_AT})
         info = self.test_block.get_team_workflow_cancellation_info(TEAM_SUB_ID_2)
         self.assertEqual(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.8.12",
+  "version": "2.8.13",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.8.12',
+    version='2.8.13',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -**

This ticket addresses EDUCATOR-5182, which notes that cancelled Team ORAs do not show their cancellation info.
**What changed?**
The cauase was the xblock was linking the inappropriate workflow in that case.  I added  new method for the team_workflow_mixin to fetch the Teams workflow version of cancellation info and linked it into the submission_mixin where appropriate.

**Note** I realized while working on this that there don't seem to be any unit tests around the workflow_mixin currently, and created a new ticket for that work

**Developer Checklist**
- [ ] Reviewed the [release process](./release_process.md)
- [ ] Translations up to date
- [ ] JS minified, SASS compiled
- [ ] Test suites passing on Jenkins
- [ ] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

JIRA: [EDUCATOR-5182](https://openedx.atlassian.net/browse/EDUCATOR-5182)

FIY: @edx/masters-devs-gta
