### PR TITLE
Surface file info as a dict instead of a tuple

### DIFF
--- a/openassessment/fileupload/tests/test_file_management.py
+++ b/openassessment/fileupload/tests/test_file_management.py
@@ -185,10 +185,10 @@ class FileUploadManagerTests(TestCase):
             mock_default_storage.exists.return_value = True
             other_users_file_manager = FileUploadManager(other_users_block)
 
-            actual_descriptors = other_users_file_manager.team_file_descriptor_tuples()
-            self.assertEqual(2, len(actual_descriptors))
-            for descriptor in actual_descriptors:
-                self.assertEqual(mock_default_storage.url.return_value, descriptor.download_url)
+            actual_metadata = other_users_file_manager.team_files_metadata()
+            self.assertEqual(2, len(actual_metadata))
+            for metadata in actual_metadata:
+                self.assertEqual(mock_default_storage.url.return_value, metadata['download_url'])
 
             actual_file_uploads = other_users_file_manager.get_team_uploads()
             self.assertEqual(2, len(actual_file_uploads))

--- a/openassessment/templates/openassessmentblock/oa_team_uploaded_files.html
+++ b/openassessment/templates/openassessmentblock/oa_team_uploaded_files.html
@@ -1,5 +1,6 @@
 {% spaceless %}
 {% load i18n %}
+{% load oa_extras%}
 
 {% if file_upload_type %}
   <div class="{{ class_prefix }}__display__file {% if not team_file_urls %}is--hidden{% endif %} submission__{{ file_upload_type }}__upload" data-upload-type="{{ file_upload_type }}">
@@ -10,7 +11,9 @@
         {% endif %}
 
         <div class="submission__answer__files">
-        {% for file_url, file_description, file_name, owner_username in team_file_urls %}
+        {% for file in team_file_urls %}
+        {% with file_url=file|get_item:"download_url" file_description=file|get_item:"description" file_name=file|get_item:"name" owner_username=file|get_item:"uploaded_by" %}
+
             <div class="submission__answer__team__file__block submission__answer__team__file__block__{{ forloop.counter0 }}" {% if not file_url %} deleted {% endif %}>
             {% if file_url %}
                 {% if file_upload_type == "image" %}
@@ -31,6 +34,7 @@
                 [{% trans "Uploaded by" %} <strong class="emphasis">{{ owner_username }}</strong>]
             {% endif %}
             </div>
+        {% endwith %}
         {% endfor %}
         </div>
     </div>

--- a/openassessment/templates/openassessmentblock/oa_uploaded_file.html
+++ b/openassessment/templates/openassessmentblock/oa_uploaded_file.html
@@ -1,5 +1,6 @@
 {% spaceless %}
 {% load i18n %}
+{% load oa_extras%}
 
 {% if file_upload_type %}
     {% if header %}
@@ -17,7 +18,9 @@
           </h5>
         {% endif %}
         <div class="submission__answer__files">
-        {% for file_url, file_description, file_name, show_delete_button in file_urls %}
+        {% for file in file_urls %}
+        {% with file_url=file|get_item:"download_url" file_description=file|get_item:"description" file_name=file|get_item:"name" show_delete_button=file|get_item:"show_delete_button" %}
+
             <div class="submission__answer__file__block submission__answer__file__block__{{ forloop.counter0 }}" {% if not file_url %} deleted {% endif %}>
             {% if file_url %}
                 {% if file_upload_type == "image" %}
@@ -42,6 +45,7 @@
                 {% endif %}
             {% endif %}
             </div>
+        {% endwith %}
         {% endfor %}
         </div>
         {% if show_warning %}

--- a/openassessment/templatetags/oa_extras.py
+++ b/openassessment/templatetags/oa_extras.py
@@ -26,3 +26,13 @@ def link_and_linebreak(text):
         escaped_text = conditional_escape(text)
         return mark_safe(linebreaks(bleach.linkify(escaped_text, callbacks=[callbacks.target_blank])))
     return None
+
+
+@register.filter()
+def get_item(dictionary, key):
+    """
+    Get values from a dictionary in Django template.
+    Usage example: {{ your_dict|get_item:your_key }}
+    """
+    if key:
+        return dictionary.get(key)

--- a/openassessment/xblock/leaderboard_mixin.py
+++ b/openassessment/xblock/leaderboard_mixin.py
@@ -92,12 +92,26 @@ class LeaderboardMixin:
                     if file_download_url:
                         file_description = descriptions[idx] if idx < len(descriptions) else ''
                         file_name = file_names[idx] if idx < len(file_names) else ''
-                        score['files'].append((file_download_url, file_description, file_name, False))
+                        score['files'].append(
+                            {
+                                'download_url': file_download_url,
+                                'description': file_description,
+                                'name': file_name,
+                                'show_delete_button': False
+                            }
+                        )
 
             elif 'file_key' in score['content']:
                 file_download_url = self._get_file_download_url(score['content']['file_key'])
                 if file_download_url:
