### PR TITLE
[BD-21] Fix missing `module_name` argument in CourseWaffleFlag constructor

### DIFF
--- a/openassessment/xblock/config_mixin.py
+++ b/openassessment/xblock/config_mixin.py
@@ -63,7 +63,8 @@ class ConfigMixin:
         with the given ``flag_name``.
         """
         CourseWaffleFlag = import_course_waffle_flag()  # pylint: disable=invalid-name
-        return CourseWaffleFlag(WAFFLE_NAMESPACE, flag_name)  # pylint: disable=feature-toggle-needs-doc
+        # pylint: disable=feature-toggle-needs-doc
+        return CourseWaffleFlag(WAFFLE_NAMESPACE, flag_name, module_name=__name__)
 
     @staticmethod
     def _settings_toggle_enabled(toggle_name):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.13.5",
+  "version": "2.13.6",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.2.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.13.5',
+    version='2.13.6',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** Get rid of a few warnings and become forward-compatible with edx-toggles==2.0.0.

**What changed?**

Add `module_name` argument to CourseWaffleFlag constructor. This argument is optional for now, but will soon become mandatory.

**Developer Checklist**
- [x] Reviewed the [release process](./release_process.md)
- [ ] ~~Translations up to date~~
- [ ] ~~JS minified, SASS compiled~~
- [ ] Test suites passing on Jenkins
- [x] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

JIRA: [Bd-21](https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943/BD-21+Toggles+Settings+Documentation)

FIY: @edx/masters-devs-gta

This is ready for review.

cc @robrap 