### PR TITLE
Allow a student to see their submission even if they are not on a team

### DIFF
--- a/openassessment/templates/openassessmentblock/response/oa_response_unavailable.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response_unavailable.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="false" disabled></button>
+    <button class="ui-slidable" aria-expanded="false" disabled/>
 {% endblock %}
 
 {% block title %}

--- a/openassessment/templates/openassessmentblock/response/oa_response_unavailable.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response_unavailable.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="false" disabled>
+    <button class="ui-slidable" aria-expanded="false" disabled></button>
 {% endblock %}
 
 {% block title %}

--- a/openassessment/xblock/message_mixin.py
+++ b/openassessment/xblock/message_mixin.py
@@ -48,7 +48,11 @@ class MessageMixin:
         # Render the instruction message based on the status of the workflow
         # and the closed status.
         if self.teams_enabled and not self.valid_access_to_team_assessment():
-            path, context = self.render_message_no_team()
+            # If the learner is not on a team and hasn't submitted, warn them
+            if status is None:
+                path, context = self.render_message_no_team()
+            else:
+                path, context = 'openassessmentblock/message/oa_message_unavailable.html', {}
         elif status in ("done", "waiting"):
             path, context = self.render_message_complete(status_details)
         elif problem_is_closed or active_step_deadline_info.get('is_closed'):

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -518,9 +518,6 @@ class OpenAssessmentBlock(MessageMixin,
         }
         template = get_template("openassessmentblock/oa_base.html")
 
-        if self.teams_enabled and not self.valid_access_to_team_assessment():
-            context_dict['rubric_assessments'] = []
-
         return self._create_fragment(template, context_dict, initialize_js_func='OpenAssessmentBlock')
 
     def ora_blocks_listing_view(self, context=None):

--- a/openassessment/xblock/test/test_message.py
+++ b/openassessment/xblock/test/test_message.py
@@ -902,3 +902,38 @@ class TestMessageRender(XBlockHandlerTestCase):
             xblock, expected_path, expected_context,
             status, deadline_information, has_peers_to_grade
         )
+
+    @scenario('data/message_scenario_staff_assessment_only.xml', user_id="Linda")
+    @ddt.data(True, False)
+    def test_no_team_with_prior_sumbission(self, xblock, has_prior_submbission):
+        status = "staff" if has_prior_submbission else None
+        deadline_information = {
+            'submission': (False, None, self.FAR_PAST, self.FUTURE),
+            'staff-assessment': (False, None, self.FAR_PAST, self.FAR_FUTURE),
+            'over-all': (False, None, self.FAR_PAST, self.FAR_FUTURE)
+        }
+        has_peers_to_grade = False
+
+        xblock.teams_enabled = True
+        xblock.selected_teamset_id = 'teamset_message_id'
+        xblock.valid_access_to_team_assessment = mock.MagicMock(return_value=False)
+
+        mock_teamset = mock.MagicMock()
+        mock_teamset.configure_mock(name='Teamset Name')
+        xblock.teamset_config = mock_teamset
+
+        expected_context = {}
+
+        # Hide the message if the learner has already submitted
+        if has_prior_submbission:
+            expected_path = 'openassessmentblock/message/oa_message_unavailable.html'
+        else:
+            expected_path = 'openassessmentblock/message/oa_message_no_team.html'
+            expected_context['teamset_name'] = "Teamset Name"
+
+        expected_context['xblock_id'] = xblock.scope_ids.usage_id
+
+        self._assert_path_and_context(
+            xblock, expected_path, expected_context,
+            status, deadline_information, has_peers_to_grade
+        )

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -1511,7 +1511,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         xblock.runtime._services['teams'] = MockTeamsService(True)
 
         # Assert that the xblock renders an unavailablbe submission
-        path, context = xblock.submission_path_and_context()
+        path, _ = xblock.submission_path_and_context()
         self.assertEqual(path, 'openassessmentblock/response/oa_response_unavailable.html')
 
     @scenario('data/team_submission.xml', user_id="Red Five")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.9.8',
+    version='2.9.9',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** Show a student their past submission, even if they are no longer on a team for a team ORA.

**What changed?**

- Changed behaviors for when a student views a team ORA when they are no longer on a team for the assignment:
   - Student has previously submitted: show their submission.
   - Student has not previously submitted: show the "this is a team assignment" warning banner and render the "unavailable assignment" skeleton.
- Staff views remain unchanged.
- Fix display bug in the `ora_response_unavailable.html` template
- Bump ORA to `2.9.9`

**Developer Checklist**
- [x] Reviewed the [release process](./release_process.md)
- [x] Translations up to date
- [x] JS minified, SASS compiled
- [x] Test suites passing on Jenkins
- [x] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

JIRA: [EDUCATOR-5280](https://openedx.atlassian.net/browse/EDUCATOR-5280)

## Screenshots
Student who is not on a team for the team-set will see the "unavailable" assignment and a warning banner:

<img width="880" alt="Screen Shot 2020-09-02 at 12 17 43" src="https://user-images.githubusercontent.com/12944465/92042507-5d7b2080-ed48-11ea-8ac7-4a3cf621b4dc.png">

FIY: @edx/masters-devs-gta
