### PR TITLE
[BD-21] Make use of new-style waffle switch objects

### DIFF
--- a/openassessment/xblock/config_mixin.py
+++ b/openassessment/xblock/config_mixin.py
@@ -3,9 +3,11 @@ Mixin for determining configuration and feature-toggle state relevant to an ORA 
 """
 
 
+from edx_django_utils.monitoring import set_custom_attribute
+from edx_toggles.toggles.__future__ import WaffleSwitch
+
 from django.conf import settings
 from django.utils.functional import cached_property
-from edx_toggles.toggles.__future__ import WaffleSwitch
 
 WAFFLE_NAMESPACE = 'openresponseassessment'
 
@@ -20,6 +22,15 @@ FEATURE_TOGGLES_BY_FLAG_NAME = {
     TEAM_SUBMISSIONS: 'ENABLE_ORA_TEAM_SUBMISSIONS',
     USER_STATE_UPLOAD_DATA: 'ENABLE_ORA_USER_STATE_UPLOAD_DATA'
 }
+
+
+def import_waffle_switch():
+    """
+    Helper method that imports WaffleSwitch from edx-platform at runtime.
+    WARNING: This method is now deprecated and should not be relied upon.
+    """
+    set_custom_attribute("deprecated_edx_ora2", "import_waffle_switch")
+    return WaffleSwitch
 
 
 def import_course_waffle_flag():

--- a/openassessment/xblock/config_mixin.py
+++ b/openassessment/xblock/config_mixin.py
@@ -5,6 +5,7 @@ Mixin for determining configuration and feature-toggle state relevant to an ORA 
 
 from django.conf import settings
 from django.utils.functional import cached_property
+from edx_toggles.toggles.__future__ import WaffleSwitch
 
 WAFFLE_NAMESPACE = 'openresponseassessment'
 
@@ -19,16 +20,6 @@ FEATURE_TOGGLES_BY_FLAG_NAME = {
     TEAM_SUBMISSIONS: 'ENABLE_ORA_TEAM_SUBMISSIONS',
     USER_STATE_UPLOAD_DATA: 'ENABLE_ORA_USER_STATE_UPLOAD_DATA'
 }
-
-
-def import_waffle_switch():
-    """
-    Helper method that imports WaffleSwitch from edx-platform at runtime.
-    https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/waffle_utils/__init__.py#L187
-    """
-    # pylint: disable=import-error
-    from openedx.core.djangoapps.waffle_utils import WaffleSwitch
-    return WaffleSwitch
 
 
 def import_course_waffle_flag():
@@ -51,8 +42,8 @@ class ConfigMixin:
         Returns a ``WaffleSwitch`` object in WAFFLE_NAMESPACE
         with the given ``switch_name``.
         """
-        WaffleSwitch = import_waffle_switch()  # pylint: disable=invalid-name
-        return WaffleSwitch(WAFFLE_NAMESPACE, switch_name)  # pylint: disable=feature-toggle-needs-doc
+        # pylint: disable=feature-toggle-needs-doc
+        return WaffleSwitch("{}.{}".format(WAFFLE_NAMESPACE, switch_name), module_name=__name__)
 
     @staticmethod
     def _course_waffle_flag(flag_name):

--- a/openassessment/xblock/test/test_config_mixin.py
+++ b/openassessment/xblock/test/test_config_mixin.py
@@ -34,11 +34,7 @@ class ConfigMixinTest(TestCase):
         *list(itertools.product([True, False], repeat=3))
     )
     @ddt.unpack
-    @mock.patch('openassessment.xblock.config_mixin.import_waffle_switch', autospec=True)
-    @mock.patch('openassessment.xblock.config_mixin.import_course_waffle_flag', autospec=True)
-    def test_team_submission_enabled(
-            self, waffle_switch_input, waffle_flag_input, settings_input, mock_waffle_flag, mock_waffle_switch
-    ):
+    def test_team_submission_enabled(self, waffle_switch_input, waffle_flag_input, settings_input):
         """
         Team submissions are expected to be enabled if at least one of the following conditions holds:
           1) The team_submissions waffle switch is enabled.
@@ -50,8 +46,6 @@ class ConfigMixinTest(TestCase):
             waffle_switch_input,
             waffle_flag_input,
             settings_input,
-            mock_waffle_flag,
-            mock_waffle_switch,
             'team_submissions_enabled',
         )
 
@@ -59,11 +53,7 @@ class ConfigMixinTest(TestCase):
         *list(itertools.product([True, False], repeat=3))
     )
     @ddt.unpack
-    @mock.patch('openassessment.xblock.config_mixin.import_waffle_switch', autospec=True)
-    @mock.patch('openassessment.xblock.config_mixin.import_course_waffle_flag', autospec=True)
-    def test_user_state_upload_data_enabled(
-            self, waffle_switch_input, waffle_flag_input, settings_input, mock_waffle_flag, mock_waffle_switch
-    ):
+    def test_user_state_upload_data_enabled(self, waffle_switch_input, waffle_flag_input, settings_input):
         """
         The user state data workaround is expected to be enabled if at least one of the following conditions holds:
           1) The user_state_upload_data waffle switch is enabled.
