### PR TITLE
Jkantor/update after python3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,24 +12,22 @@ chardet==3.0.4            # via requests
 defusedxml==0.6.0         # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-submissions
 django-simple-history==2.11.0  # via -r requirements/base.in
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, edx-i18n-tools, edx-submissions, jsonfield2
+django==2.2.15            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, edx-i18n-tools, edx-submissions, jsonfield2
 djangorestframework==3.9.4  # via -r requirements/base.in, edx-submissions
 edx-i18n-tools==0.5.3     # via -r requirements/base.in
 edx-submissions==3.1.12   # via -r requirements/base.in
 fs==2.0.18                # via -c requirements/constraints.txt, xblock
 html5lib==1.1             # via -r requirements/base.in
 idna==2.8                 # via -c requirements/constraints.txt, requests
-importlib-metadata==1.7.0  # via path
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in, edx-submissions
 lazy==1.4                 # via -r requirements/base.in
 libsass==0.20.0           # via -r requirements/base.in
 loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements/base.in
 lxml==4.5.2               # via -r requirements/base.in, xblock
 markupsafe==1.1.1         # via xblock
-more-itertools==8.4.0     # via zipp
 packaging==20.4           # via bleach
-path.py==12.4.0           # via -r requirements/base.in, edx-i18n-tools
-path==13.1.0              # via path.py
+path.py==12.5.0           # via -r requirements/base.in, edx-i18n-tools
+path==15.0.0              # via path.py
 polib==1.1.0              # via edx-i18n-tools
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/base.in, xblock
@@ -39,13 +37,12 @@ pyyaml==5.3.1             # via edx-i18n-tools, xblock
 requests==2.24.0          # via python-swiftclient
 six==1.15.0               # via bleach, django-simple-history, edx-i18n-tools, fs, html5lib, libsass, packaging, python-dateutil, python-swiftclient, xblock
 sqlparse==0.3.1           # via django
-urllib3==1.25.9           # via requests
+urllib3==1.25.10          # via requests
 voluptuous==0.11.7        # via -c requirements/constraints.txt, -r requirements/base.in
 web-fragments==0.3.2      # via xblock
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.6              # via xblock
-xblock==1.3.1             # via -r requirements/base.in
-zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata
+xblock==1.4.0             # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,15 +19,17 @@ edx-submissions==3.1.12   # via -r requirements/base.in
 fs==2.0.18                # via -c requirements/constraints.txt, xblock
 html5lib==1.1             # via -r requirements/base.in
 idna==2.8                 # via -c requirements/constraints.txt, requests
+importlib-metadata==1.7.0  # via path
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in, edx-submissions
 lazy==1.4                 # via -r requirements/base.in
 libsass==0.20.0           # via -r requirements/base.in
 loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements/base.in
 lxml==4.5.2               # via -r requirements/base.in, xblock
 markupsafe==1.1.1         # via xblock
+more-itertools==8.4.0     # via zipp
 packaging==20.4           # via bleach
 path.py==12.5.0           # via -r requirements/base.in, edx-i18n-tools
-path==15.0.0              # via path.py
+path==13.1.0              # via -c requirements/constraints.txt, path.py
 polib==1.1.0              # via edx-i18n-tools
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/base.in, xblock
@@ -43,6 +45,7 @@ web-fragments==0.3.2      # via xblock
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.6              # via xblock
 xblock==1.4.0             # via -r requirements/base.in
+zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -27,3 +27,6 @@ freezegun<=0.3.14                   # Test failures on 0.3.15
 pytest==4.5.0
 pytest-cov==2.7.1
 pytest-django==3.7.0
+
+# path 13.2.0 drops support for Python 3.5
+path<13.2.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -21,3 +21,9 @@ ddt==1.0.0                          # Test failures at versions > 1.0.0
 idna<2.9.0                          # moto version moto==1.3.14 requires idna<2.9.0
 fs-s3fs==0.1.8                      # Constrained by edx-platform
 wrapt==1.11.*                       # Constrained by astroid
+freezegun<=0.3.14                   # Test failures on 0.3.15
+
+# https://github.com/edx/edx-ora2/pull/1303
+pytest==4.5.0
+pytest-cov==2.7.1
+pytest-django==3.7.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.2.1          # via -r requirements/pip-tools.in
+pip-tools==5.3.1          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -11,17 +11,17 @@ attrs==19.3.0             # via -r requirements/test.txt, jsonschema, pytest
 aws-sam-translator==1.25.0  # via -r requirements/test.txt, cfn-lint
 aws-xray-sdk==2.6.0       # via -r requirements/test.txt, moto
 bleach==3.1.5             # via -r requirements/test.txt
