### PR TITLE
[BD-05][TNL-7915][BB-3611] Improve ZIP File content structure

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -20,8 +20,6 @@ from django.db.models import CharField, F, OuterRef, Subquery
 from django.db.models.functions import Coalesce
 from django.utils.translation import ugettext as _
 
-from openedx.core.djangoapps.external_user_ids.models import ExternalId
-
 from submissions import api as sub_api
 from submissions.errors import SubmissionNotFoundError
 from openassessment.assessment.models import Assessment, AssessmentFeedback, AssessmentPart
@@ -1003,6 +1001,7 @@ class OraDownloadData:
         - edX username, if external ID is absent.
         - Anonymized username, if `ENABLE_ORA_USERNAMES_ON_DATA_EXPORT` feature is disabled.
         """
+        from openedx.core.djangoapps.external_user_ids.models import ExternalId
 
         student_ids = [item[0]["student_id"] for item in all_submission_information]
 
@@ -1030,7 +1029,6 @@ class OraDownloadData:
         )
 
         return {user["student_id"]: user["path_id"] for user in users}
-
 
     @classmethod
     def _submission_directory_name(
@@ -1218,7 +1216,7 @@ class OraDownloadData:
                     'description': uploaded_file.description,
                     'size': uploaded_file.size,
                     'file_path': cls._submission_filepath(
-                        ora_paths_inforall_ora_path_informationmation[student['item_id']],
+                        all_ora_path_information[student['item_id']],
                         student_identifiers_map[student['student_id']],
                         uploaded_file.name,
                     ),

--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -969,25 +969,28 @@ class OraDownloadData:
 
         path_info = {}
 
-        def children(usage_key):
-            for index, child in enumerate(blocks.get_xblock_field(usage_key, 'children') or [], 1):
+        def children(usage_key, condition=None):
+            filtered = filter(condition, blocks.get_xblock_field(usage_key, 'children') or [])
+            for index, child in enumerate(filtered, 1):
                 yield index, blocks.get_xblock_field(child, 'display_name'), child
+
+        def only_ora_blocks(block):
+            return block.block_type == "openassessment"
 
         for section_index, section_name, section in children(blocks.root_block_usage_key):
             for sub_section_index, sub_section_name, sub_section in children(section):
                 for unit_index, unit_name, unit in children(sub_section):
-                    for block_index, block_name, block in children(unit):
-                        if block.block_type == "openassessment":
-                            path_info[str(block)] = {
-                                "section_index": section_index,
-                                "section_name": section_name,
-                                "sub_section_index": sub_section_index,
-                                "sub_section_name": sub_section_name,
-                                "unit_index": unit_index,
-                                "unit_name": unit_name,
-                                "ora_index": block_index,
-                                "ora_name": block_name,
-                            }
+                    for block_index, block_name, block in children(unit, only_ora_blocks):
+                        path_info[str(block)] = {
+                            "section_index": section_index,
+                            "section_name": section_name,
+                            "sub_section_index": sub_section_index,
+                            "sub_section_name": sub_section_name,
+                            "unit_index": unit_index,
+                            "unit_name": unit_name,
+                            "ora_index": block_index,
+                            "ora_name": block_name,
+                        }
 
         return path_info
 

--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -930,7 +930,7 @@ class OraDownloadData:
 
     ATTACHMENT = 'attachment'
     TEXT = 'text'
-    DOWNLOADS_CSV_HEADER = (
+    SUBMISSIONS_CSV_HEADER = (
         'course_id',
         'block_id',
         'student_id',
@@ -1143,12 +1143,12 @@ class OraDownloadData:
         ├── [1]Some Section, [2]Some Subsection, [2]Unit
         │   ├── [1] - edx - prompt_0.txt
         │   └── [1] - edx - the_most_dangerous_kitten.jpg
-        └── downloads.csv
+        └── submissions.csv
         ```
         """
         csv_output_buffer = StringIO()
 
-        csvwriter = csv.DictWriter(csv_output_buffer, cls.DOWNLOADS_CSV_HEADER, extrasaction='ignore')
+        csvwriter = csv.DictWriter(csv_output_buffer, cls.SUBMISSIONS_CSV_HEADER, extrasaction='ignore')
         csvwriter.writeheader()
 
         with ZipFile(file, 'w') as zip_file:
@@ -1183,7 +1183,7 @@ class OraDownloadData:
                     csvwriter.writerow({**file_data, 'file_found': file_found})
 
             zip_file.writestr(
-                'downloads.csv',
+                'submissions.csv',
                 csv_output_buffer.getvalue().encode('utf-8')
             )
 

