### PR TITLE
fix manifest to include new webpack-compiled output files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include README.rst
 include setup.cfg
 include openassessment/xblock/static/css/*.css
 include openassessment/xblock/static/css/lib/backgrid/*.css
-include openassessment/xblock/static/js/openassessment*.min.js
+include openassessment/xblock/static/js/openassessment*.js
 include openassessment/xblock/static/js/lib/backgrid/*.js
 include requirements/*.in
 recursive-include openassessment/xblock/static/js/src *.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.2.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.11.2',
+    version='2.11.3',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** we were deploying to pypi in a way that didn't include the new webpack output and it broke everything

**What changed?**

- we used to compile js to `openassessment-lms.min.js` and `openassessment-studio.min.js`
- as of 2.11.0 we compile them to `openassessment-lms.js` and `openassessment-studio.js`
- the manifest wasn't updated so we weren't picking up our comipled files anymore when we deployed to pypi

**Developer Checklist**
- [x] Reviewed the [release process](./release_process.md)
- [x] Translations up to date
- [x] JS minified, SASS compiled
- [x] Test suites passing on Jenkins
- [x] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

JIRA: [EDUCATOR-5399](https://openedx.atlassian.net/browse/EDUCATOR-5399)

FIY: @edx/masters-devs-gta