-boto3==1.14.21            # via -r requirements/test.txt, aws-sam-translator, fs-s3fs, moto
+boto3==1.14.38            # via -r requirements/test.txt, aws-sam-translator, fs-s3fs, moto
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/test.txt, moto
-botocore==1.17.21         # via -r requirements/test.txt, aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.17.38         # via -r requirements/test.txt, aws-xray-sdk, boto3, moto, s3transfer
 certifi==2020.6.20        # via -r requirements/test.txt, requests
-cffi==1.14.0              # via -r requirements/test.txt, cryptography
-cfn-lint==0.33.2          # via -r requirements/test.txt, moto
+cffi==1.14.1              # via -r requirements/test.txt, cryptography
+cfn-lint==0.34.1          # via -r requirements/test.txt, moto
 chardet==3.0.4            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
-coverage==5.2             # via -r requirements/test.txt, pytest-cov
-cryptography==2.9.2       # via -r requirements/test.txt, moto, sshpubkeys
+coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
+cryptography==3.0         # via -r requirements/test.txt, moto, sshpubkeys
 ddt==1.0.0                # via -c requirements/constraints.txt, -r requirements/test.txt
 decorator==4.4.2          # via -r requirements/test.txt, networkx
 defusedxml==0.6.0         # via -r requirements/test.txt
@@ -29,24 +29,24 @@ distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-submissions
 django-pyfs==2.2          # via -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/test.txt
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, django-pyfs, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
+django==2.2.15            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, django-pyfs, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
 djangorestframework==3.9.4  # via -r requirements/test.txt, edx-submissions
 docker==4.2.2             # via -r requirements/test.txt, moto
 docutils==0.15.2          # via -r requirements/test.txt, botocore
-ecdsa==0.15               # via -r requirements/test.txt, python-jose, sshpubkeys
+ecdsa==0.14.1             # via -r requirements/test.txt, python-jose, sshpubkeys
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-lint==1.5.0           # via -r requirements/quality.in
 edx-submissions==3.1.12   # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.1.1              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
-freezegun==0.3.14         # via -r requirements/test.txt
+freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.txt
 fs-s3fs==0.1.8            # via -c requirements/constraints.txt, -r requirements/test.txt, django-pyfs
 fs==2.0.18                # via -c requirements/constraints.txt, -r requirements/test.txt, django-pyfs, fs-s3fs, xblock
 future==0.18.2            # via -r requirements/test.txt, aws-xray-sdk
 html5lib==1.1             # via -r requirements/test.txt
 idna==2.8                 # via -c requirements/constraints.txt, -r requirements/test.txt, moto, requests
-importlib-metadata==1.7.0  # via -r requirements/test.txt, importlib-resources, jsonpickle, jsonschema, path, pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -r requirements/test.txt, importlib-resources, jsonpickle, jsonschema, pluggy, tox, virtualenv
 importlib-resources==1.5.0  # via -r requirements/test.txt, cfn-lint, virtualenv
 isort==4.3.21             # via pylint
 jinja2==2.11.2            # via -r requirements/test.txt, moto
@@ -70,9 +70,8 @@ more-itertools==8.4.0     # via -r requirements/test.txt, pytest, zipp
 moto==1.3.14              # via -r requirements/test.txt
 networkx==2.4             # via -r requirements/test.txt, cfn-lint
 packaging==20.4           # via -r requirements/test.txt, bleach, tox
-path.py==12.4.0           # via -r requirements/test.txt, edx-i18n-tools
-path==13.1.0              # via -r requirements/test.txt, path.py
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+path.py==12.5.0           # via -r requirements/test.txt, edx-i18n-tools
+path==15.0.0              # via -r requirements/test.txt, path.py
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
@@ -85,11 +84,11 @@ pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pyrsistent==0.16.0        # via -r requirements/test.txt, jsonschema
-pytest-cov==2.7.1         # via -r requirements/test.txt
-pytest-django==3.7.0      # via -r requirements/test.txt
-pytest==4.5.0             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest-cov==2.7.1         # via -c requirements/constraints.txt, -r requirements/test.txt
+pytest-django==3.7.0      # via -c requirements/constraints.txt, -r requirements/test.txt
+pytest==4.5.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/test.txt, botocore, faker, freezegun, moto, xblock
-python-jose==3.1.0        # via -r requirements/test.txt, moto
+python-jose==3.2.0        # via -r requirements/test.txt, moto
 python-swiftclient==3.10.0  # via -c requirements/constraints.txt, -r requirements/test.txt
 pytz==2020.1              # via -r requirements/test.txt, django, edx-submissions, fs, moto, xblock
 pyyaml==5.3.1             # via -r requirements/test.txt, cfn-lint, edx-i18n-tools, moto, xblock
