### PR TITLE
Rerun MathJax for staff grade view

### DIFF
--- a/openassessment/templates/openassessmentblock/staff_area/oa_staff_grade_learners_assessment.html
+++ b/openassessment/templates/openassessmentblock/staff_area/oa_staff_grade_learners_assessment.html
@@ -9,6 +9,9 @@
       data-team-usernames="{{ team_usernames|default:"" }}"
     >
         <div class="wrapper--staff-assessment">
+            <script>
+                MathJax.Hub.Typeset()
+            </script>
             <div>
                 {% if teams_enabled %}
                   <p>{% trans "Give this team a grade using the problem's rubric." %}</p>


### PR DESCRIPTION

**TL;DR -** [ A short summary of what this PR does and why ]
In the staff grading view, math formatted writeup was not working. MathJax.Hub.Typeset() needs to be called for typesetting, dynamically loaded part. 

**What changed?**
Just added a script tag to the template which calls MathJax.Hub.Typeset()

- [ More in depth breakdown of changes ]
- [ Peripheral things that got changed ]
- [ etc... ]

**Developer Checklist**
- [ ] Reviewed the [release process](./release_process.md)
- [ ] Translations up to date
- [ ] JS minified, SASS compiled
- [ ] Test suites passing on Jenkins
- [ ] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

JIRA: [JIRA-XXXX](https://openedx.atlassian.net/browse/JIRA-XXXX)

FIY: @edx/masters-devs-gta
