### PR TITLE
Leaderboard doesn't show file names

### DIFF
--- a/openassessment/xblock/leaderboard_mixin.py
+++ b/openassessment/xblock/leaderboard_mixin.py
@@ -86,7 +86,7 @@ class LeaderboardMixin:
             if 'file_keys' in score['content']:
                 file_keys = score['content'].get('file_keys', [])
                 descriptions = score['content'].get('files_descriptions', [])
-                file_names = score['content'].get('files_name', [])
+                file_names = score['content'].get('files_names', [])
                 for idx, key in enumerate(file_keys):
                     file_download_url = self._get_file_download_url(key)
                     if file_download_url:

--- a/openassessment/xblock/test/test_leaderboard.py
+++ b/openassessment/xblock/test/test_leaderboard.py
@@ -173,7 +173,7 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
         """
         file_keys = ['foo', 'bar']
         file_descriptions = ['{}-description'.format(file_key) for file_key in file_keys]
-        file_names = ['{}-file_name'.format(file_key) for file_key in file_keys]
+        files_names = ['{}-file_name'.format(file_key) for file_key in file_keys]
         conn = boto.connect_s3()
         bucket = conn.create_bucket('mybucket')
         for file_key in file_keys:
@@ -183,7 +183,7 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
                 {
                     'download_url': api.get_download_url(file_key),
                     'description': file_descriptions[idx],
-                    'name': file_names[idx],
+                    'name': files_names[idx],
                     'show_delete_button': False
                 }
                 for idx, file_key in enumerate(file_keys)
@@ -193,7 +193,7 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
         submission = prepare_submission_for_serialization(('test answer 1 part 1', 'test answer 1 part 2'))
         submission[u'file_keys'] = file_keys
         submission[u'files_descriptions'] = file_descriptions
-        submission[u'files_name'] = file_names
+        submission[u'files_names'] = files_names
         self._create_submissions_and_scores(xblock, [
             (submission, 1)
         ])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.9.13",
+  "version": "2.9.14",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.9.13',
+    version='2.9.14',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** One missing letter caused file names to not show up on leaderboards

**What changed?**

**Before**
![Screen Shot 2020-09-23 at 12 15 29 PM](https://user-images.githubusercontent.com/1639231/94040101-87978f80-fd96-11ea-8f9b-a24fe20da0bd.png)

**After**
![Screen Shot 2020-09-23 at 12 16 25 PM](https://user-images.githubusercontent.com/1639231/94040221-ad249900-fd96-11ea-8ae4-ad82d49097cc.png)


**Developer Checklist**
- [x] Reviewed the [release process](./release_process.md)
- [x] Translations up to date
- [x] JS minified, SASS compiled
- [x] Test suites passing on Jenkins
- [x] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

FIY: @edx/masters-devs-gta