@@ -97,16 +96,16 @@ requests==2.24.0          # via -r requirements/test.txt, docker, moto, python-s
 responses==0.10.15        # via -r requirements/test.txt, moto
 rsa==4.6                  # via -r requirements/test.txt, python-jose
 s3transfer==0.3.3         # via -r requirements/test.txt, boto3
-six==1.15.0               # via -r requirements/test.txt, astroid, aws-sam-translator, bleach, cfn-lint, cryptography, django-simple-history, docker, ecdsa, edx-i18n-tools, edx-lint, freezegun, fs, fs-s3fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pathlib2, pyrsistent, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
+six==1.15.0               # via -r requirements/test.txt, astroid, aws-sam-translator, bleach, cfn-lint, cryptography, django-simple-history, docker, ecdsa, edx-i18n-tools, edx-lint, freezegun, fs, fs-s3fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pyrsistent, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 sshpubkeys==3.1.0         # via -r requirements/test.txt, moto
 testfixtures==6.14.1      # via -r requirements/test.txt
 text-unidecode==1.3       # via -r requirements/test.txt, faker
 toml==0.10.1              # via -r requirements/test.txt, tox
-tox==3.17.1               # via -r requirements/test.txt
+tox==3.19.0               # via -r requirements/test.txt
 typed-ast==1.4.1          # via astroid
-urllib3==1.25.9           # via -r requirements/test.txt, botocore, requests
-virtualenv==20.0.27       # via -r requirements/test.txt, tox
+urllib3==1.25.10          # via -r requirements/test.txt, botocore, requests
+virtualenv==20.0.30       # via -r requirements/test.txt, tox
 voluptuous==0.11.7        # via -c requirements/constraints.txt, -r requirements/test.txt
 wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 web-fragments==0.3.2      # via -r requirements/test.txt, xblock
@@ -115,8 +114,8 @@ webob==1.8.6              # via -r requirements/test.txt, xblock
 websocket-client==0.57.0  # via -r requirements/test.txt, docker
 werkzeug==1.0.1           # via -r requirements/test.txt, moto
 wrapt==1.11.2             # via -c requirements/constraints.txt, -r requirements/test.txt, astroid, aws-xray-sdk
-xblock-sdk==0.2.0         # via -r requirements/test.txt
-xblock==1.3.1             # via -r requirements/test.txt
+xblock-sdk==0.2.2         # via -r requirements/test.txt
+xblock==1.4.0             # via -r requirements/test.txt
 xmltodict==0.12.0         # via -r requirements/test.txt, moto
 zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -31,7 +31,7 @@ django-pyfs==2.2          # via -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/test.txt
 django==2.2.15            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, django-pyfs, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
 djangorestframework==3.9.4  # via -r requirements/test.txt, edx-submissions
-docker==4.2.2             # via -r requirements/test.txt, moto
+docker==4.3.0             # via -r requirements/test.txt, moto
 docutils==0.15.2          # via -r requirements/test.txt, botocore
 ecdsa==0.14.1             # via -r requirements/test.txt, python-jose, sshpubkeys
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
@@ -46,7 +46,7 @@ fs==2.0.18                # via -c requirements/constraints.txt, -r requirements
 future==0.18.2            # via -r requirements/test.txt, aws-xray-sdk
 html5lib==1.1             # via -r requirements/test.txt
 idna==2.8                 # via -c requirements/constraints.txt, -r requirements/test.txt, moto, requests
-importlib-metadata==1.7.0  # via -r requirements/test.txt, importlib-resources, jsonpickle, jsonschema, pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -r requirements/test.txt, importlib-resources, jsonpickle, jsonschema, path, pluggy, tox, virtualenv
 importlib-resources==1.5.0  # via -r requirements/test.txt, cfn-lint, virtualenv
 isort==4.3.21             # via pylint
 jinja2==2.11.2            # via -r requirements/test.txt, moto
