### PR TITLE
[TSD] Add annotations for  ORA2_FILEUPLOAD_BACKEND

### DIFF
--- a/openassessment/fileupload/backends/__init__.py
+++ b/openassessment/fileupload/backends/__init__.py
@@ -7,7 +7,10 @@ from . import django_storage, filesystem, s3, swift
 
 
 def get_backend():
-    # Use S3 backend by default (current behaviour)
+    # .. setting_name: ORA2_FILEUPLOAD_BACKEND
+    # .. setting_default: s3
+    # .. setting_description: The backend used to upload the ora2 submissions attachments
+    #     the supported values are: s3, filesystem, swift and django.
     backend_setting = getattr(settings, "ORA2_FILEUPLOAD_BACKEND", "s3")
     if backend_setting == "s3":
         return s3.Backend()


### PR DESCRIPTION
**TL;DR -** Add annotations for ORA2_FILEUPLOAD_BACKEND django setting but does not affect behavior.

**What changed?**

Added annotations for ORA2_FILEUPLOAD_BACKEND django setting as part of the doc-a-thon event!

**Testing Instructions**

[ How should a reviewer test this PR? ]
You should review that the annotations follow the conventions of openedx 
https://openedx.atlassian.net/wiki/spaces/AC/pages/2248409171/Toggles+and+Settings+Doc-a-thon+2021#1.-Short-Background-Reading

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review


FYI: @edx/masters-devs-gta
