### PR TITLE
only show message about team uploads if the user is on a team

### DIFF
--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -230,10 +230,12 @@
                               {% trans "(Optional)" %}
                             {% endif %}
                           </h5>
-                          {% blocktrans %}
-                            Upload files and review files uploaded by you and your teammates below. Be sure to add
-                            descriptions to your files to help your teammates identify them.
-                          {% endblocktrans %}
+                          {% if team_name %}
+                            {% blocktrans %}
+                                Upload files and review files uploaded by you and your teammates below. Be sure to add
+                                descriptions to your files to help your teammates identify them.
+                            {% endblocktrans %}
+                          {% endif %}
                           <li class="field">
                               <div class="upload__error">
                                   <div class="message message--inline message--error message--error-server" tabindex="-1">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.9.12',
+    version='2.9.13',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** There's a message that should only be shown for team ORA that is being shown for individual ORAs

**What changed?**

- That's it

**Developer Checklist**
- [x] Reviewed the [release process](./release_process.md)
- [x] Translations up to date
- [x] JS minified, SASS compiled
- [x] Test suites passing on Jenkins
- [ ] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

This is the message: 
![Screen Shot 2020-09-22 at 2 26 03 PM](https://user-images.githubusercontent.com/1639231/93922166-93744a80-fcdf-11ea-80b7-b46f5242cb66.png)

FIY: @edx/masters-devs-gta