@@ -71,7 +71,7 @@ moto==1.3.14              # via -r requirements/test.txt
 networkx==2.4             # via -r requirements/test.txt, cfn-lint
 packaging==20.4           # via -r requirements/test.txt, bleach, tox
 path.py==12.5.0           # via -r requirements/test.txt, edx-i18n-tools
-path==15.0.0              # via -r requirements/test.txt, path.py
+path==13.1.0              # via -c requirements/constraints.txt, -r requirements/test.txt, path.py
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox

--- a/requirements/test-acceptance.in
+++ b/requirements/test-acceptance.in
@@ -5,6 +5,6 @@
 
 bok-choy
 ddt
-pytest==4.5.0
+pytest
 pyinstrument
 selenium

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -11,15 +11,15 @@ aws-sam-translator==1.25.0  # via -r requirements/test.txt, cfn-lint
 aws-xray-sdk==2.6.0       # via -r requirements/test.txt, moto
 bleach==3.1.5             # via -r requirements/test.txt
 bok-choy==1.1.1           # via -r requirements/test-acceptance.in
-boto3==1.14.21            # via -r requirements/test.txt, aws-sam-translator, fs-s3fs, moto
+boto3==1.14.38            # via -r requirements/test.txt, aws-sam-translator, fs-s3fs, moto
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/test.txt, moto
-botocore==1.17.21         # via -r requirements/test.txt, aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.17.38         # via -r requirements/test.txt, aws-xray-sdk, boto3, moto, s3transfer
 certifi==2020.6.20        # via -r requirements/test.txt, requests
-cffi==1.14.0              # via -r requirements/test.txt, cryptography
-cfn-lint==0.33.2          # via -r requirements/test.txt, moto
+cffi==1.14.1              # via -r requirements/test.txt, cryptography
+cfn-lint==0.34.1          # via -r requirements/test.txt, moto
 chardet==3.0.4            # via -r requirements/test.txt, requests
-coverage==5.2             # via -r requirements/test.txt, pytest-cov
-cryptography==2.9.2       # via -r requirements/test.txt, moto, sshpubkeys
+coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
+cryptography==3.0         # via -r requirements/test.txt, moto, sshpubkeys
 ddt==1.0.0                # via -c requirements/constraints.txt, -r requirements/test-acceptance.in, -r requirements/test.txt
 decorator==4.4.2          # via -r requirements/test.txt, networkx
 defusedxml==0.6.0         # via -r requirements/test.txt
@@ -27,23 +27,23 @@ distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-submissions
 django-pyfs==2.2          # via -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/test.txt
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, django-pyfs, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
+django==2.2.15            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, django-pyfs, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
 djangorestframework==3.9.4  # via -r requirements/test.txt, edx-submissions
 docker==4.2.2             # via -r requirements/test.txt, moto
 docutils==0.15.2          # via -r requirements/test.txt, botocore
-ecdsa==0.15               # via -r requirements/test.txt, python-jose, sshpubkeys
+ecdsa==0.14.1             # via -r requirements/test.txt, python-jose, sshpubkeys
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-submissions==3.1.12   # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.1.1              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
-freezegun==0.3.14         # via -r requirements/test.txt
+freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.txt
 fs-s3fs==0.1.8            # via -c requirements/constraints.txt, -r requirements/test.txt, django-pyfs
 fs==2.0.18                # via -c requirements/constraints.txt, -r requirements/test.txt, django-pyfs, fs-s3fs, xblock
 future==0.18.2            # via -r requirements/test.txt, aws-xray-sdk
 html5lib==1.1             # via -r requirements/test.txt
 idna==2.8                 # via -c requirements/constraints.txt, -r requirements/test.txt, moto, requests
-importlib-metadata==1.7.0  # via -r requirements/test.txt, importlib-resources, jsonpickle, jsonschema, path, pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -r requirements/test.txt, importlib-resources, jsonpickle, jsonschema, pluggy, tox, virtualenv
 importlib-resources==1.5.0  # via -r requirements/test.txt, cfn-lint, virtualenv
 jinja2==2.11.2            # via -r requirements/test.txt, moto
 jmespath==0.10.0          # via -r requirements/test.txt, boto3, botocore
@@ -64,9 +64,8 @@ more-itertools==8.4.0     # via -r requirements/test.txt, pytest, zipp
 moto==1.3.14              # via -r requirements/test.txt
 networkx==2.4             # via -r requirements/test.txt, cfn-lint
 packaging==20.4           # via -r requirements/test.txt, bleach, tox
