### PR TITLE
add analytics event for file deletion

### DIFF
--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -498,6 +498,12 @@ class SubmissionMixin:
         if self._can_delete_file(filenum):
             try:
                 self.file_manager.delete_upload(filenum)
+                # Emit analytics event...
+                self.runtime.publish(
+                    self,
+                    "openassessmentblock.remove_uploaded_file",
+                    {"student_item_key": student_item_key}
+                )
                 logger.debug("Deleted file {student_item_key}".format(student_item_key=student_item_key))
                 return {'success': True}
             except FileUploadError as exc:

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -339,6 +339,19 @@ class SubmissionTest(SubmissionXBlockHandlerTestCase):
             response_format='json'
         )
         self.assertTrue(resp['success'])
+
+        student_item_key = api.get_student_file_key(
+            xblock.get_student_item_dict(),
+            index=file_index_to_remove
+        )
+        self.assert_event_published(
+            xblock,
+            'openassessmentblock.remove_uploaded_file',
+            {
+                "student_item_key": student_item_key
+            }
+        )
+
         with patch('submissions.api.create_submission') as mocked_submit:
             with patch.object(WorkflowMixin, 'create_workflow'):
                 mocked_submit.return_value = {


### PR DESCRIPTION
**TL;DR -** We didn't have one, so add analytics event for file deletion

JIRA: [EDUCATOR-5498](https://openedx.atlassian.net/browse/EDUCATOR-5498)

**What changed?**

- Fire an event to the tracking logs for when a user deletes a file. Previously this was only viewable by looking for the server request event. This is much clearer and easier to track.

**Developer Checklist**

- [x] Reviewed the [release process](./release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

**Testing Instructions**

- Have the LMS logs open
- Delete a file
- You should see an entry in the logs that has the following shape:
            [timestamp] INFO X [tracking] [user X] [ip] - {
                   (not in this order)
                   "name": "openassessmentblock.remove_uploaded_file",
                   "event": {"student_item_key": <file key>}, 
                   "event_type": "openassessmentblock.remove_uploaded_file"
                   ...< LOTS OF OTHER STUFF > ...
               }

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
