### PR TITLE
[BB-2991] [BD-05] WIP: Add new APIs

### DIFF
--- a/openassessment/api/urls.py
+++ b/openassessment/api/urls.py
@@ -1,0 +1,17 @@
+""" API paths. """
+
+
+from django.conf.urls import url
+
+from openassessment.api import views
+
+urlpatterns = [
+    url(
+        r'summarise/(?P<course_id>[^/]+)',
+        views.SummariseAllAssesments.as_view()
+    ),
+    url(
+        r'waiting/(?P<course_id>[^/]+)',
+        views.ListWaitingAssessments.as_view()
+    ),
+]

--- a/openassessment/api/views.py
+++ b/openassessment/api/views.py
@@ -1,0 +1,84 @@
+import json
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAdminUser
+from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.django import modulestore
+from openassessment.data import OraAggregateData
+import six
+from openassessment.workflow.models import AssessmentWorkflow, TeamAssessmentWorkflow
+from submissions import api as sub_api
+from django.contrib.sites.models import Site
+
+
+class SummariseAllAssesments(APIView):
+    """
+    View to list all tasks in a course.
+
+    * Only staff users are able to access this view.
+    """
+
+    permission_classes = (IsAdminUser,)
+
+    def get(self, request, course_id):
+        """
+        List ORA tasks in a course, along with their statistics.
+        """
+
+        responses = OraAggregateData.collect_ora2_responses(str(course_id))
+        
+        all_valid_ora_statuses = set()
+        all_valid_ora_statuses.update(AssessmentWorkflow().STATUS_VALUES)
+        all_valid_ora_statuses.update(TeamAssessmentWorkflow().STATUS_VALUES)
+        
+        openassessment_blocks = modulestore().get_items(
+            CourseKey.from_string(course_id), qualifiers={'category': 'openassessment'}
+        )
+        # filter out orphaned openassessment blocks
+        openassessment_blocks = {
+            six.text_type(block.location): block for block in openassessment_blocks if block.parent is not None
+        }
+
+        result = {}
+        parent_names = {}
+        for location, block in openassessment_blocks.items():
+            parent_str = six.text_type(block.parent)
+            if location in responses.keys():
+                result[location] = responses[location]
+            else:
+                result[location] = {key: 0 for key in all_valid_ora_statuses}
+            
+            if parent_str not in parent_names:
+                parent_names[parent_str] = modulestore().get_item(block.parent).display_name
+            result[location]['unit'] = parent_names[parent_str]
+        
+        return Response(result)
+
+class ListWaitingAssessments(APIView):
+    """
+    List students that are waiting for some grade, and show a link to override it's grade.
+
+    * Only staff users are able to access this view.
+    """
+
+    permission_classes = (IsAdminUser,)
+
+    def get(self, request, course_id):
+        """
+        List all users waiting on grading and a link to override their grade.
+        """
+
+        result = []
+        domain = Site.objects.get_current().domain
+        # Blocker: How do i get the site name? From the request or through Site like above?
+        # Blocker: How do i get the name of the student? TODO later
+        all_waiting_workflows = AssessmentWorkflow.objects.filter(course_id=course_id, status="waiting")
+
+        for workflow in all_waiting_workflows:
+            response = {}
+            student_item = sub_api.get_submission_and_student(workflow.submission_uuid)['student_item']
+            response['user'] = student_item
+            response['link'] = 'https://{domain}/xblock/{xblock_id}'.format(domain=domain, xblock_id=student_item['item_id'])
+            result.append(response)
+
+        return Response(result)

--- a/openassessment/utils.py
+++ b/openassessment/utils.py
@@ -1,0 +1,40 @@
+"""
+Utility functions
+"""
+import logging
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+
+logger = logging.getLogger("ora.utils")
+
+
+def anonymized_id_to_username(cls, anonymized_id):
+    """
+    Args:
+        anonymized_id - an anonymized id.
+    Returns:
+        username - username mapped to the anonymized ID
+    """
+    User = get_user_model()
+
+    cache_key = "anonymized.to.username.{}".format(anonymized_id)
+    try:
+        cached_username = cache.get(cache_key)
+    except Exception:  # pylint: disable=broad-except
+        # The cache backend could raise an exception
+        # (for example, memcache keys that contain spaces)
+        logger.exception("Error occurred while retrieving student item from the cache")
+        cached_username = None
+
+    if cached_username is not None:
+        return cached_username
+    else:
+        try:
+            username = cls._use_read_replica(  # pylint: disable=protected-access
+                User.objects.filter(anonymoususerid__anonymous_user_id=anonymized_id)
+            )[0].username
+
+            cache.set(cache_key, username)
+            return username
+        except IndexError:
+            return None


### PR DESCRIPTION
This PR adds two new endpoints:

1. List ORA tasks in a course, along with their statistics. This endpoint should present all data currently shown in the instructor dashboard.
2. List students that are waiting for some grade, and show a link to override it's grade.

**JIRA tickets**: https://openedx.atlassian.net/browse/TNL-7576

**Merge deadline**: None

**Testing instructions**:

1. Clone this PR (You can use the GH CLI tool to do it in one shot! See the 'open with' at top right)
2. Install this package by using pip install
3. Using Postman or other tool, make a GET query to 'http://localhost:18000/openassessment/summarise/course-v1:edX+DemoX+Demo_Course' for a summary of all ORA blocks in the course
4. Using Postman or other tool, make a GET query to 'http://localhost:18000/openassessment/waiting/course-v1:edX+DemoX+Demo_Course' for a list of all students waiting on a grade & a link to the page containing the associated ORA block

**Author notes and concerns**:

1. Some blockers mentioned in views.py
2. Tests need to be added
3. Need to convert to pluggable app

**Reviewers**
- [ ] @giovannicimolin