### PR TITLE
[EDUCATOR-5738]: Don't let flexible peer grading bring must_be_graded_by to zero

### DIFF
--- a/openassessment/assessment/api/peer.py
+++ b/openassessment/assessment/api/peer.py
@@ -53,6 +53,8 @@ def required_peer_grades(submission_uuid, peer_requirements):
         # check if flexible grading applies. if it does, then update must_grade
         if days_elapsed >= FLEXIBLE_PEER_GRADING_REQUIRED_SUBMISSION_AGE_IN_DAYS:
             must_grade = int(must_grade * FLEXIBLE_PEER_GRADING_GRADED_BY_PERCENTAGE / 100)
+            if must_grade == 0:
+                must_grade = 1
 
     return must_grade
 

--- a/openassessment/assessment/test/test_peer.py
+++ b/openassessment/assessment/test/test_peer.py
@@ -1749,10 +1749,10 @@ class TestPeerApi(CacheResetTest):
         workflow.save()
 
         # The learner has not been graded by anyone, but flexible grading rounds the required 3 to .9 and casts to 0
+        # The must_grade = 0 is technically disallowed by validation rules but these api calls don't care
         requirements = {'must_grade': 0, 'must_be_graded_by': 3, 'enable_flexible_grading': True}
-        self.assertEqual(0, peer_api.required_peer_grades(submission['uuid'], requirements))
-        with self.assertRaises(IndexError):
-            peer_api.get_score(submission['uuid'], requirements)
+        self.assertEqual(1, peer_api.required_peer_grades(submission['uuid'], requirements))
+        self.assertIsNone(peer_api.get_score(submission['uuid'], requirements))
 
     @staticmethod
     def _create_student_and_submission(student, answer, date=None):

--- a/openassessment/assessment/test/test_peer.py
+++ b/openassessment/assessment/test/test_peer.py
@@ -1734,6 +1734,26 @@ class TestPeerApi(CacheResetTest):
         else:
             assert score is None
 
+    def test_flexible_peer_grading__zero_graded(self):
+        # create a student with a submission from eight days ago
+        user_submissions = []
+        submission_date = timezone.now() - datetime.timedelta(days=8)
+        submission, user = self._create_student_and_submission(
+            'test-student',
+            'student-submission',
+            date=submission_date
+        )
+        # Backdate created_by so that flexible grading kicks in
+        workflow = PeerWorkflow.get_by_submission_uuid(submission['uuid'])
+        workflow.created_at = submission_date
+        workflow.save()
+
+        # The learner has not been graded by anyone, but flexible grading rounds the required 3 to .9 and casts to 0
+        requirements = {'must_grade': 0, 'must_be_graded_by': 3, 'enable_flexible_grading': True}
+        self.assertEqual(0, peer_api.required_peer_grades(submission['uuid'], requirements))
+        with self.assertRaises(IndexError):
+            peer_api.get_score(submission['uuid'], requirements)
+
     @staticmethod
     def _create_student_and_submission(student, answer, date=None):
         """ Creats a student and submission for tests. """

--- a/openassessment/xblock/studio_mixin.py
+++ b/openassessment/xblock/studio_mixin.py
@@ -146,6 +146,11 @@ class StudioMixin:
         white_listed_file_types = self.get_allowed_file_types_or_preset()
         white_listed_file_types_string = ','.join(white_listed_file_types) if white_listed_file_types else ''
 
+        breakpoint()
+        other_ora_blocks = self.get_other_course_ora_blocks()
+        for other_ora_block in other_ora_blocks:
+            logger.info(self._get_rubric(other_ora_block.location))
+
         return {
             'prompts': self.prompts,
             'prompts_type': self.prompts_type,

--- a/openassessment/xblock/studio_mixin.py
+++ b/openassessment/xblock/studio_mixin.py
@@ -146,11 +146,6 @@ class StudioMixin:
         white_listed_file_types = self.get_allowed_file_types_or_preset()
         white_listed_file_types_string = ','.join(white_listed_file_types) if white_listed_file_types else ''
 
-        breakpoint()
-        other_ora_blocks = self.get_other_course_ora_blocks()
-        for other_ora_block in other_ora_blocks:
-            logger.info(self._get_rubric(other_ora_block.location))
-
         return {
             'prompts': self.prompts,
             'prompts_type': self.prompts_type,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.6.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='3.5.2',
+    version='3.5.3',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** Don't let flexible peer grading bring must_be_graded_by to zero

JIRA: [EDUCATOR-5738](https://openedx.atlassian.net/browse/EDUCATOR-5738)

**What changed?**

- When flexible peer grading is active, we allow the peer review step to be complete when the learner receives only 30% of the required number of reviews after a certain amount of time. We calculate the new number by doing `int(must_be_graded_by * 30 / 100)`. When 30 percent of must_be_graded_by is less than 1, it gets casted down to 0.
- We then blow up because we want to know the grade the learner was given, but there's no grade because there have been no reviews.
- Don't let the value be zero, always keep a min of 1.

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

- Create an ORA with a peer review step. Set must_grade = 2 must_be_graded_by = 2 and flexible peer grading = True.
- Make three submissions from three different users. (make your response something unique so you can identify it later)
-  Have the one target learner grade the other two learners
- Modify one learner's submission to have been submitted at more than 7 days ago:
```
> cd (devstack)
> make mysql57-shell
> mysql
> use edxapp
> update submissions_submission set submitted_at = '2020-05-11 13:58:03.079302' where id = <your submission id>;
```
you can find your submission id by going to the mysql shell (first four commands above) and running `select * from submissions_submission order by submitted_at desc limit 3` which should show only your two submissions, which you can then identify by the content of `raw_answer`

whew

then, after you've updated your response to be from the past, go to the ORA as a staff account and attempt to load the `Manage Individual Learners` for the specific learner. I also suspect you can just try to load the ORA for that one person too, but I haven't tested manually. 

Before the change, kaboom, errors. After the change, aah, no errors.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [x] I've tested the new functionality

FYI: @edx/masters-devs-gta