-path.py==12.4.0           # via -r requirements/test.txt, edx-i18n-tools
-path==13.1.0              # via -r requirements/test.txt, path.py
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+path.py==12.5.0           # via -r requirements/test.txt, edx-i18n-tools
+path==15.0.0              # via -r requirements/test.txt, path.py
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
@@ -76,11 +75,11 @@ pyinstrument-cext==0.2.2  # via pyinstrument
 pyinstrument==3.1.3       # via -r requirements/test-acceptance.in
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pyrsistent==0.16.0        # via -r requirements/test.txt, jsonschema
-pytest-cov==2.7.1         # via -r requirements/test.txt
-pytest-django==3.7.0      # via -r requirements/test.txt
-pytest==4.5.0             # via -r requirements/test-acceptance.in, -r requirements/test.txt, pytest-cov, pytest-django
+pytest-cov==2.7.1         # via -c requirements/constraints.txt, -r requirements/test.txt
+pytest-django==3.7.0      # via -c requirements/constraints.txt, -r requirements/test.txt
+pytest==4.5.0             # via -c requirements/constraints.txt, -r requirements/test-acceptance.in, -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/test.txt, botocore, faker, freezegun, moto, xblock
-python-jose==3.1.0        # via -r requirements/test.txt, moto
+python-jose==3.2.0        # via -r requirements/test.txt, moto
 python-swiftclient==3.10.0  # via -c requirements/constraints.txt, -r requirements/test.txt
 pytz==2020.1              # via -r requirements/test.txt, django, edx-submissions, fs, moto, xblock
 pyyaml==5.3.1             # via -r requirements/test.txt, cfn-lint, edx-i18n-tools, moto, xblock
@@ -89,15 +88,15 @@ responses==0.10.15        # via -r requirements/test.txt, moto
 rsa==4.6                  # via -r requirements/test.txt, python-jose
 s3transfer==0.3.3         # via -r requirements/test.txt, boto3
 selenium==3.141.0         # via -r requirements/test-acceptance.in, bok-choy
-six==1.15.0               # via -r requirements/test.txt, aws-sam-translator, bleach, bok-choy, cfn-lint, cryptography, django-simple-history, docker, ecdsa, edx-i18n-tools, freezegun, fs, fs-s3fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pathlib2, pyrsistent, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
+six==1.15.0               # via -r requirements/test.txt, aws-sam-translator, bleach, bok-choy, cfn-lint, cryptography, django-simple-history, docker, ecdsa, edx-i18n-tools, freezegun, fs, fs-s3fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pyrsistent, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 sshpubkeys==3.1.0         # via -r requirements/test.txt, moto
 testfixtures==6.14.1      # via -r requirements/test.txt
 text-unidecode==1.3       # via -r requirements/test.txt, faker
 toml==0.10.1              # via -r requirements/test.txt, tox
-tox==3.17.1               # via -r requirements/test.txt
-urllib3==1.25.9           # via -r requirements/test.txt, botocore, requests, selenium
-virtualenv==20.0.27       # via -r requirements/test.txt, tox
+tox==3.19.0               # via -r requirements/test.txt
+urllib3==1.25.10          # via -r requirements/test.txt, botocore, requests, selenium
+virtualenv==20.0.30       # via -r requirements/test.txt, tox
 voluptuous==0.11.7        # via -c requirements/constraints.txt, -r requirements/test.txt
 wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 web-fragments==0.3.2      # via -r requirements/test.txt, xblock
@@ -106,8 +105,8 @@ webob==1.8.6              # via -r requirements/test.txt, xblock
 websocket-client==0.57.0  # via -r requirements/test.txt, docker
 werkzeug==1.0.1           # via -r requirements/test.txt, moto
 wrapt==1.11.2             # via -c requirements/constraints.txt, -r requirements/test.txt, aws-xray-sdk
-xblock-sdk==0.2.0         # via -r requirements/test.txt
-xblock==1.3.1             # via -r requirements/test.txt
+xblock-sdk==0.2.2         # via -r requirements/test.txt
+xblock==1.4.0             # via -r requirements/test.txt
 xmltodict==0.12.0         # via -r requirements/test.txt, moto
 zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -29,7 +29,7 @@ django-pyfs==2.2          # via -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/test.txt
 django==2.2.15            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, django-pyfs, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
 djangorestframework==3.9.4  # via -r requirements/test.txt, edx-submissions