--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -56,6 +56,11 @@ def _use_read_replica(queryset):
 def _get_course_blocks(course_id):
     """
     Returns untransformed block structure for a given course key.
+
+    Args:
+        course_id - CourseLocator instance
+    Returns:
+        BlockStructureBlockData instance
     """
 
     from lms.djangoapps.course_blocks.api import get_course_blocks

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -1376,7 +1376,7 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
             zip_file.read(get_filepath(7)), self.answer_text.encode('utf-8')
         )
 
-        self.assertTrue(zip_file.read('downloads.csv'))
+        self.assertTrue(zip_file.read('submissions.csv'))
 
     def test_csv_file_for_create_zip_with_attachments(self):
         file = BytesIO()

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -1265,7 +1265,7 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
         with patch(
             'openassessment.data.OraDownloadData._download_file_by_key', return_value=file_content
         ) as download_mock:
-            OraDownloadData.create_zip_with_attachments(file, COURSE_ID, self.submission_files_data)
+            OraDownloadData.create_zip_with_attachments(file, self.submission_files_data)
 
             download_mock.assert_has_calls([
                 call(self.file_key_5),

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -1386,18 +1386,16 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
         with patch(
             'openassessment.data.OraDownloadData._download_file_by_key', return_value=file_content
         ) as download_mock:
-            OraDownloadData.create_zip_with_attachments(file, COURSE_ID, self.submission_files_data)
+            OraDownloadData.create_zip_with_attachments(file, self.submission_files_data)
 
         zip_file = zipfile.ZipFile(file)
-        # zip file contain csv file
-        csv_path = os.path.join(COURSE_ID, 'downloads.csv')
-        self.assertTrue(zip_file.read(csv_path))
+        self.assertTrue(zip_file.read('submissions.csv'))
 
-        with zip_file.open(csv_path) as csv_file:
+        with zip_file.open('submissions.csv') as csv_file:
             csv_reader = csv.DictReader(TextIOWrapper(csv_file, 'utf-8'))
             for row in csv_reader:
-                # csv file contains OraDownloadData.DOWNLOADS_CSV_HEADER
-                for column in OraDownloadData.DOWNLOADS_CSV_HEADER:
+                # csv file contains OraDownloadData.SUBMISSIONS_CSV_HEADER
+                for column in OraDownloadData.SUBMISSIONS_CSV_HEADER:
                     # prove that all column exist
                     self.assertIn(column, row)
                 # file_found column is True for all of them
@@ -1412,7 +1410,7 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
             'openassessment.data.OraDownloadData._download_file_by_key'
         ) as download_mock:
             download_mock.side_effect = FileMissingException
-            OraDownloadData.create_zip_with_attachments(file, COURSE_ID, self.submission_files_data)
+            OraDownloadData.create_zip_with_attachments(file, self.submission_files_data)
 
             download_mock.assert_has_calls([
                 call(self.file_key_5),
@@ -1461,18 +1459,16 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
             'openassessment.data.OraDownloadData._download_file_by_key'
         ) as download_mock:
             download_mock.side_effect = FileMissingException
-            OraDownloadData.create_zip_with_attachments(file, COURSE_ID, self.submission_files_data)
+            OraDownloadData.create_zip_with_attachments(file, self.submission_files_data)
 
         zip_file = zipfile.ZipFile(file)
-        # zip file contain csv file
-        csv_path = os.path.join(COURSE_ID, 'downloads.csv')
-        self.assertTrue(zip_file.read(csv_path))
+        self.assertTrue(zip_file.read('submissions.csv'))
 
-        with zip_file.open(csv_path) as csv_file:
+        with zip_file.open('submissions.csv') as csv_file:
             csv_reader = csv.DictReader(TextIOWrapper(csv_file, 'utf-8'))
             for row in csv_reader:
-                # csv file contains OraDownloadData.DOWNLOADS_CSV_HEADER
-                for column in OraDownloadData.DOWNLOADS_CSV_HEADER:
+                # csv file contains OraDownloadData.SUBMISSIONS_CSV_HEADER
+                for column in OraDownloadData.SUBMISSIONS_CSV_HEADER:
                     # prove that all column exist
                     self.assertIn(column, row)
                 # csv and data in the zip file are consistence

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.6.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='3.5.0',
+    version='3.5.1',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
This PR contains an improvement of the submission files archive structure, which can be generated by clicking this button in the "Data Download" section of the instructor dashboard:
![image](https://user-images.githubusercontent.com/18251194/113404859-841e3a00-93b1-11eb-95a7-373b4a1f937c.png)

Previous structure example:
```
.
└── CourseId
    ├── BlockId1
    │   ├── StudentId1
    │   │   ├── attachments
    │   │   │   ├── SomeFile1
    │   │   │   └── SomeFile2
    │   │   ├── part_0.txt
    │   │   └── part_1.txt
    │   └── StudentId2
    │       ├── part_0.txt
    │       └── part_1.txt
    ├── BlockId2
    │   └── StudentId3
    │       ├── attachments
    │       │   └── SomeFile4
    │       └── part_0.txt
    └── downloads.csv
```

New structure example:
```
.
├── [1]Some Section, [1]Some Subsection, [1]Unit
│   ├── [1] - 00f636b9ac6d480c9fb95c23bf1d2129 - prompt_0.txt
│   ├── [1] - 00f636b9ac6d480c9fb95c23bf1d2129 - prompt_1.txt
│   ├── [1] - edx - prompt_0.txt
│   ├── [1] - edx - prompt_1.txt
│   ├── [2] - edx - prompt_0.txt
│   └── [2] - edx - Structure and Interpretation of Computer Programs.pdf
├── [1]Some Section, [2]Some Subsection, [1]Unit
│   └── [1] - edx - prompt_0.txt
├── [1]Some Section, [2]Some Subsection, [2]Unit
│   ├── [1] - edx - prompt_0.txt
│   └── [1] - edx - the_most_dangerous_kitten.jpg
└── downloads.csv
```

**JIRA tickets**:
- [BB-3611](https://tasks.opencraft.com/browse/BB-3611).
- [TNL-7915](https://openedx.atlassian.net/browse/TNL-7915).
- [BLENDED-799](https://openedx.atlassian.net/browse/BLENDED-799).

**Sandboxes**:
- https://pr27218.sandbox.opencraft.hosting/

**Discussions**:
- [First Slack thread](https://openedx.slack.com/archives/C014VAUJUJ0/p1612272008003000).
- [Second Slack thread](https://openedx.slack.com/archives/C014VAUJUJ0/p1612968435011100).
- [Third Slack thread](https://openedx.slack.com/archives/C014VAUJUJ0/p1617028572003900).

**Dependencies**:
- https://github.com/edx/edx-platform/pull/27218 depends on this PR.

**Testing instructions**:

###### Step I: checkout edx-platform
1. `cd $(devstack_root)`
1. `cd ../edx-platform`
1. `git remote add opencraft https://github.com/open-craft/edx-platform`
1. `git fetch opencraft 0x29a/bb3611/improve_zip_file_content_structure`
1. `git checkout 0x29a/bb3611/improve_zip_file_content_structure`

###### Step II: install edx-ora2
1. `cd $(devstack_root)`
1. `cd ../src/`
1. `git clone https://github.com/edx/edx-ora2/`
1. `cd edx-ora2`
1. `git checkout 0x29a/bb3611/improve_zip_file_content_structure`
1. `make install-local-ora`
1. `cd $(devstack_root)`
1. `make lms-restart`

###### Step III: prepare course
1. Add ORA block to the demo course, enable optional file attachments.
1. Change name of subsection where ORA was added to:
```
*************************************************************************************************************************************************************************************************************************************************************** | THIS PART WILL BE TRUNCATED
```
3. Submit answer as `staff@example.com` user, attach file with a following name:
```
***************************************************************************************************************************************************************************************************************************** | THIS PART WILL BE TRUNCATED.jpg
```

###### Step IV: create external ID
1. `cd $(devstack_root)`
1. `make lms-shell`
1. `python manage.py lms shell`
1. `from openedx.core.djangoapps.external_user_ids.models import ExternalId`
1. `from django.contrib.auth import get_user_model`
1. `ExternalId.add_new_user_id(get_user_model().objects.get(email='staff@example.com'), 'mb_coaching')`

###### Step V: check zip structure
1. Go to the "Download Data" section of the instructor dashboard.
1. Click "Generate Submission Files Archive".
1. Download generated file.
1. Ensure that the subsection name is truncated, as well as filename base. Ensure that submission files for a `staff` user contain external ID.

**Reviewers**
- [ ] @giovannicimolin 
- [ ] @jnlapierre 