### PR TITLE
fix: broken PR template links and version bump

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,9 +10,9 @@ JIRA: [JIRA-XXXX](https://openedx.atlassian.net/browse/JIRA-XXXX)
 
 **Developer Checklist**
 
-- [ ] Reviewed the [release process](./release_process.md)
+- [ ] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
 - [ ] Translations and JS/SASS compiled
-- [ ] Bumped version number in [setup.py](../setup.py) and [package.json](../package.json)
+- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)
 
 **Testing Instructions**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.6.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='3.0.2',
+    version='3.1.0',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -**

* The links in the PR template for release process,
setup.py, and package.json have been fixed. For
setup.py and package.json, also added a line number
link using a commit hash.
*  Updating the version because it was determined that the
following unreleased PR warrants a minor version bump: #1250

**Developer Checklist**

- [X] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] ~~Translations and JS/SASS compiled~~
- [X] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

FYI: @edx/masters-devs-gta