-docker==4.2.2             # via -r requirements/test.txt, moto
+docker==4.3.0             # via -r requirements/test.txt, moto
 docutils==0.15.2          # via -r requirements/test.txt, botocore
 ecdsa==0.14.1             # via -r requirements/test.txt, python-jose, sshpubkeys
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
@@ -43,7 +43,7 @@ fs==2.0.18                # via -c requirements/constraints.txt, -r requirements
 future==0.18.2            # via -r requirements/test.txt, aws-xray-sdk
 html5lib==1.1             # via -r requirements/test.txt
 idna==2.8                 # via -c requirements/constraints.txt, -r requirements/test.txt, moto, requests
-importlib-metadata==1.7.0  # via -r requirements/test.txt, importlib-resources, jsonpickle, jsonschema, pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -r requirements/test.txt, importlib-resources, jsonpickle, jsonschema, path, pluggy, tox, virtualenv
 importlib-resources==1.5.0  # via -r requirements/test.txt, cfn-lint, virtualenv
 jinja2==2.11.2            # via -r requirements/test.txt, moto
 jmespath==0.10.0          # via -r requirements/test.txt, boto3, botocore
@@ -65,7 +65,7 @@ moto==1.3.14              # via -r requirements/test.txt
 networkx==2.4             # via -r requirements/test.txt, cfn-lint
 packaging==20.4           # via -r requirements/test.txt, bleach, tox
 path.py==12.5.0           # via -r requirements/test.txt, edx-i18n-tools
-path==15.0.0              # via -r requirements/test.txt, path.py
+path==13.1.0              # via -c requirements/constraints.txt, -r requirements/test.txt, path.py
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -7,11 +7,11 @@ coverage                            # Repeat a test case with multiple data inpu
 ddt
 django-pyfs
 factory_boy                         # Fixture factories for test setup
-freezegun<=0.3.14                   # Mock the datetime module to manipulate date functions, breaks on 0.3.15
+freezegun                           # Mock the datetime module to manipulate date functions
 mock                                # Stub out specific code during test runs
-pytest==4.5.0
-pytest-cov==2.7.1                          # pytest extension for code coverage statistics
-pytest-django==3.7.0                       # pytest extension for better Django support
+pytest
+pytest-cov                          # pytest extension for code coverage statistics
+pytest-django                       # pytest extension for better Django support
 moto
 testfixtures                        # Provides a LogCapture utility to be used by tests
 tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,15 +10,15 @@ attrs==19.3.0             # via jsonschema, pytest
 aws-sam-translator==1.25.0  # via cfn-lint
 aws-xray-sdk==2.6.0       # via moto
 bleach==3.1.5             # via -r requirements/base.txt
-boto3==1.14.21            # via aws-sam-translator, fs-s3fs, moto
+boto3==1.14.38            # via aws-sam-translator, fs-s3fs, moto
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/base.txt, moto
-botocore==1.17.21         # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.17.38         # via aws-xray-sdk, boto3, moto, s3transfer
 certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.0              # via cryptography
-cfn-lint==0.33.2          # via moto
+cffi==1.14.1              # via cryptography
+cfn-lint==0.34.1          # via moto
 chardet==3.0.4            # via -r requirements/base.txt, requests
-coverage==5.2             # via -r requirements/test.in, pytest-cov
-cryptography==2.9.2       # via moto, sshpubkeys
+coverage==5.2.1           # via -r requirements/test.in, pytest-cov
+cryptography==3.0         # via moto, sshpubkeys
 ddt==1.0.0                # via -c requirements/constraints.txt, -r requirements/test.in
 decorator==4.4.2          # via networkx
 defusedxml==0.6.0         # via -r requirements/base.txt
@@ -28,19 +28,19 @@ django-pyfs==2.2          # via -r requirements/test.in
 django-simple-history==2.11.0  # via -r requirements/base.txt
 docker==4.2.2             # via moto
 docutils==0.15.2          # via botocore
-ecdsa==0.15               # via python-jose, sshpubkeys
+ecdsa==0.14.1             # via python-jose, sshpubkeys
 edx-i18n-tools==0.5.3     # via -r requirements/base.txt
 edx-submissions==3.1.12   # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.1.1              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
