### PR TITLE
[BD-21] Upgrade usage of edx_toggles.toggles

### DIFF
--- a/openassessment/xblock/config_mixin.py
+++ b/openassessment/xblock/config_mixin.py
@@ -4,7 +4,7 @@ Mixin for determining configuration and feature-toggle state relevant to an ORA 
 
 
 from edx_django_utils.monitoring import set_custom_attribute
-from edx_toggles.toggles.__future__ import WaffleSwitch
+from edx_toggles.toggles import WaffleSwitch
 
 from django.conf import settings
 from django.utils.functional import cached_property

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "2.13.9",
+  "version": "3.0.2",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.6.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ djangorestframework==3.12.2  # via -r requirements/base.in, edx-submissions
 edx-django-utils==3.13.0  # via -r requirements/base.in, edx-toggles
 edx-i18n-tools==0.5.3     # via -r requirements/base.in
 edx-submissions==3.2.4    # via -r requirements/base.in
-edx-toggles==1.2.1        # via -r requirements/base.in
+edx-toggles==3.1.0        # via -r requirements/base.in
 fs==2.0.18                # via -c requirements/constraints.txt, xblock
 html5lib==1.1             # via -r requirements/base.in
 idna==2.8                 # via -c requirements/constraints.txt, requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -40,7 +40,7 @@ edx-django-utils==3.13.0  # via -r requirements/test.txt, edx-toggles
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-lint==1.6             # via -r requirements/quality.in
 edx-submissions==3.2.4    # via -r requirements/test.txt
-edx-toggles==1.2.1        # via -r requirements/test.txt
+edx-toggles==3.1.0        # via -r requirements/test.txt
 factory-boy==3.1.0        # via -r requirements/test.txt
 faker==5.0.2              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -38,7 +38,7 @@ ecdsa==0.14.1             # via -r requirements/test.txt, python-jose, sshpubkey
 edx-django-utils==3.13.0  # via -r requirements/test.txt, edx-toggles
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-submissions==3.2.4    # via -r requirements/test.txt
-edx-toggles==1.2.1        # via -r requirements/test.txt
+edx-toggles==3.1.0        # via -r requirements/test.txt
 factory-boy==3.1.0        # via -r requirements/test.txt
 faker==5.0.2              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -35,7 +35,7 @@ ecdsa==0.14.1             # via python-jose, sshpubkeys
 edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-toggles
 edx-i18n-tools==0.5.3     # via -r requirements/base.txt
 edx-submissions==3.2.4    # via -r requirements/base.txt
-edx-toggles==1.2.1        # via -r requirements/base.txt
+edx-toggles==3.1.0        # via -r requirements/base.txt
 factory-boy==3.1.0        # via -r requirements/test.in
 faker==5.0.2              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='3.0.1',
+    version='3.0.2',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** 

The waffle classes previously in __future__ are now available directly from
edx_toggles.toggles. Since this __future__ module is going to be removed soon,
we become future-proof by getting rid of it.

JIRA: [JIRA-BD-21](https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943/BD-21+Toggles+Settings+Documentation)

**Developer Checklist**

- [x] Reviewed the [release process](./release_process.md)
- [ ] ~~Translations and JS/SASS compiled~~
- [x] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)

FYI: @edx/masters-devs-gta

Note that the package version was obsolete in package.json.