@@ -75,8 +65,6 @@ class ConfigMixinTest(TestCase):
             waffle_switch_input,
             waffle_flag_input,
             settings_input,
-            mock_waffle_flag,
-            mock_waffle_switch,
             'user_state_upload_data_enabled',
         )
 
@@ -84,11 +72,7 @@ class ConfigMixinTest(TestCase):
         *list(itertools.product([True, False], repeat=3))
     )
     @ddt.unpack
-    @mock.patch('openassessment.xblock.config_mixin.import_waffle_switch', autospec=True)
-    @mock.patch('openassessment.xblock.config_mixin.import_course_waffle_flag', autospec=True)
-    def test_all_files_urls_enabled(
-            self, waffle_switch_input, waffle_flag_input, settings_input, mock_waffle_flag, mock_waffle_switch
-    ):
+    def test_all_files_urls_enabled(self, waffle_switch_input, waffle_flag_input, settings_input):
         """
         The "all file urls" workaround is expected to be enabled if at least one of the following conditions holds:
           1) The all_files_urls waffle switch is enabled.
@@ -100,8 +84,6 @@ class ConfigMixinTest(TestCase):
             waffle_switch_input,
             waffle_flag_input,
             settings_input,
-            mock_waffle_flag,
-            mock_waffle_switch,
             'is_fetch_all_urls_waffle_enabled',
         )
 
@@ -111,9 +93,7 @@ class ConfigMixinTest(TestCase):
         (None, False),
     )
     @ddt.unpack
-    def test_mobile_support_enabled(
-            self, settings_input, expected_output
-    ):
+    def test_mobile_support_enabled(self, settings_input, expected_output):
         """
         The mobile support is expected to be enabled only if:
           1) The settings.FEATURES['ENABLE_ORA_MOBILE_SUPPORT'] value is True.
