### PR TITLE
[BD-05] [TNL-7576] [BB-2991] Embeddable endpoint for instructor dashboard

### DIFF
--- a/openassessment/xblock/embed_mixin.py
+++ b/openassessment/xblock/embed_mixin.py
@@ -3,7 +3,6 @@ The Embed Mixin renders views that might be embedded by other services like MFE.
 """
 
 
-import json
 import six
 
 from django.urls import reverse
@@ -41,6 +40,7 @@ class EmbedMixin:
 
         # webob request doesn't have META which is request for
         # is_mobile_app and is_learning_mfe utility functions
+        # pylint: disable=protected-access
         django_request = request._request
 
         render_context = {

--- a/openassessment/xblock/embed_mixin.py
+++ b/openassessment/xblock/embed_mixin.py
@@ -1,0 +1,113 @@
+"""
+The Embed Mixin renders views that might be embedded by other services like MFE.
+"""
+
+
+import json
+import six
+
+from django.urls import reverse
+from django.conf import settings
+from django.utils.translation import ugettext as _
+from webob import Response
+from xblock.core import XBlock
+from openassessment.xblock.staff_area_mixin import require_course_staff
+
+
+class EmbedMixin:
+    """
+    Implements instructor dashboard as standalone view and other
+    utility methods to achieve that.
+    """
+
+    def _get_course(self):
+        """
+        Get course instance
+        """
+        from lms.djangoapps.courseware.courses import get_course_by_id
+        return get_course_by_id(self.location.course_key)
+
+    def _standalone_render(self, request, fragment, context=None):
+        """
+        Given a fragment return standalone response.
+        """
+        from common.djangoapps.edxmako.shortcuts import render_to_string
+        from lms.djangoapps.course_home_api.utils import is_request_from_learning_mfe
+        from openedx.core.lib.mobile_utils import is_request_from_mobile_app
+
+        course = self._get_course()
+
+        template = 'courseware/courseware-chromeless.html'
+
+        # webob request doesn't have META which is request for
+        # is_mobile_app and is_learning_mfe utility functions
+        django_request = request._request
+
+        render_context = {
+            'fragment': fragment,
+            'disable_accordion': True,
+            'allow_iframing': True,
+            'disable_header': True,
+            'disable_footer': True,
+            'disable_window_wrap': True,
+            'course': course,
+            'on_courseware_page': True,
+            'is_learning_mfe': is_request_from_learning_mfe(django_request),
+            'is_mobile_app': is_request_from_mobile_app(django_request),
+        }
+
+        # allow overriding render context
+        if context:
+            render_context.update(context)
+
+        return Response(render_to_string(template, render_context), content_type='text/html', charset='UTF-8')
+
+    @XBlock.handler
+    @require_course_staff('STAFF_AREA')
+    def embed_instructor_dashboard(self, request, suffix=''):  # pylint: disable=unused-argument
+        """
+        Standalone instructor dashboard.
+        """
+        from xmodule.modulestore.django import modulestore
+
+        course = self._get_course()
+
+        # find all open assessment blocks under the course
+        openassessment_blocks = modulestore().get_items(
+            self.location.course_key, qualifiers={'category': 'openassessment'}
+        )
+
+        # filter out orphaned openassessment blocks
+        openassessment_blocks = [
+            block for block in openassessment_blocks if block.parent is not None
+        ]
+
+        ora_items = []
+        parents = {}
+
+        for block in openassessment_blocks:
+            block_parent_id = six.text_type(block.parent)
+            result_item_id = six.text_type(block.location)
+            if block_parent_id not in parents:
+                parents[block_parent_id] = modulestore().get_item(block.parent)
+            assessment_name = _("Team") + " : " + block.display_name if block.teams_enabled else block.display_name
+            ora_items.append({
+                'id': result_item_id,
+                'name': assessment_name,
+                'parent_id': block_parent_id,
+                'parent_name': parents[block_parent_id].display_name,
+                'staff_assessment': 'staff-assessment' in block.assessment_steps,
+                'url_base': reverse('xblock_view', args=[course.id, block.location, 'student_view']),
+                'url_grade_available_responses': reverse(
+                    'xblock_view',
+                    args=[course.id, block.location, 'grade_available_responses_view']
+                ),
+            })
+
+        # create listing view fragment
+        fragment = self.render('ora_blocks_listing_view', context={
+            'ora_items': ora_items,
+            'ora_item_view_enabled': settings.FEATURES.get('ENABLE_XBLOCK_VIEW_ENDPOINT', False)
+        })
+
+        return self._standalone_render(request, fragment)

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -23,6 +23,7 @@ from web_fragments.fragment import Fragment
 
 from openassessment.workflow.errors import AssessmentWorkflowError
 from openassessment.xblock.course_items_listing_mixin import CourseItemsListingMixin
+from openassessment.xblock.embed_mixin import EmbedMixin
 from openassessment.xblock.data_conversion import create_prompts_list, create_rubric_dict, update_assessments_format
 from openassessment.xblock.defaults import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from openassessment.xblock.grade_mixin import GradeMixin
@@ -113,6 +114,7 @@ class OpenAssessmentBlock(MessageMixin,
                           StudentTrainingMixin,
                           LmsCompatibilityMixin,
                           CourseItemsListingMixin,
+                          EmbedMixin,
                           ConfigMixin,
                           TeamMixin,
                           OpenAssessmentTemplatesMixin,


### PR DESCRIPTION
This PR introduces a new xblock handler which renders the Instructor dashboard in a standalone fashion. This will enable embedding instructor dashboard in MFE.

**JIRA tickets**: 
- https://tasks.opencraft.com/browse/BB-2991
- https://openedx.atlassian.net/browse/TNL-7576

**Discussions**: N/A

**Dependencies**: None

**Screenshots**: 
![Screenshot from 2020-12-09 01-13-56](https://user-images.githubusercontent.com/1010244/101530339-f9599f80-39bb-11eb-98dc-fa12d4f091c5.png)

![Screenshot from 2020-12-09 01-14-06](https://user-images.githubusercontent.com/1010244/101530350-fc549000-39bb-11eb-9aa3-5ee856865794.png)


**Sandbox URL**: TBD.

**Merge deadline**: None

**Testing instructions**:

1. Pull this PR into your local devstack src folder.
2. Install ``edx-ora2`` by running ``make install-local-ora`` from ``edx-ora2`` root directory.
3. Enable ORA from studio by adding ``openassessment`` in Advanced Module List if not already enabled.
4. Enable ``ENABLE_XBLOCK_VIEW_ENDPOINT`` feature flag in ``lms.yml``
5. Create a ORA block with Staff Grading enabled.
6. Create a submission with waiting for Staff Grading.
7. Go to ``http://localhost:18000/courses/<COURSE_KEY>/xblock/<USAGE_KEY>/handler/embed_instructor_dashboard``.
8. You should see a standalone Instructor Dashboard.
9. You can perform staff grading by clicking on the number on the ``Staff`` Column.
10. Check if this view has all the functionality from the Instructor dashboard.

**Author notes and concerns**:

1. The Listing View and Staff grading view seems to be tightly coupled. I couldn't make Staff Grading standalone without the Listing View.
2. I couldn't find any utility that converts Webob request to Django request. Due to that, I had to access the protected property ``_request`` as ``lms.djangoapps.course_home_api.utils.is_request_from_learning_mfe`` and ``openedx.core.lib.mobile_utils.is_request_from_mobile_app`` needs ``request.META`` to work. Should we add support for Webob request object on this utility functions?
3. I couldn't figure out how to write tests for these new methods I've implemented. All those require LMS/openedx module-specific functionality to work.

**Reviewers**
- [ ] @giovannicimolin 
- [ ] edX reviewer[s] TBD
