### PR TITLE
[BB-3269] [BTR-48] Fix writing binary files like images/pdf

### DIFF
--- a/openassessment/fileupload/backends/filesystem.py
+++ b/openassessment/fileupload/backends/filesystem.py
@@ -44,7 +44,7 @@ class Backend(BaseBackend):
 
     def get_download_url(self, key):
         key_name = self._get_key_name(key)
-        if self._is_file_existing(key_name):
+        if self._file_exists(key_name):
             make_download_url_available(key_name, self.DOWNLOAD_URL_TIMEOUT)
             return self._get_url(key)
         return None
@@ -58,7 +58,7 @@ class Backend(BaseBackend):
         url = reverse("openassessment-filesystem-storage", kwargs={'key': key_name})
         return url
 
-    def _is_file_existing(self, key_name):
+    def _file_exists(self, key_name):
         from openassessment.fileupload.views_filesystem import get_file_path
 
         file_path = get_file_path(key_name)

--- a/openassessment/fileupload/tests/test_api.py
+++ b/openassessment/fileupload/tests/test_api.py
@@ -248,12 +248,12 @@ class TestFileUploadServiceWithFilesystemBackend(TestCase):
 
     def test_upload_download(self):
         upload_url = self.backend.get_upload_url(self.key, self.content_type)
-        download_url = self.backend.get_download_url(self.key)
         file_path = views.get_file_path(self.key_name)
 
         upload_response = self.client.put(
             upload_url, data=self.content.read(), content_type=self.content_type
         )
+        download_url = self.backend.get_download_url(self.key)
         download_response = self.client.get(download_url)
         self.content.seek(0)
 
@@ -305,11 +305,11 @@ class TestFileUploadServiceWithFilesystemBackend(TestCase):
     def test_upload_download_with_accented_key(self):
         self.set_key(u"noël.jpg")
         upload_url = self.backend.get_upload_url(self.key, self.content_type)
-        download_url = self.backend.get_download_url(self.key)
 
         upload_response = self.client.put(
             upload_url, data=self.content.read(), content_type=self.content_type
         )
+        download_url = self.backend.get_download_url(self.key)
         download_response = self.client.get(download_url)
 
         self.assertEqual(200, upload_response.status_code)

--- a/openassessment/fileupload/views_filesystem.py
+++ b/openassessment/fileupload/views_filesystem.py
@@ -43,7 +43,7 @@ def download_file(key):
     with open(metadata_path) as f:
         metadata = json.load(f)
         content_type = metadata.get("Content-Type", 'application/octet-stream')
-    with open(file_path, 'r') as f:
+    with open(file_path, 'rb') as f:
         response = HttpResponse(f.read(), content_type=content_type)
 
     file_name = os.path.basename(os.path.dirname(file_path))
@@ -111,8 +111,11 @@ def safe_save(path, content):
         raise exceptions.FileUploadInternalError(u"File upload root directory does not exist: %s" % root_directory)
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
-    with open(path, 'w') as f:
-        f.write(content.decode('utf-8') if isinstance(content, bytes) else content)
+    mode = "w"
+    if isinstance(content, bytes):
+        mode = "wb"
+    with open(path, mode) as f:
+        f.write(content)
 
 
 def safe_remove(path):


### PR DESCRIPTION
This commits helps to fix filesystem backend to write binary files.
The file operation mode was set to just "w" which was causing the issue.
The way we send data now is all binary with the write files attached.

**JIRA tickets**: [BTR-48](https://openedx.atlassian.net/browse/BTR-48)

~**Screenshots**:~

~**Sandbox URL**: TBD - sandbox is being provisioned (if needed).~

**Testing instructions**:

* Get the master devstack running
* Clone this repo in devstack_root/src and activate the `edxapp` venv by `source /edx/app/edxapp/venvs/edxapp/bin/activate`
* Uninstall ora2, `pip uninstall ora2`, `cd /edx/src/edx-ora2/` and do a `pip install -e .`
* Sign in to studio
* In the demo course add a unit
* Add open assessment block to it by `Problem--> Advance --> Open Response Assessment`
* In ORA click on the `Edit --> Settings --> File Uploads Response` and change it to `Required`
* Also mark `Multiple File Upload` to true and save the settings
* Drop in your studio shell using `make dev.shell.studio`
* Open the studio.yml file `vim /edx/etc/studio.yml`
* Add  
```
ORA2_FILE_PREFIX: default_env-default_deployment/ora2
ORA2_FILEUPLOAD_CACHE_NAME: 'default'
ORA2_FILEUPLOAD_ROOT: '/edx/var/ora2/'
ORA2_FILEUPLOAD_BACKEND: 'filesystem'
```
* Now `make studio-restart`
* Try uploading a picture(png/jpg) in the studio and it will fail, giving you a Unicodeerror.
* if you refresh it will show the broken URL in the list as well.
* Now checkout to this branch and do the same after restarting the server, you will see the error is gone. You shouldn't be 
able to see the broken URL as well.


**Author notes and concerns**:

The same issues was also dropping in when reading from the file, as in when we were trying to download a file,
hence this fixes that as well.

**Reviewers**
- [ ] @0x29a 