-                    score['files'].append((file_download_url, '', '', False))
+                    score['files'].append(
+                        {
+                            'download_url': file_download_url,
+                            'description': '',
+                            'name': '',
+                            'show_delete_button': False
+                        }
+                    )
             if 'text' in score['content'] or 'parts' in score['content']:
                 submission = {'answer': score.pop('content')}
                 score['submission'] = create_submission_dict(submission, self.prompts)

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -528,12 +528,22 @@ class SubmissionMixin:
                     except AttributeError:
                         file_name = ''
                         logger.error('descriptions[idx] is None in {}'.format(submission))
-                    urls.append((file_download_url, file_description, file_name, False))
+                    urls.append({
+                        'download_url': file_download_url,
+                        'description': file_description,
+                        'name': file_name,
+                        'show_delete_button': False
+                    })
         elif 'file_key' in submission['answer']:
             key = submission['answer'].get('file_key', '')
             file_download_url = self._get_url_by_file_key(key)
             if file_download_url:
-                urls.append((file_download_url, '', '', False))
+                urls.append({
+                    'download_url': file_download_url,
+                    'description': '',
+                    'name': '',
+                    'show_delete_button': False
+                })
         return urls
 
     def get_files_info_from_user_state(self, username):
@@ -567,7 +577,12 @@ class SubmissionMixin:
                 download_url = self._get_url_by_file_key(file_key)
                 if download_url:
                     file_name = files_names[index] if index < len(files_names) else ''
-                    files_info.append((download_url, description, file_name, False))
+                    files_info.append({
+                        'download_url': download_url,
+                        'description': description,
+                        'name': file_name,
+                        'show_delete_button': False
+                    })
                 else:
                     # If file has been removed, the URL doesn't exist
                     logger.info("URLWorkaround: no URL for description {desc} & key {key} for user:{user}".format(
@@ -610,7 +625,12 @@ class SubmissionMixin:
                     user=username_or_email,
                     block=str(self.location)
                 ))
-                file_uploads.append((download_url, '', '', False))
+                file_uploads.append({
+                    'download_url': download_url,
+                    'description': '',
+                    'name': '',
+                    'show_delete_button': False
+                })
             else:
                 continue
 
@@ -711,8 +731,8 @@ class SubmissionMixin:
         file_urls = None
 
         if self.file_upload_type:
-            context['file_urls'] = self.file_manager.file_descriptor_tuples(include_deleted=True)
-            context['team_file_urls'] = self.file_manager.team_file_descriptor_tuples()
+            context['file_urls'] = self.file_manager.files_metadata(include_deleted=True)
+            context['team_file_urls'] = self.file_manager.team_files_metadata()
         if self.file_upload_type == 'custom':
             context['white_listed_file_types'] = self.white_listed_file_types
 

--- a/openassessment/xblock/test/test_leaderboard.py
+++ b/openassessment/xblock/test/test_leaderboard.py
@@ -180,7 +180,12 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
             key = Key(bucket, 'submissions_attachments/{}'.format(file_key))
             key.set_contents_from_string("How d'ya do?")
             files_url_and_description = [
-                (api.get_download_url(file_key), file_descriptions[idx], file_names[idx], False)
+                {
+                    'download_url': api.get_download_url(file_key),
+                    'description': file_descriptions[idx],
+                    'name': file_names[idx],
+                    'show_delete_button': False
+                }
                 for idx, file_key in enumerate(file_keys)
             ]
 
@@ -217,7 +222,14 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
         key = Key(bucket, 'submissions_attachments/foo')
         key.set_contents_from_string("How d'ya do?")
 
-        file_download_url = [(api.get_download_url('foo'), '', '', False)]
+        file_download_url = [
+            {
+                'download_url': api.get_download_url('foo'),
+                'description': '',
+                'name': '',
+                'show_delete_button': False
+            }
+        ]
         # Create a image and text submission
         submission = prepare_submission_for_serialization(('test answer 1 part 1', 'test answer 1 part 2'))
         submission[u'file_key'] = 'foo'
@@ -349,6 +361,9 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
         for score in scores:
             if score.get('files'):
                 score['files'] = [
-                    (_clean_query_string(file_info[0]), file_info[1]) for file_info in score['files']
+                    {
+                        'download_url': _clean_query_string(file_info['download_url']),
+                        'description': file_info['description']
+                    } for file_info in score['files']
                 ]
         return scores

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -451,11 +451,15 @@ class TestCourseStaff(XBlockHandlerTestCase):
 
             # Check the context passed to the template
             self.assertEqual(
-                [
-                    ('http://www.example.com/image.jpeg', 'test_description', 'test_fileName', False)
-                ],
+                [{
+                    'download_url': 'http://www.example.com/image.jpeg',
+                    'description': 'test_description',
+                    'name': 'test_fileName',
+                    'show_delete_button': False
+                }],
                 context['staff_file_urls']
             )
+
             self.assertEqual('image', context['file_upload_type'])
 
             # Check the fully rendered template