-freezegun==0.3.14         # via -r requirements/test.in
+freezegun==0.3.14         # via -c requirements/constraints.txt, -r requirements/test.in
 fs-s3fs==0.1.8            # via -c requirements/constraints.txt, django-pyfs
 fs==2.0.18                # via -c requirements/constraints.txt, -r requirements/base.txt, django-pyfs, fs-s3fs, xblock
 future==0.18.2            # via aws-xray-sdk
 html5lib==1.1             # via -r requirements/base.txt
 idna==2.8                 # via -c requirements/constraints.txt, -r requirements/base.txt, moto, requests
-importlib-metadata==1.7.0  # via -r requirements/base.txt, importlib-resources, jsonpickle, jsonschema, path, pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via importlib-resources, jsonpickle, jsonschema, pluggy, tox, virtualenv
 importlib-resources==1.5.0  # via cfn-lint, virtualenv
 jinja2==2.11.2            # via moto
 jmespath==0.10.0          # via boto3, botocore
@@ -57,13 +57,12 @@ loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements
 lxml==4.5.2               # via -r requirements/base.txt, xblock
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2, xblock
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in, moto
-more-itertools==8.4.0     # via -r requirements/base.txt, -r requirements/test.in, pytest, zipp
+more-itertools==8.4.0     # via -r requirements/test.in, pytest, zipp
 moto==1.3.14              # via -r requirements/test.in
 networkx==2.4             # via cfn-lint
 packaging==20.4           # via -r requirements/base.txt, bleach, tox
-path.py==12.4.0           # via -r requirements/base.txt, edx-i18n-tools
-path==13.1.0              # via -r requirements/base.txt, path.py
-pathlib2==2.3.5           # via pytest
+path.py==12.5.0           # via -r requirements/base.txt, edx-i18n-tools
+path==15.0.0              # via -r requirements/base.txt, path.py
 pluggy==0.13.1            # via pytest, tox
 polib==1.1.0              # via -r requirements/base.txt, edx-i18n-tools
 py==1.9.0                 # via pytest, tox
@@ -71,11 +70,11 @@ pyasn1==0.4.8             # via python-jose, rsa
 pycparser==2.20           # via cffi
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
 pyrsistent==0.16.0        # via jsonschema
-pytest-cov==2.7.1         # via -r requirements/test.in
-pytest-django==3.7.0      # via -r requirements/test.in
-pytest==4.5.0             # via -r requirements/test.in, pytest-cov, pytest-django
+pytest-cov==2.7.1         # via -c requirements/constraints.txt, -r requirements/test.in
+pytest-django==3.7.0      # via -c requirements/constraints.txt, -r requirements/test.in
+pytest==4.5.0             # via -c requirements/constraints.txt, -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/base.txt, botocore, faker, freezegun, moto, xblock
-python-jose==3.1.0        # via moto
+python-jose==3.2.0        # via moto
 python-swiftclient==3.10.0  # via -c requirements/constraints.txt, -r requirements/base.txt
 pytz==2020.1              # via -r requirements/base.txt, django, edx-submissions, fs, moto, xblock
 pyyaml==5.3.1             # via -r requirements/base.txt, cfn-lint, edx-i18n-tools, moto, xblock
@@ -83,15 +82,15 @@ requests==2.24.0          # via -r requirements/base.txt, docker, moto, python-s
 responses==0.10.15        # via moto
 rsa==4.6                  # via python-jose
 s3transfer==0.3.3         # via boto3
-six==1.15.0               # via -r requirements/base.txt, aws-sam-translator, bleach, cfn-lint, cryptography, django-simple-history, docker, ecdsa, edx-i18n-tools, freezegun, fs, fs-s3fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pathlib2, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
+six==1.15.0               # via -r requirements/base.txt, aws-sam-translator, bleach, cfn-lint, cryptography, django-simple-history, docker, ecdsa, edx-i18n-tools, freezegun, fs, fs-s3fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 sshpubkeys==3.1.0         # via moto
 testfixtures==6.14.1      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
 toml==0.10.1              # via tox
-tox==3.17.1               # via -r requirements/test.in
-urllib3==1.25.9           # via -r requirements/base.txt, botocore, requests
-virtualenv==20.0.27       # via tox
+tox==3.19.0               # via -r requirements/test.in
+urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
+virtualenv==20.0.30       # via tox
 voluptuous==0.11.7        # via -c requirements/constraints.txt, -r requirements/base.txt
 wcwidth==0.2.5            # via pytest
 web-fragments==0.3.2      # via -r requirements/base.txt, xblock