@@ -124,8 +104,7 @@ class ConfigMixinTest(TestCase):
             self.assertEqual(expected_output, my_block.is_mobile_support_enabled)
 
     def _run_feature_toggle_test(
-            self, flag_name, waffle_switch_input, waffle_flag_input, settings_input,
-            mock_waffle_flag, mock_waffle_switch, feature_property
+        self, flag_name, waffle_switch_input, waffle_flag_input, settings_input, feature_property
     ):
         """
         Any feature name is expected to be enabled if at least one of the following conditions holds:
@@ -139,15 +118,17 @@ class ConfigMixinTest(TestCase):
             expected_output = False
 
         my_block = MockBlock()
-
-        # pylint: disable=invalid-name
-        MockWaffleSwitch, MockCourseWaffleFlag = self._setup_waffle_switch_and_flag(
-            mock_waffle_switch, waffle_switch_input, mock_waffle_flag, waffle_flag_input
-        )
-
         settings_feature_key = FEATURE_TOGGLES_BY_FLAG_NAME[flag_name]
-        with self.settings(FEATURES={settings_feature_key: settings_input}):
-            self.assertEqual(expected_output, getattr(my_block, feature_property, None))
+
+        with mock.patch('openassessment.xblock.config_mixin.WaffleSwitch', autospec=True) as MockWaffleSwitch:
+            MockWaffleSwitch.return_value.is_enabled.return_value = waffle_switch_input
+            with mock.patch(
+                'openassessment.xblock.config_mixin.import_course_waffle_flag', autospec=True
+            ) as mock_course_waffle_flag:
+                MockCourseWaffleFlag = mock_course_waffle_flag.return_value
+                MockCourseWaffleFlag.return_value.is_enabled.return_value = waffle_flag_input
+                with self.settings(FEATURES={settings_feature_key: settings_input}):
+                    self.assertEqual(expected_output, getattr(my_block, feature_property, None))
 
         mock_flag_instance = MockCourseWaffleFlag.return_value
         mock_flag_instance.is_enabled.assert_called_once_with(my_block.location.course_key)
@@ -155,16 +136,3 @@ class ConfigMixinTest(TestCase):
         if not waffle_flag_input:
             mock_switch_instance = MockWaffleSwitch.return_value
             mock_switch_instance.is_enabled.assert_called_once_with()
-
-    def _setup_waffle_switch_and_flag(
-            self, mock_waffle_switch, switch_return_value, mock_waffle_flag, flag_return_value
-    ):
-        """
-        Configures and returns mocked WaffleSwitch and CourseWaffleFlag objects.
-        """
-        # pylint: disable=invalid-name
-        MockWaffleSwitch = mock_waffle_switch.return_value
-        MockWaffleSwitch.return_value.is_enabled.return_value = switch_return_value
-        MockCourseWaffleFlag = mock_waffle_flag.return_value
-        MockCourseWaffleFlag.return_value.is_enabled.return_value = flag_return_value
-        return MockWaffleSwitch, MockCourseWaffleFlag

--- a/openassessment/xblock/test/test_studio.py
+++ b/openassessment/xblock/test/test_studio.py
@@ -111,19 +111,14 @@ class StudioViewTest(XBlockHandlerTestCase):
     @classmethod
     def setUpClass(cls):
         super(StudioViewTest, cls).setUpClass()
-        cls.waffle_switch_patcher = patch(
-            'openassessment.xblock.config_mixin.import_waffle_switch'
-        )
         cls.waffle_course_flag_patcher = patch(
             'openassessment.xblock.config_mixin.import_course_waffle_flag'
         )
-        cls.waffle_switch_patcher.start()
         cls.waffle_course_flag_patcher.start()
 
     @classmethod
     def tearDownClass(cls):
         super(StudioViewTest, cls).tearDownClass()
-        cls.waffle_switch_patcher.stop()
         cls.waffle_course_flag_patcher.stop()
 
     @scenario('data/basic_scenario.xml')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.11.6",
+  "version": "2.12.0",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.2.0",

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,6 +4,7 @@
 # edX Internal Requirements
 edx-i18n-tools
 edx-submissions
+edx-toggles
 djangorestframework
 Xblock
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,6 +4,7 @@
 # edX Internal Requirements
 edx-i18n-tools
 edx-submissions
+edx-django-utils
 edx-toggles
 djangorestframework
 Xblock

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,45 +10,55 @@ boto3==1.16.19            # via -r requirements/base.in
 botocore==1.19.19         # via boto3, s3transfer
 certifi==2020.11.8        # via requests
 chardet==3.0.4            # via requests
+click==7.1.2              # via code-annotations
+code-annotations==0.10.0  # via edx-toggles
 defusedxml==0.6.0         # via -r requirements/base.in
+django-crum==0.7.8        # via edx-django-utils, edx-toggles
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-submissions
 django-simple-history==2.12.0  # via -r requirements/base.in
-django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, edx-i18n-tools, edx-submissions, jsonfield2
+django-waffle==2.0.0      # via edx-django-utils, edx-toggles
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, code-annotations, django-crum, django-model-utils, edx-django-utils, edx-i18n-tools, edx-submissions, edx-toggles, jsonfield2
 djangorestframework==3.9.4  # via -r requirements/base.in, edx-submissions
+edx-django-utils==3.11.0  # via edx-toggles
 edx-i18n-tools==0.5.3     # via -r requirements/base.in
 edx-submissions==3.2.2    # via -r requirements/base.in
+edx-toggles==1.2.0        # via -r requirements/base.in
 fs==2.0.18                # via -c requirements/constraints.txt, xblock
 html5lib==1.1             # via -r requirements/base.in
 idna==2.8                 # via -c requirements/constraints.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, path
+jinja2==2.11.2            # via code-annotations
 jmespath==0.10.0          # via boto3, botocore
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in, edx-submissions
 lazy==1.4                 # via -r requirements/base.in
 libsass==0.20.1           # via -r requirements/base.in
 loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements/base.in
 lxml==4.6.1               # via -r requirements/base.in, xblock
-markupsafe==1.1.1         # via xblock
-more-itertools==8.6.0     # via zipp
+markupsafe==1.1.1         # via jinja2, xblock
+newrelic==5.22.1.152      # via edx-django-utils
 packaging==20.4           # via bleach
 path.py==12.5.0           # via -r requirements/base.in, edx-i18n-tools
 path==13.1.0              # via -c requirements/constraints.txt, path.py
+pbr==5.5.1                # via stevedore
 polib==1.1.0              # via edx-i18n-tools
+psutil==5.7.3             # via edx-django-utils
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/base.in, botocore, xblock
+python-slugify==4.0.1     # via code-annotations
 python-swiftclient==3.10.1  # via -c requirements/constraints.txt, -r requirements/base.in
 pytz==2020.4              # via -r requirements/base.in, django, edx-submissions, fs, xblock
-pyyaml==5.3.1             # via edx-i18n-tools, xblock
+pyyaml==5.3.1             # via code-annotations, edx-i18n-tools, xblock
 requests==2.25.0          # via python-swiftclient
 s3transfer==0.3.3         # via boto3
 six==1.15.0               # via bleach, django-simple-history, edx-i18n-tools, fs, html5lib, libsass, packaging, python-dateutil, python-swiftclient, xblock
 sqlparse==0.4.1           # via django
+stevedore==1.32.0          # via code-annotations, edx-django-utils
+text-unidecode==1.3       # via python-slugify
 urllib3==1.26.2           # via botocore, requests
 voluptuous==0.12.0        # via -c requirements/constraints.txt, -r requirements/base.in
 web-fragments==0.3.2      # via xblock
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.6              # via xblock
 xblock==1.4.0             # via -r requirements/base.in
-zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ django-simple-history==2.12.0  # via -r requirements/base.in
 django-waffle==2.0.0      # via edx-django-utils, edx-toggles
 django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, code-annotations, django-crum, django-model-utils, edx-django-utils, edx-i18n-tools, edx-submissions, edx-toggles, jsonfield2
 djangorestframework==3.9.4  # via -r requirements/base.in, edx-submissions
-edx-django-utils==3.11.0  # via edx-toggles
+edx-django-utils==3.11.0  # via -r requirements/base.in, edx-toggles
 edx-i18n-tools==0.5.3     # via -r requirements/base.in
 edx-submissions==3.2.2    # via -r requirements/base.in
 edx-toggles==1.2.0        # via -r requirements/base.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -19,23 +19,28 @@ cffi==1.14.3              # via -r requirements/test.txt, cryptography
 cfn-lint==0.40.0          # via -r requirements/test.txt, moto
 chardet==3.0.4            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via edx-lint
-click==7.1.2              # via click-log, edx-lint
+click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
+code-annotations==0.10.0  # via -r requirements/test.txt, edx-toggles
 coverage==5.3             # via -r requirements/test.txt, pytest-cov
 cryptography==3.2.1       # via -r requirements/test.txt, moto, sshpubkeys
 ddt==1.0.0                # via -c requirements/constraints.txt, -r requirements/test.txt
 decorator==4.4.2          # via -r requirements/test.txt, networkx
 defusedxml==0.6.0         # via -r requirements/test.txt
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
+django-crum==0.7.8        # via -r requirements/test.txt, edx-django-utils, edx-toggles
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-submissions
 django-pyfs==2.2          # via -r requirements/test.txt
 django-simple-history==2.12.0  # via -r requirements/test.txt
-django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, django-pyfs, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
+django-waffle==2.0.0      # via -r requirements/test.txt, edx-django-utils, edx-toggles
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-crum, django-model-utils, django-pyfs, edx-django-utils, edx-i18n-tools, edx-submissions, edx-toggles, jsonfield2, xblock-sdk
 djangorestframework==3.9.4  # via -r requirements/test.txt, edx-submissions
 docker==4.3.1             # via -r requirements/test.txt, moto
 ecdsa==0.14.1             # via -r requirements/test.txt, python-jose, sshpubkeys
+edx-django-utils==3.11.0  # via -r requirements/test.txt, edx-toggles
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-lint==1.5.2           # via -r requirements/quality.in
 edx-submissions==3.2.2    # via -r requirements/test.txt
+edx-toggles==1.2.0        # via -r requirements/test.txt
 factory-boy==3.1.0        # via -r requirements/test.txt
 faker==4.15.0             # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
@@ -45,10 +50,9 @@ fs==2.0.18                # via -c requirements/constraints.txt, -r requirements
 future==0.18.2            # via -r requirements/test.txt, aws-xray-sdk
 html5lib==1.1             # via -r requirements/test.txt
 idna==2.8                 # via -c requirements/constraints.txt, -r requirements/test.txt, moto, requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-resources, jsonpickle, jsonschema, path, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/test.txt, cfn-lint, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, jsonpickle
 isort==4.3.21             # via pylint
-jinja2==2.11.2            # via -r requirements/test.txt, moto
+jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, moto
 jmespath==0.10.0          # via -r requirements/test.txt, boto3, botocore
 jsondiff==1.1.2           # via -r requirements/test.txt, moto
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-submissions
@@ -68,12 +72,14 @@ mock==3.0.5               # via -c requirements/constraints.txt, -r requirements
 more-itertools==8.6.0     # via -r requirements/test.txt, pytest, zipp
 moto==1.3.14              # via -c requirements/constraints.txt, -r requirements/test.txt
 networkx==2.4             # via -c requirements/constraints.txt, -r requirements/test.txt, cfn-lint
+newrelic==5.22.1.152      # via -r requirements/test.txt, edx-django-utils
 packaging==20.4           # via -r requirements/test.txt, bleach, tox
 path.py==12.5.0           # via -r requirements/test.txt, edx-i18n-tools
 path==13.1.0              # via -c requirements/constraints.txt, -r requirements/test.txt, path.py
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+pbr==5.5.1                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
+psutil==5.7.3             # via -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
 pyasn1==0.4.8             # via -r requirements/test.txt, python-jose, rsa
 pycodestyle==2.6.0        # via -r requirements/quality.in
@@ -89,21 +95,22 @@ pytest-django==3.7.0      # via -c requirements/constraints.txt, -r requirements
 pytest==4.5.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/test.txt, botocore, faker, freezegun, moto, xblock
 python-jose==3.2.0        # via -r requirements/test.txt, moto
+python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python-swiftclient==3.10.1  # via -c requirements/constraints.txt, -r requirements/test.txt
 pytz==2020.4              # via -r requirements/test.txt, django, edx-submissions, fs, moto, xblock
-pyyaml==5.3.1             # via -r requirements/test.txt, cfn-lint, edx-i18n-tools, moto, xblock
+pyyaml==5.3.1             # via -r requirements/test.txt, cfn-lint, code-annotations, edx-i18n-tools, moto, xblock
 requests==2.25.0          # via -r requirements/test.txt, docker, moto, python-swiftclient, responses
 responses==0.12.1         # via -r requirements/test.txt, moto
 rsa==4.6                  # via -r requirements/test.txt, python-jose
 s3transfer==0.3.3         # via -r requirements/test.txt, boto3
-six==1.15.0               # via -r requirements/test.txt, astroid, aws-sam-translator, bleach, cfn-lint, cryptography, django-simple-history, docker, ecdsa, edx-i18n-tools, edx-lint, freezegun, fs, fs-s3fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pathlib2, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
+six==1.15.0               # via -r requirements/test.txt, astroid, aws-sam-translator, bleach, cfn-lint, cryptography, django-simple-history, docker, ecdsa, edx-i18n-tools, edx-lint, freezegun, fs, fs-s3fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
 sqlparse==0.4.1           # via -r requirements/test.txt, django
 sshpubkeys==3.1.0         # via -r requirements/test.txt, moto
+stevedore==1.32.0          # via -r requirements/test.txt, code-annotations, edx-django-utils
 testfixtures==6.15.0      # via -r requirements/test.txt
-text-unidecode==1.3       # via -r requirements/test.txt, faker
+text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.2              # via -r requirements/test.txt, tox
 tox==3.20.1               # via -r requirements/test.txt
-typed-ast==1.4.1          # via astroid
 urllib3==1.26.2           # via -r requirements/test.txt, botocore, requests, responses
 virtualenv==20.1.0        # via -r requirements/test.txt, tox
 voluptuous==0.12.0        # via -c requirements/constraints.txt, -r requirements/test.txt
@@ -117,7 +124,7 @@ wrapt==1.11.2             # via -c requirements/constraints.txt, -r requirements
 xblock-sdk==0.2.2         # via -r requirements/test.txt
 xblock==1.4.0             # via -r requirements/test.txt
 xmltodict==0.12.0         # via -r requirements/test.txt, moto
-zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -18,21 +18,27 @@ certifi==2020.11.8        # via -r requirements/test.txt, requests
 cffi==1.14.3              # via -r requirements/test.txt, cryptography
 cfn-lint==0.40.0          # via -r requirements/test.txt, moto
 chardet==3.0.4            # via -r requirements/test.txt, requests
+click==7.1.2              # via -r requirements/test.txt, code-annotations
+code-annotations==0.10.0  # via -r requirements/test.txt, edx-toggles
 coverage==5.3             # via -r requirements/test.txt, pytest-cov
 cryptography==3.2.1       # via -r requirements/test.txt, moto, sshpubkeys
 ddt==1.0.0                # via -c requirements/constraints.txt, -r requirements/test-acceptance.in, -r requirements/test.txt
 decorator==4.4.2          # via -r requirements/test.txt, networkx
 defusedxml==0.6.0         # via -r requirements/test.txt
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
+django-crum==0.7.8        # via -r requirements/test.txt, edx-django-utils, edx-toggles
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-submissions
 django-pyfs==2.2          # via -r requirements/test.txt
 django-simple-history==2.12.0  # via -r requirements/test.txt
-django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, django-pyfs, edx-i18n-tools, edx-submissions, jsonfield2, xblock-sdk
+django-waffle==2.0.0      # via -r requirements/test.txt, edx-django-utils, edx-toggles
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-crum, django-model-utils, django-pyfs, edx-django-utils, edx-i18n-tools, edx-submissions, edx-toggles, jsonfield2, xblock-sdk
 djangorestframework==3.9.4  # via -r requirements/test.txt, edx-submissions
 docker==4.3.1             # via -r requirements/test.txt, moto
 ecdsa==0.14.1             # via -r requirements/test.txt, python-jose, sshpubkeys
+edx-django-utils==3.11.0  # via -r requirements/test.txt, edx-toggles
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-submissions==3.2.2    # via -r requirements/test.txt
+edx-toggles==1.2.0        # via -r requirements/test.txt
 factory-boy==3.1.0        # via -r requirements/test.txt
 faker==4.15.0             # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
@@ -42,9 +48,8 @@ fs==2.0.18                # via -c requirements/constraints.txt, -r requirements
 future==0.18.2            # via -r requirements/test.txt, aws-xray-sdk
 html5lib==1.1             # via -r requirements/test.txt
 idna==2.8                 # via -c requirements/constraints.txt, -r requirements/test.txt, moto, requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-resources, jsonpickle, jsonschema, path, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/test.txt, cfn-lint, virtualenv
-jinja2==2.11.2            # via -r requirements/test.txt, moto
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, jsonpickle
+jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, moto
 jmespath==0.10.0          # via -r requirements/test.txt, boto3, botocore
 jsondiff==1.1.2           # via -r requirements/test.txt, moto
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-submissions
@@ -62,12 +67,14 @@ mock==3.0.5               # via -c requirements/constraints.txt, -r requirements
 more-itertools==8.6.0     # via -r requirements/test.txt, pytest, zipp
 moto==1.3.14              # via -c requirements/constraints.txt, -r requirements/test.txt
 networkx==2.4             # via -c requirements/constraints.txt, -r requirements/test.txt, cfn-lint
+newrelic==5.22.1.152      # via -r requirements/test.txt, edx-django-utils
 packaging==20.4           # via -r requirements/test.txt, bleach, tox
 path.py==12.5.0           # via -r requirements/test.txt, edx-i18n-tools
 path==13.1.0              # via -c requirements/constraints.txt, -r requirements/test.txt, path.py
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+pbr==5.5.1                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
+psutil==5.7.3             # via -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
 pyasn1==0.4.8             # via -r requirements/test.txt, python-jose, rsa
 pycparser==2.20           # via -r requirements/test.txt, cffi
@@ -80,19 +87,21 @@ pytest-django==3.7.0      # via -c requirements/constraints.txt, -r requirements
 pytest==4.5.0             # via -c requirements/constraints.txt, -r requirements/test-acceptance.in, -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/test.txt, botocore, faker, freezegun, moto, xblock
 python-jose==3.2.0        # via -r requirements/test.txt, moto
+python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python-swiftclient==3.10.1  # via -c requirements/constraints.txt, -r requirements/test.txt
 pytz==2020.4              # via -r requirements/test.txt, django, edx-submissions, fs, moto, xblock
-pyyaml==5.3.1             # via -r requirements/test.txt, cfn-lint, edx-i18n-tools, moto, xblock
+pyyaml==5.3.1             # via -r requirements/test.txt, cfn-lint, code-annotations, edx-i18n-tools, moto, xblock
 requests==2.25.0          # via -r requirements/test.txt, docker, moto, python-swiftclient, responses
 responses==0.12.1         # via -r requirements/test.txt, moto
 rsa==4.6                  # via -r requirements/test.txt, python-jose
 s3transfer==0.3.3         # via -r requirements/test.txt, boto3
 selenium==3.141.0         # via -r requirements/test-acceptance.in, bok-choy
-six==1.15.0               # via -r requirements/test.txt, aws-sam-translator, bleach, bok-choy, cfn-lint, cryptography, django-simple-history, docker, ecdsa, edx-i18n-tools, freezegun, fs, fs-s3fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pathlib2, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
+six==1.15.0               # via -r requirements/test.txt, aws-sam-translator, bleach, bok-choy, cfn-lint, cryptography, django-simple-history, docker, ecdsa, edx-i18n-tools, freezegun, fs, fs-s3fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
 sqlparse==0.4.1           # via -r requirements/test.txt, django
 sshpubkeys==3.1.0         # via -r requirements/test.txt, moto
+stevedore==1.32.0          # via -r requirements/test.txt, code-annotations, edx-django-utils
 testfixtures==6.15.0      # via -r requirements/test.txt
-text-unidecode==1.3       # via -r requirements/test.txt, faker
+text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.2              # via -r requirements/test.txt, tox
 tox==3.20.1               # via -r requirements/test.txt
 urllib3==1.26.2           # via -r requirements/test.txt, botocore, requests, responses, selenium
@@ -108,7 +117,7 @@ wrapt==1.11.2             # via -c requirements/constraints.txt, -r requirements
 xblock-sdk==0.2.2         # via -r requirements/test.txt
 xblock==1.4.0             # via -r requirements/test.txt
 xmltodict==0.12.0         # via -r requirements/test.txt, moto
-zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,19 +17,25 @@ certifi==2020.11.8        # via -r requirements/base.txt, requests
 cffi==1.14.3              # via cryptography
 cfn-lint==0.40.0          # via moto
 chardet==3.0.4            # via -r requirements/base.txt, requests
+click==7.1.2              # via -r requirements/base.txt, code-annotations
+code-annotations==0.10.0  # via -r requirements/base.txt, edx-toggles
 coverage==5.3             # via -r requirements/test.in, pytest-cov
 cryptography==3.2.1       # via moto, sshpubkeys
 ddt==1.0.0                # via -c requirements/constraints.txt, -r requirements/test.in
 decorator==4.4.2          # via networkx
 defusedxml==0.6.0         # via -r requirements/base.txt
 distlib==0.3.1            # via virtualenv
+django-crum==0.7.8        # via -r requirements/base.txt, edx-django-utils, edx-toggles
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-submissions
 django-pyfs==2.2          # via -r requirements/test.in
 django-simple-history==2.12.0  # via -r requirements/base.txt
+django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-toggles
 docker==4.3.1             # via moto
 ecdsa==0.14.1             # via python-jose, sshpubkeys
+edx-django-utils==3.11.0  # via -r requirements/base.txt, edx-toggles
 edx-i18n-tools==0.5.3     # via -r requirements/base.txt
 edx-submissions==3.2.2    # via -r requirements/base.txt
+edx-toggles==1.2.0        # via -r requirements/base.txt
 factory-boy==3.1.0        # via -r requirements/test.in
 faker==4.15.0             # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
@@ -39,9 +45,8 @@ fs==2.0.18                # via -c requirements/constraints.txt, -r requirements
 future==0.18.2            # via aws-xray-sdk
 html5lib==1.1             # via -r requirements/base.txt
 idna==2.8                 # via -c requirements/constraints.txt, -r requirements/base.txt, moto, requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-resources, jsonpickle, jsonschema, path, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via cfn-lint, virtualenv
-jinja2==2.11.2            # via moto
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, jsonpickle
+jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, moto
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 jsondiff==1.1.2           # via moto
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-submissions
@@ -56,15 +61,17 @@ loremipsum==1.0.5         # via -c requirements/constraints.txt, -r requirements
 lxml==4.6.1               # via -r requirements/base.txt, xblock
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2, xblock
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in, moto
-more-itertools==8.6.0     # via -r requirements/base.txt, -r requirements/test.in, pytest, zipp
+more-itertools==8.6.0     # via -r requirements/test.in, pytest
 moto==1.3.14              # via -c requirements/constraints.txt, -r requirements/test.in
 networkx==2.4             # via -c requirements/constraints.txt, cfn-lint
+newrelic==5.22.1.152      # via -r requirements/base.txt, edx-django-utils
 packaging==20.4           # via -r requirements/base.txt, bleach, tox
 path.py==12.5.0           # via -r requirements/base.txt, edx-i18n-tools
 path==13.1.0              # via -c requirements/constraints.txt, -r requirements/base.txt, path.py
-pathlib2==2.3.5           # via pytest
+pbr==5.5.1                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest, tox
 polib==1.1.0              # via -r requirements/base.txt, edx-i18n-tools
+psutil==5.7.3             # via -r requirements/base.txt, edx-django-utils
 py==1.9.0                 # via pytest, tox
 pyasn1==0.4.8             # via python-jose, rsa
 pycparser==2.20           # via cffi
@@ -75,18 +82,20 @@ pytest-django==3.7.0      # via -c requirements/constraints.txt, -r requirements
 pytest==4.5.0             # via -c requirements/constraints.txt, -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.4.0    # via -c requirements/constraints.txt, -r requirements/base.txt, botocore, faker, freezegun, moto, xblock
 python-jose==3.2.0        # via moto
+python-slugify==4.0.1     # via -r requirements/base.txt, code-annotations
 python-swiftclient==3.10.1  # via -c requirements/constraints.txt, -r requirements/base.txt
 pytz==2020.4              # via -r requirements/base.txt, django, edx-submissions, fs, moto, xblock
-pyyaml==5.3.1             # via -r requirements/base.txt, cfn-lint, edx-i18n-tools, moto, xblock
+pyyaml==5.3.1             # via -r requirements/base.txt, cfn-lint, code-annotations, edx-i18n-tools, moto, xblock
 requests==2.25.0          # via -r requirements/base.txt, docker, moto, python-swiftclient, responses
 responses==0.12.1         # via moto
 rsa==4.6                  # via python-jose
 s3transfer==0.3.3         # via -r requirements/base.txt, boto3
-six==1.15.0               # via -r requirements/base.txt, aws-sam-translator, bleach, cfn-lint, cryptography, django-simple-history, docker, ecdsa, edx-i18n-tools, freezegun, fs, fs-s3fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pathlib2, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
+six==1.15.0               # via -r requirements/base.txt, aws-sam-translator, bleach, cfn-lint, cryptography, django-simple-history, docker, ecdsa, edx-i18n-tools, freezegun, fs, fs-s3fs, html5lib, jsonschema, junit-xml, libsass, mock, moto, packaging, pytest, python-dateutil, python-jose, python-swiftclient, responses, tox, virtualenv, websocket-client, xblock
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 sshpubkeys==3.1.0         # via moto
+stevedore==1.32.0          # via -r requirements/base.txt, code-annotations, edx-django-utils
 testfixtures==6.15.0      # via -r requirements/test.in
-text-unidecode==1.3       # via faker
+text-unidecode==1.3       # via -r requirements/base.txt, faker, python-slugify
 toml==0.10.2              # via tox
 tox==3.20.1               # via -r requirements/test.in
 urllib3==1.26.2           # via -r requirements/base.txt, botocore, requests, responses
@@ -102,7 +111,7 @@ wrapt==1.11.2             # via -c requirements/constraints.txt, aws-xray-sdk
 xblock-sdk==0.2.2         # via -r requirements/test.in
 xblock==1.4.0             # via -r requirements/base.txt
 xmltodict==0.12.0         # via moto
-zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -7,9 +7,6 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
-importlib-resources==3.2.1  # via virtualenv
-more-itertools==8.6.0     # via zipp
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
@@ -18,4 +15,3 @@ six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.2              # via tox
 tox==3.20.1               # via -r requirements/tox.in
 virtualenv==20.1.0        # via tox
-zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -13,9 +13,6 @@ distlib==0.3.1            # via -r requirements/tox.txt, virtualenv
 docopt==0.6.2             # via coveralls
 filelock==3.0.12          # via -r requirements/tox.txt, tox, virtualenv
 idna==2.8                 # via -c requirements/constraints.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/tox.txt, pluggy, tox, virtualenv
-importlib-resources==3.2.1  # via -r requirements/tox.txt, virtualenv
-more-itertools==8.6.0     # via -r requirements/tox.txt, zipp
 packaging==20.4           # via -r requirements/tox.txt, tox
 pluggy==0.13.1            # via -r requirements/tox.txt, tox
 py==1.9.0                 # via -r requirements/tox.txt, tox
@@ -26,4 +23,3 @@ toml==0.10.2              # via -r requirements/tox.txt, tox
 tox==3.20.1               # via -r requirements/tox.txt
 urllib3==1.26.2           # via requests
 virtualenv==20.1.0        # via -r requirements/tox.txt, tox
-zipp==1.0.0               # via -c requirements/constraints.txt, -r requirements/tox.txt, importlib-metadata, importlib-resources

--- a/settings/base.py
+++ b/settings/base.py
@@ -111,6 +111,8 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.admindocs',
 
+    # Waffle flag/switches
+    'waffle',
 
     # XBlock
     'workbench',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.11.6',
+    version='2.12.0',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** Stop the `from waffle_utils import WaffleSwitch` shenanigans.

**What changed?**

- WaffleSwitch is not imported from edx-platform's `waffle_utils` (which is deprecated), but from edx-toggles, which is thus added to the base requirements. Note that CourseWaffleFlag objects remain in edx-platform.
- Unit tests were refactored to take this into account.

This will be ready for review once edx-toggles==1.2.0 is released: https://github.com/edx/edx-toggles/pull/81 

**Developer Checklist**

**Before Merge**
- [x] Ensure edx-toggles 1.2.0 is released and tests are passing.
  - [x] Ensure 1.2.0 custom attributes show that no deprecated methods are still in use from WaffleSwitch.
- [x] Reviewed the [release process](./release_process.md)
~~- [ ] Translations up to date~~
~~- [ ] JS minified, SASS compiled~~
- [x] Test suites passing on Jenkins
- [x] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

**Post Merge**
- [ ] Release new version.

JIRA: [JIRA-BD-21](https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943/BD-21+Toggles+Settings+Documentation)

FIY: @edx/masters-devs-gta @robrap 
