### PR TITLE
Do not use waffle for activation of mobile support due to it prevents…

### DIFF
--- a/openassessment/xblock/config_mixin.py
+++ b/openassessment/xblock/config_mixin.py
@@ -114,8 +114,8 @@ class ConfigMixin:
         return self.is_feature_enabled(ALL_FILES_URLS)
 
     @cached_property
-    def is_mobile_support_waffle_enabled(self):
+    def is_mobile_support_enabled(self):
         """
         Returns a boolean indicating if the mobile support feature flag is enabled or not.
         """
-        return self.is_feature_enabled(MOBILE_SUPPORT)
+        return self._settings_toggle_enabled(FEATURE_TOGGLES_BY_FLAG_NAME.get(MOBILE_SUPPORT))

--- a/openassessment/xblock/mobile.py
+++ b/openassessment/xblock/mobile.py
@@ -16,7 +16,7 @@ class TogglableMobileSupport(ConfigMixin):
         Add mobile support if the feature flag is enabled.
         """
         try:
-            if self.is_mobile_support_waffle_enabled:
+            if self.is_mobile_support_enabled:
                 return XBlock.supports('multi_device')(view)
         except ImportError:
             # Openedx libraries are not available in testing

--- a/openassessment/xblock/test/test_config_mixin.py
+++ b/openassessment/xblock/test/test_config_mixin.py
@@ -106,29 +106,22 @@ class ConfigMixinTest(TestCase):
         )
 
     @ddt.data(
-        *list(itertools.product([True, False], repeat=3))
+        (True, True),
+        (False, False),
+        (None, False),
     )
     @ddt.unpack
-    @mock.patch('openassessment.xblock.config_mixin.import_waffle_switch', autospec=True)
-    @mock.patch('openassessment.xblock.config_mixin.import_course_waffle_flag', autospec=True)
     def test_mobile_support_enabled(
-            self, waffle_switch_input, waffle_flag_input, settings_input, mock_waffle_flag, mock_waffle_switch
+            self, settings_input, expected_output
     ):
         """
-        The "ora mobile support" workaround is expected to be enabled if at least one of the following conditions holds:
-          1) The all_files_urls waffle switch is enabled.
-          2) The all_files_urls course waffle flag is enabled.
-          3) The settings.FEATURES['ENABLE_ORA_MOBILE_SUPPORT'] value is True.
+        The mobile support is expected to be enabled only if:
+          1) The settings.FEATURES['ENABLE_ORA_MOBILE_SUPPORT'] value is True.
         """
-        self._run_feature_toggle_test(
-            MOBILE_SUPPORT,
-            waffle_switch_input,
-            waffle_flag_input,
-            settings_input,
-            mock_waffle_flag,
-            mock_waffle_switch,
-            'is_mobile_support_waffle_enabled',
-        )
+        my_block = MockBlock()
+        settings_feature_key = FEATURE_TOGGLES_BY_FLAG_NAME[MOBILE_SUPPORT]
+        with self.settings(FEATURES={settings_feature_key: settings_input}):
+            self.assertEqual(expected_output, my_block.is_mobile_support_enabled)
 
     def _run_feature_toggle_test(
             self, flag_name, waffle_switch_input, waffle_flag_input, settings_input,

--- a/openassessment/xblock/test/test_mobile.py
+++ b/openassessment/xblock/test/test_mobile.py
@@ -11,7 +11,7 @@ class MobileSupportTest(TestCase):
 
     @mock.patch('xblock.core.XBlock.supports')
     @mock.patch(
-        'openassessment.xblock.config_mixin.ConfigMixin.is_mobile_support_waffle_enabled',
+        'openassessment.xblock.config_mixin.ConfigMixin.is_mobile_support_enabled',
         new_callable=mock.PropertyMock
     )
     def test_mobile_support_enabled(self, config_mixin_mock, xblock_mock):
@@ -31,7 +31,7 @@ class MobileSupportTest(TestCase):
 
     @mock.patch('xblock.core.XBlock.supports')
     @mock.patch(
-        'openassessment.xblock.config_mixin.ConfigMixin.is_mobile_support_waffle_enabled',
+        'openassessment.xblock.config_mixin.ConfigMixin.is_mobile_support_enabled',
         new_callable=mock.PropertyMock
     )
     def test_mobile_support_disabled(self, config_mixin_mock, xblock_mock):

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.11.4',
+    version='2.11.5',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
This remove the usage of waffle flags for enable/disable de mobile support in ora2.


A full description of the issue in:

https://discuss.openedx.org/t/upgrading-tutor-for-koa/3499/2