@@ -100,10 +99,10 @@ webob==1.8.6              # via -r requirements/base.txt, xblock
 websocket-client==0.57.0  # via docker
 werkzeug==1.0.1           # via moto
 wrapt==1.11.2             # via -c requirements/constraints.txt, aws-xray-sdk
-xblock-sdk==0.2.0         # via -r requirements/test.in
-xblock==1.3.1             # via -r requirements/base.txt
+xblock-sdk==0.2.2         # via -r requirements/test.in
+xblock==1.4.0             # via -r requirements/base.txt
 xmltodict==0.12.0         # via moto
-zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,7 +26,7 @@ distlib==0.3.1            # via virtualenv
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-submissions
 django-pyfs==2.2          # via -r requirements/test.in
 django-simple-history==2.11.0  # via -r requirements/base.txt
-docker==4.2.2             # via moto
+docker==4.3.0             # via moto
 docutils==0.15.2          # via botocore
 ecdsa==0.14.1             # via python-jose, sshpubkeys
 edx-i18n-tools==0.5.3     # via -r requirements/base.txt
@@ -40,7 +40,7 @@ fs==2.0.18                # via -c requirements/constraints.txt, -r requirements
 future==0.18.2            # via aws-xray-sdk
 html5lib==1.1             # via -r requirements/base.txt
 idna==2.8                 # via -c requirements/constraints.txt, -r requirements/base.txt, moto, requests
-importlib-metadata==1.7.0  # via importlib-resources, jsonpickle, jsonschema, pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -r requirements/base.txt, importlib-resources, jsonpickle, jsonschema, path, pluggy, tox, virtualenv
 importlib-resources==1.5.0  # via cfn-lint, virtualenv
 jinja2==2.11.2            # via moto
 jmespath==0.10.0          # via boto3, botocore
@@ -57,12 +57,12 @@ loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements
 lxml==4.5.2               # via -r requirements/base.txt, xblock
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2, xblock
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in, moto
-more-itertools==8.4.0     # via -r requirements/test.in, pytest, zipp
+more-itertools==8.4.0     # via -r requirements/base.txt, -r requirements/test.in, pytest, zipp
 moto==1.3.14              # via -r requirements/test.in
 networkx==2.4             # via cfn-lint
 packaging==20.4           # via -r requirements/base.txt, bleach, tox
 path.py==12.5.0           # via -r requirements/base.txt, edx-i18n-tools
-path==15.0.0              # via -r requirements/base.txt, path.py
+path==13.1.0              # via -c requirements/constraints.txt, -r requirements/base.txt, path.py
 pluggy==0.13.1            # via pytest, tox
 polib==1.1.0              # via -r requirements/base.txt, edx-i18n-tools
 py==1.9.0                 # via pytest, tox
@@ -102,7 +102,7 @@ wrapt==1.11.2             # via -c requirements/constraints.txt, aws-xray-sdk
 xblock-sdk==0.2.2         # via -r requirements/test.in
 xblock==1.4.0             # via -r requirements/base.txt
 xmltodict==0.12.0         # via moto
-zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -16,6 +16,6 @@ py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
-tox==3.17.1               # via -r requirements/tox.in
-virtualenv==20.0.27       # via tox
+tox==3.19.0               # via -r requirements/tox.in
+virtualenv==20.0.30       # via tox
 zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,7 +7,7 @@
 appdirs==1.4.4            # via -r requirements/tox.txt, virtualenv
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-coverage==5.2             # via coveralls
+coverage==5.2.1           # via coveralls
 coveralls==2.1.1          # via -r requirements/travis.in
 distlib==0.3.1            # via -r requirements/tox.txt, virtualenv
 docopt==0.6.2             # via coveralls
@@ -23,7 +23,7 @@ pyparsing==2.4.7          # via -r requirements/tox.txt, packaging
 requests==2.24.0          # via coveralls
 six==1.15.0               # via -r requirements/tox.txt, packaging, tox, virtualenv
 toml==0.10.1              # via -r requirements/tox.txt, tox
-tox==3.17.1               # via -r requirements/tox.txt
-urllib3==1.25.9           # via requests
-virtualenv==20.0.27       # via -r requirements/tox.txt, tox
+tox==3.19.0               # via -r requirements/tox.txt
+urllib3==1.25.10          # via requests
+virtualenv==20.0.30       # via -r requirements/tox.txt, tox
 zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/tox.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-4822

This ticket was about removing requirement pins that were specifically python 2, but i don't see any.

I moved some pins from *in files to constraints.txt and ran make upgrade.

@edx/masters-devs-gta 