@@ -507,7 +511,12 @@ class TestCourseStaff(XBlockHandlerTestCase):
 
             # Check the context passed to the template
             self.assertEqual(
-                [(image, "test_description%d" % i, "fname%d" % i, False) for i, image in enumerate(images)],
+                [{
+                    "download_url": image,
+                    "description": "test_description%d" % i,
+                    "name": "fname%d" % i,
+                    "show_delete_button": False
+                } for i, image in enumerate(images)],
                 context['staff_file_urls']
             )
             self.assertEqual('image', context['file_upload_type'])
@@ -1029,8 +1038,14 @@ class TestCourseStaff(XBlockHandlerTestCase):
             self._verify_user_state_usage_log_present(logger, **{'location': xblock.location})
             staff_urls = context['staff_file_urls']
             for count in range(2):
-                self.assertTupleEqual(
-                    staff_urls[count], (FILE_URL, SAVED_FILES_DESCRIPTIONS[count], SAVED_FILES_NAMES[count], False)
+                self.assertDictEqual(
+                    staff_urls[count],
+                    {
+                        'download_url': FILE_URL,
+                        'description': SAVED_FILES_DESCRIPTIONS[count],
+                        'name': SAVED_FILES_NAMES[count],
+                        'show_delete_button': False
+                    }
                 )
 
             self._verify_staff_assessment_rendering(
@@ -1161,7 +1176,12 @@ class TestCourseStaff(XBlockHandlerTestCase):
         # Calling this method directly as using `get_student_info_path_and_context`
         # will use user state. This is because we are mocking get_download_url method.
         staff_urls = xblock.get_all_upload_urls_for_user('Bob')
-        expected_staff_urls = [(FILE_URL, '', '', False)] * xblock.MAX_FILES_COUNT
+        expected_staff_urls = [{
+            'download_url': FILE_URL,
+            'description': '',
+            'name': '',
+            'show_delete_button': False
+        }] * xblock.MAX_FILES_COUNT
         self.assertEqual(staff_urls, expected_staff_urls)
 
         new_context = dict(context.items())
@@ -1279,11 +1299,13 @@ class TestCourseStaff(XBlockHandlerTestCase):
             file_api.get_download_url.assert_called_with("test_key")
 
             # Check the context passed to the template
-
             self.assertEqual(
-                [
-                    ('http://www.example.com/image.jpeg', 'test_description', 'test_fileName', False)
-                ],
+                [{
+                    'download_url': 'http://www.example.com/image.jpeg',
+                    'description': 'test_description',
+                    'name': 'test_fileName',
+                    'show_delete_button': False
+                }],
                 context['staff_file_urls']
             )
 

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -516,8 +516,18 @@ class SubmissionTest(SubmissionXBlockHandlerTestCase):
             # Even though one of the keys had no good download URL, we should
             # still return data for keys that came after it.
             expected_urls = [
-                ('download-url-1', 'desc-1', 'name-1', False),
-                ('download-url-3', 'desc-3', 'name-3', False),
+                {
+                    'download_url': 'download-url-1',
+                    'description': 'desc-1',
+                    'name': 'name-1',
+                    'show_delete_button': False
+                },
+                {
+                    'download_url': 'download-url-3',
+                    'description': 'desc-3',
+                    'name': 'name-3',
+                    'show_delete_button': False
+                },
             ]
             self.assertEqual(expected_urls, actual_urls)
 
@@ -540,7 +550,12 @@ class SubmissionTest(SubmissionXBlockHandlerTestCase):
 
             actual_urls = xblock.get_download_urls_from_submission(mock_submission)
             expected_urls = [
-                ('download-url-1', '', '', False),
+                {
+                    'download_url': 'download-url-1',
+                    'description': '',
+                    'name': '',
+                    'show_delete_button': False
+                }
             ]
             self.assertEqual(expected_urls, actual_urls)
 
@@ -819,8 +834,8 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'file_upload_response': 'optional',
                 'file_upload_type': 'pdf-and-image',
                 'file_urls': [
-                    ('', 'file-1', None, True),
-                    ('', 'file-2', None, True)
+                    {'download_url': '', 'description': 'file-1', 'name': None, 'show_delete_button': True},
+                    {'download_url': '', 'description': 'file-2', 'name': None, 'show_delete_button': True}
                 ],
                 'team_file_urls': [],
                 'saved_response': create_submission_dict({


### PR DESCRIPTION
**TL;DR -** surface file info as a dict instead of a tuple.

**Benefit:** Treating file info as a dictionary allows us to remove or extend file data more easily when surfacing to Django templates.

**What changed?**
- Change file API to pass file info as a dict instead of a tuple: `file_descriptor_tuples` -> `files_metadata`
- Remove deprecated `FileDescriptor` and `TeamFileDescriptor` named tuples
- Add a Django template filter, `get_item`, to allow unpacking data from a dictionary
- Modify templates to unpack and use dictionary data for file info

**Developer Checklist**
- [x] Reviewed the [release process](./release_process.md)
- [x] Translations up to date
- [x] JS minified, SASS compiled
- [ ] Test suites passing on Jenkins
- [ ] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

JIRA: [JIRA-XXXX](https://openedx.atlassian.net/browse/JIRA-XXXX)

FIY: @edx/masters-devs-gta
