### PR TITLE
move team info box

### DIFF
--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -82,6 +82,22 @@
                                     </div>
                                 </article>
 
+                                <div id='team_name_and_users'>
+                                    {% trans "You are on team " %}
+                                    <a href="{{team_url}}">{{team_name}}</a>.
+                                    {% trans "Team Members: " %}
+                                    <strong class="emphasis">{{team_usernames|join:", "}}.</strong>
+                                    {% if team_members_with_external_submissions %}
+                                      <br />
+                                      <strong class="emphasis">
+                                        {% blocktrans %}
+                                            {{team_members_with_external_submissions}}
+                                            have/has already submitted a response to this assignment with another team,
+                                            and will not be a part of your team's submission or assignment grade.
+                                        {% endblocktrans %}
+                                      </strong>
+                                    {% endif %}
+                                </div>
 
                                 {% if text_response %}
                                 <div class="field field--textarea submission__answer__part__text">
@@ -123,22 +139,6 @@
                                     {% endblocktrans %}
                                 </div>
                             {% endif %}
-                            <div id='team_name_and_users'>
-                                {% trans "You are on team " %}
-                                <a href="{{team_url}}">{{team_name}}</a>.
-                                {% trans "Team Members: " %}
-                                <strong class="emphasis">{{team_usernames|join:", "}}.</strong>
-                                {% if team_members_with_external_submissions %}
-                                  <br />
-                                  <strong class="emphasis">
-                                    {% blocktrans %}
-                                        {{team_members_with_external_submissions}}
-                                        have/has already submitted a response to this assignment with another team,
-                                        and will not be a part of your team's submission or assignment grade.
-                                    {% endblocktrans %}
-                                  </strong>
-                                {% endif %}
-                            </div>
                             {% if previous_team_name %}
                                 <div id='team_user_has_previous_submission'>
                                     {% blocktrans %}


### PR DESCRIPTION
**TL;DR -** 
Move the Team info box to the location indicated in the figma file

![image](https://user-images.githubusercontent.com/5533134/92621957-7c226f80-f292-11ea-9610-ae4a1129a1e6.png)
https://www.figma.com/file/VQg46ULo3TraRsu5KOZdS8/ORA-Teams-Pilot-Feedback?node-id=553%3A76

**Developer Checklist**
- [ ] Reviewed the [release process](./release_process.md)
- [ ] Translations up to date
- [ ] JS minified, SASS compiled
- [ ] Test suites passing on Jenkins
- [ ] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

JIRA: [EDUCATOR-5310](https://openedx.atlassian.net/browse/EDUCATOR-5310)

FIY: @edx/masters-devs-gta
