### PR TITLE
EDUCATOR-5365: backwards compatibility for old ora submissions

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -774,11 +774,17 @@ class OraDownloadData:
         all_submission_information = sub_api.get_all_course_submission_information(course_id, 'openassessment')
 
         for student, submission, _ in all_submission_information:
-            answer = submission['answer']
+            answer = submission.get('answer', dict())
 
             # collecting submission attachments with metadata
             for index, file_key in enumerate(answer.get('file_keys', [])):
-                file_name = answer['files_names'][index]
+                file_names = answer.get('files_names', answer.get('files_name', []))
+                file_name = file_names[index]
+
+                file_size = 0
+                file_sizes = answer.get('files_sizes')
+                if file_sizes:
+                    file_size = file_sizes[index]
 
                 yield {
                     'type': cls.ATTACHMENT,
@@ -788,7 +794,7 @@ class OraDownloadData:
                     'key': file_key,
                     'name': file_name,
                     'description': answer['files_descriptions'][index],
-                    'size': answer['files_sizes'][index],
+                    'size': file_size,
                     'file_path': os.path.join(
                         str(course_id),
                         student['item_id'],

--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -778,9 +778,12 @@ class OraDownloadData:
 
             # collecting submission attachments with metadata
             for index, file_key in enumerate(answer.get('file_keys', [])):
+                # Old submissions (approx. pre-2020) have file names under the key "files_name"
                 file_names = answer.get('files_names', answer.get('files_name', []))
                 file_name = file_names[index]
 
+                # 'files_sizes' was added sometime around the beginning of 2020, so older submissions
+                # will not have it
                 file_size = 0
                 file_sizes = answer.get('files_sizes')
                 if file_sizes:

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -952,7 +952,8 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
         submission.save()
 
         # Answers once had a different format
-        old_style_submission = sub_api._get_submission_model(self.old_style_submission['uuid'])  # pylint: disable=protected-access
+        old_uuid = self.old_style_submission['uuid']
+        old_style_submission = sub_api._get_submission_model(old_uuid)  # pylint: disable=protected-access
         old_style_submission.answer = self.old_style_answer
         old_style_submission.save()
 

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -25,6 +25,7 @@ from openassessment.workflow import api as workflow_api, team_api as team_workfl
 COURSE_ID = "Test_Course"
 
 STUDENT_ID = u"Student"
+OLD_STUDENT_ID = "Old_Student"
 
 STUDENT_USERNAME = "Student Username"
 
@@ -48,6 +49,13 @@ ITEM_DISPLAY_NAME = "Open Response Assessment"
 
 STUDENT_ITEM = dict(
     student_id=STUDENT_ID,
+    course_id=COURSE_ID,
+    item_id=ITEM_ID,
+    item_type="openassessment"
+)
+
+OLD_STUDENT_ITEM = dict(
+    student_id=OLD_STUDENT_ID,
     course_id=COURSE_ID,
     item_id=ITEM_ID,
     item_type="openassessment"
@@ -801,19 +809,23 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
         self.maxDiff = None  # pylint: disable=invalid-name
 
         self.submission = self._create_submission(STUDENT_ITEM)
+        self.old_style_submission = self._create_submission(OLD_STUDENT_ITEM)
         self.scorer_submission = self._create_submission(SCORER_ITEM)
 
         self.file_name_1 = 'file_name_1.jpg'
         self.file_name_2 = 'file_name_2.pdf'
         self.file_name_3 = 'file_name_3.png'
+        self.file_name_4 = 'file_name_4.png'
 
         self.file_key_1 = '{}/{}/{}'.format(STUDENT_ID, COURSE_ID, ITEM_ID)
         self.file_key_2 = '{}/{}/{}/1'.format(STUDENT_ID, COURSE_ID, ITEM_ID)
         self.file_key_3 = '{}/{}/{}/2'.format(STUDENT_ID, COURSE_ID, ITEM_ID)
+        self.file_key_4 = '{}/{}/{}'.format(OLD_STUDENT_ID, COURSE_ID, ITEM_ID)
 
         self.file_description_1 = 'Some Description 1'
         self.file_description_2 = 'Some Description 2'
         self.file_description_3 = 'Some Description 3'
+        self.file_description_4 = 'Some Description 4'
 
         self.file_size_1 = 2 ** 20
         self.file_size_2 = 2 ** 21
@@ -834,8 +846,41 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
             'files_names': [self.file_name_1, self.file_name_2, self.file_name_3],
             'files_sizes': [self.file_size_1, self.file_size_2, self.file_size_3],
         }
+        self.old_style_answer = {
+            'parts': [{'text': self.answer_text}],
+            'file_keys': [self.file_key_4],
+            'files_descriptions': [self.file_description_4],
+            'files_name': [self.file_name_4]
+        }
 
         self.submission_files_data = [
+            {
+                'course_id': COURSE_ID,
+                'block_id': ITEM_ID,
+                'student_id': OLD_STUDENT_ID,
+                'key': self.file_key_4,
+                'name': self.file_name_4,
+                'type': OraDownloadData.ATTACHMENT,
+                'description': self.file_description_4,
+                'size': 0,
+                'file_path': '{}/{}/{}/attachments/{}'.format(
+                    COURSE_ID, ITEM_ID, OLD_STUDENT_ID, self.file_name_4
+                ),
+            },
+            {
+                'course_id': COURSE_ID,
+                'block_id': ITEM_ID,
+                'student_id': OLD_STUDENT_ID,
+                'key': '',
+                'name': 'part_0.txt',
+                'type': OraDownloadData.TEXT,
+                'description': 'Submission text.',
+                'content': self.answer_text,
+                'size': len(self.answer_text),
+                'file_path': '{}/{}/{}/{}'.format(
+                    COURSE_ID, ITEM_ID, OLD_STUDENT_ID, 'part_0.txt'
+                ),
+            },
             {
                 'course_id': COURSE_ID,
                 'block_id': ITEM_ID,
@@ -906,6 +951,11 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
         submission.answer = self.answer
         submission.save()
 
+        # Answers once had a different format
+        old_style_submission = sub_api._get_submission_model(self.old_style_submission['uuid'])  # pylint: disable=protected-access
+        old_style_submission.answer = self.old_style_answer
+        old_style_submission.save()
+
         # answer for scorer submission is just a string, and `collect_ora2_submission_files`
         # raises exception because of it, so we change it to empty dict
         scorer_submission = sub_api._get_submission_model(  # pylint: disable=protected-access
@@ -914,7 +964,8 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
         scorer_submission.answer = {}
         scorer_submission.save()
 
-        assert list(OraDownloadData.collect_ora2_submission_files(COURSE_ID)) == self.submission_files_data
+        collected_ora_files_data = list(OraDownloadData.collect_ora2_submission_files(COURSE_ID))
+        assert collected_ora_files_data == self.submission_files_data
 
     def test_create_zip_with_attachments(self):
         file = BytesIO()
@@ -927,6 +978,7 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
             OraDownloadData.create_zip_with_attachments(file, COURSE_ID, self.submission_files_data)
 
             download_mock.assert_has_calls([
+                call(self.file_key_4),
                 call(self.file_key_1),
                 call(self.file_key_2),
                 call(self.file_key_3),
@@ -934,26 +986,34 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
 
         zip_file = zipfile.ZipFile(file)
 
-        # archive should contain three attachments, one part text file and one csv
-        self.assertEqual(len(zip_file.infolist()), 5)
+        # archive should contain four attachments, two parts text file and one csv
+        self.assertEqual(len(zip_file.infolist()), 7)
 
-        # check that all attachments have been written to the archive
+        # check for old_user's file and text
         self.assertEqual(
             zip_file.read(self.submission_files_data[0]['file_path']),
             file_content
         )
         self.assertEqual(
             zip_file.read(self.submission_files_data[1]['file_path']),
-            file_content
+            self.answer_text.encode('utf-8')
         )
+        # check that main user's attachments have been written to the archive
         self.assertEqual(
             zip_file.read(self.submission_files_data[2]['file_path']),
             file_content
         )
-
-        # check that all texts are also here
         self.assertEqual(
             zip_file.read(self.submission_files_data[3]['file_path']),
+            file_content
+        )
+        self.assertEqual(
+            zip_file.read(self.submission_files_data[4]['file_path']),
+            file_content
+        )
+        # main user's text response
+        self.assertEqual(
+            zip_file.read(self.submission_files_data[5]['file_path']),
             self.answer_text.encode('utf-8')
         )
 

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -847,7 +847,7 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
             'files_sizes': [self.file_size_1, self.file_size_2, self.file_size_3],
         }
 
-        # Older responses (approx. pre-2020) won't have files_sizes 
+        # Older responses (approx. pre-2020) won't have files_sizes
         # and will have the key 'files_name' rather than 'files_names'
         self.old_style_answer = {
             'parts': [{'text': self.answer_text}],

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -846,6 +846,8 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
             'files_names': [self.file_name_1, self.file_name_2, self.file_name_3],
             'files_sizes': [self.file_size_1, self.file_size_2, self.file_size_3],
         }
+
+        # Older responses (approx. pre-2020) won't have files_sizes and will have the key 'files_name' rather than 'files_names'
         self.old_style_answer = {
             'parts': [{'text': self.answer_text}],
             'file_keys': [self.file_key_4],

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -847,7 +847,8 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
             'files_sizes': [self.file_size_1, self.file_size_2, self.file_size_3],
         }
 
-        # Older responses (approx. pre-2020) won't have files_sizes and will have the key 'files_name' rather than 'files_names'
+        # Older responses (approx. pre-2020) won't have files_sizes 
+        # and will have the key 'files_name' rather than 'files_names'
         self.old_style_answer = {
             'parts': [{'text': self.answer_text}],
             'file_keys': [self.file_key_4],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.9.18",
+  "version": "2.10.1",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "backbone": "~1.2.3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.10.0',
+    version='2.10.1',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -**  `OraDownloadData.collect_ora2_submission_files()` tries to access `answer['files_names']` and `answer['files_sizes'` which don't exist for ORA answers older than Jan 2020ish. This fixes this and fixes the linked bug.

**Testing instructions**
This is tricky. Create the default test ORA with uploads allowed on local or stage, and submit an answer with some number of files. ~Then , go into django admin and manually modify the submission.~  Actually, you can't edit submissions from django admin, you'll have to manually update it from mysql eww
 
1. Change the key `files_names` to `files_name`
2. Delete the `files_sizes` key and value.

Now, go to the instructor dashboard for the course and  click 'Generate Submission Files Archive'.
If you can download the file, the bug has been fixed.

**Developer Checklist**
- [x] Reviewed the [release process](./release_process.md)
- [x] Translations up to date
- [x] JS minified, SASS compiled
- [x] Test suites passing on Jenkins
- [x] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

JIRA: [EDUCATOR-5365](https://openedx.atlassian.net/browse/EDUCATOR-5365)

FIY: @edx/masters-devs-gta
