### PR TITLE
Jkantor/waiting bug

### DIFF
--- a/openassessment/assessment/api/self.py
+++ b/openassessment/assessment/api/self.py
@@ -12,9 +12,7 @@ from openassessment.assessment.errors import SelfAssessmentInternalError, SelfAs
 from openassessment.assessment.models import Assessment, AssessmentPart, InvalidRubricSelection
 from openassessment.assessment.serializers import (InvalidRubric, full_assessment_dict, rubric_from_dict,
                                                    serialize_assessments)
-
-# Assessments are tagged as "self-evaluation"
-SELF_TYPE = "SE"
+from openassessment.assessment.score_type_constants import SELF_TYPE
 
 logger = logging.getLogger("openassessment.assessment.api.self")  # pylint: disable=invalid-name
 

--- a/openassessment/assessment/api/staff.py
+++ b/openassessment/assessment/api/staff.py
@@ -13,11 +13,10 @@ from submissions import api as submissions_api
 from openassessment.assessment.errors import StaffAssessmentInternalError, StaffAssessmentRequestError
 from openassessment.assessment.models import Assessment, AssessmentPart, InvalidRubricSelection, StaffWorkflow
 from openassessment.assessment.serializers import InvalidRubric, full_assessment_dict, rubric_from_dict
+from openassessment.assessment.score_type_constants import STAFF_TYPE
 
 
 logger = logging.getLogger("openassessment.assessment.api.staff")  # pylint: disable=invalid-name
-
-STAFF_TYPE = "ST"
 
 
 def submitter_is_finished(submission_uuid, staff_requirements):  # pylint: disable=unused-argument

--- a/openassessment/assessment/api/teams.py
+++ b/openassessment/assessment/api/teams.py
@@ -14,11 +14,9 @@ from openassessment.assessment.api.staff import _complete_assessment
 from openassessment.assessment.errors import StaffAssessmentInternalError, StaffAssessmentRequestError
 from openassessment.assessment.models import Assessment, TeamStaffWorkflow, InvalidRubricSelection
 from openassessment.assessment.serializers import InvalidRubric, full_assessment_dict
-
+from openassessment.assessment.score_type_constants import STAFF_TYPE
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
-
-STAFF_TYPE = "ST"
 
 
 def submitter_is_finished(team_submission_uuid, team_requirements):  # pylint: disable=unused-argument

--- a/openassessment/assessment/models/peer.py
+++ b/openassessment/assessment/models/peer.py
@@ -249,7 +249,6 @@ class PeerWorkflow(models.Model):
                 'graded_by': 2
             }
         """
-        Count, Q = models.Count, models.Q
         waiting = cls.objects.filter(
             item_id=item_id, course_id=course_id,
             grading_completed_at__isnull=True,
@@ -257,19 +256,19 @@ class PeerWorkflow(models.Model):
         ).annotate(
             # distinct=True required due to
             # https://docs.djangoproject.com/en/3.2/topics/db/aggregation/#combining-multiple-aggregations
-            graded_count=Count(
+            graded_count=models.Count(
                 'graded',
                 distinct=True,
                 # From PeerWorkflow.num_peers_graded
-                filter=Q(
+                filter=models.Q(
                     graded__assessment__isnull=False
                 )
             ),
-            graded_by_count=Count(
+            graded_by_count=models.Count(
                 'graded_by',
                 distinct=True,
                 # from peer_api.get_graded_by_count
-                filter=Q(
+                filter=models.Q(
                     graded_by__assessment__submission_uuid__in=submission_uuids,
                     graded_by__assessment__score_type=PEER_TYPE
                 )

--- a/openassessment/assessment/models/peer.py
+++ b/openassessment/assessment/models/peer.py
@@ -18,6 +18,7 @@ from django.utils.timezone import now
 
 from openassessment.assessment.errors import PeerAssessmentInternalError, PeerAssessmentWorkflowError
 from openassessment.assessment.models.base import Assessment
+from openassessment.assessment.score_type_constants import PEER_TYPE
 
 logger = logging.getLogger("openassessment.assessment.models")  # pylint: disable=invalid-name
 
@@ -248,13 +249,31 @@ class PeerWorkflow(models.Model):
                 'graded_by': 2
             }
         """
+        Count, Q = models.Count, models.Q
         waiting = cls.objects.filter(
             item_id=item_id, course_id=course_id,
             grading_completed_at__isnull=True,
             submission_uuid__in=submission_uuids,
         ).annotate(
-            graded_count=models.Count('graded'),
-            graded_by_count=models.Count('graded_by'),
+            # distinct=True required due to
+            # https://docs.djangoproject.com/en/3.2/topics/db/aggregation/#combining-multiple-aggregations
+            graded_count=Count(
+                'graded',
+                distinct=True,
+                # From PeerWorkflow.num_peers_graded
+                filter=Q(
+                    graded__assessment__isnull=False
+                )
+            ),
+            graded_by_count=Count(
+                'graded_by',
+                distinct=True,
+                # from peer_api.get_graded_by_count
+                filter=Q(
+                    graded_by__assessment__submission_uuid__in=submission_uuids,
+                    graded_by__assessment__score_type=PEER_TYPE
+                )
+            )
         ).filter(
             graded_by_count__lt=must_be_graded_by
         )

--- a/openassessment/assessment/score_type_constants.py
+++ b/openassessment/assessment/score_type_constants.py
@@ -1,0 +1,5 @@
+""" Constant strings used to identify what type of score an Assessment is. Used in the 'score_type' field """
+
+PEER_TYPE = "PE"
+SELF_TYPE = "SE"
+STAFF_TYPE = "ST"

--- a/openassessment/assessment/test/test_peer.py
+++ b/openassessment/assessment/test/test_peer.py
@@ -218,7 +218,7 @@ class TestPeerApi(CacheResetTest):
         self._create_student_and_submission("Tim", "Tim's answer")
         bob_sub, bob = self._create_student_and_submission("Bob", "Bob's answer")
         peer_api.get_submission_to_assess(bob_sub['uuid'], 1)
-        assessment = peer_api.create_assessment(
+        peer_api.create_assessment(
             bob_sub["uuid"],
             bob["student_id"],
             ASSESSMENT_DICT['options_selected'],
@@ -1736,9 +1736,8 @@ class TestPeerApi(CacheResetTest):
 
     def test_flexible_peer_grading__zero_graded(self):
         # create a student with a submission from eight days ago
-        user_submissions = []
         submission_date = timezone.now() - datetime.timedelta(days=8)
-        submission, user = self._create_student_and_submission(
+        submission, _ = self._create_student_and_submission(
             'test-student',
             'student-submission',
             date=submission_date
@@ -1755,14 +1754,67 @@ class TestPeerApi(CacheResetTest):
         self.assertIsNone(peer_api.get_score(submission['uuid'], requirements))
 
     @staticmethod
-    def _create_student_and_submission(student, answer, date=None):
+    def _create_student_and_submission(student, answer, date=None, steps=None):
         """ Creats a student and submission for tests. """
         new_student_item = STUDENT_ITEM.copy()
         new_student_item["student_id"] = student
         submission = sub_api.create_submission(new_student_item, answer, date)
         peer_api.on_start(submission["uuid"])
-        workflow_api.create_workflow(submission["uuid"], STEPS)
+        workflow_api.create_workflow(submission["uuid"], steps or STEPS)
         return submission, new_student_item
+
+    def _assert_assessment_workflow_status(self, uuid, expected_status):
+        self.assertEqual(
+            workflow_api.get_workflow_for_submission(uuid, STEP_REQUIREMENTS)['status'],
+            expected_status
+        )
+
+    def test_get_waiting_step_details__peer_item_created_not_assessed(self):
+        # a target student and submission, and some other students and submissions
+        target_learner_sub, target_learner = self._create_student_and_submission(
+            'TargetLearner',
+            'TargetLearner submission',
+            steps=['peer']
+        )
+        other_learner_submissions = [
+            self._create_student_and_submission(f'Student{i}', f'Student{i} submission', steps=['peer'])
+            for i in range(5)
+        ]
+
+        # Have the target student submit her required assessment, they should now be waiting.
+        peer_api.get_submission_to_assess(target_learner_sub['uuid'], target_learner['student_id'])
+        peer_api.create_assessment(
+            target_learner_sub['uuid'],
+            target_learner['student_id'],
+            ASSESSMENT_DICT['options_selected'],
+            ASSESSMENT_DICT['criterion_feedback'],
+            ASSESSMENT_DICT['overall_feedback'],
+            RUBRIC_DICT,
+            1
+        )
+        self._assert_assessment_workflow_status(target_learner_sub['uuid'], 'waiting')
+
+        # Call get_submission_to_assess so all five learners in other_learner_submissions are
+        # currently assessing target_learner
+        for sub, student in other_learner_submissions:
+            chosen_submission = peer_api.get_submission_to_assess(sub['uuid'], student['student_id'])
+            self.assertIsNotNone(chosen_submission)
+            self.assertEqual(chosen_submission['uuid'], target_learner_sub['uuid'])
+
+        # The target learner is still in waiting and has five pending items but zero peer grades
+        self._assert_assessment_workflow_status(target_learner_sub['uuid'], 'waiting')
+        self.assertEqual(PeerWorkflow.get_by_submission_uuid(target_learner_sub['uuid']).graded_by.count(), 5)
+        self.assertEqual(peer_api.get_graded_by_count(target_learner_sub['uuid']), 0)
+
+        # The learner is not returned from 'get_waiting_step_details'
+        students_waiting = peer_api.get_waiting_step_details(
+            STUDENT_ITEM['course_id'],
+            STUDENT_ITEM['item_id'],
+            [target_learner_sub['uuid']] + [sub['uuid'] for sub, _ in other_learner_submissions],
+            must_be_graded_by=1,
+        )
+        waiting_student_ids = {learner['student_id'] for learner in students_waiting}
+        self.assertNotIn(target_learner['student_id'], waiting_student_ids)
 
 
 class PeerWorkflowTest(CacheResetTest):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.6.5",
+  "version": "3.6.6",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.6.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='3.6.5',
+    version='3.6.6',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** Fix a bug where the waiting details page would not include legitimate 'waiting' students. 

JIRA: [AU-21](https://openedx.atlassian.net/browse/AU-21)

**What changed?**

- changed `get_waiting_step_details ` to not include "unfinished" (aka, no actual assessment) PeerWorkflowItems
- I also did a small refactor to move some "magic strings" from the assessment/api files to their own file, to avoid a circular import
- some quality errors that somehow slipped through?

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

I won't lie, this is gonna be a pain to test.
- Make an ORA with only a peer review step, with one required grade and one required graded_by, in a course with at least two learners
- Make a submission with both learners.
- For learner 1, submit an assessment for learner 2
- Learner 1 should be in waiting because they have not received a peer review
- Make sure learner 2 has been "assigned" learner 1, by which I mean log in as learner 2 and make sure that learner 1's submission is listed as your active review in your peer review step
- Go to the instructor dashboard. There should be one learner listed as "peer" (learner 2) and one learner listed as "waiting"  (learner 1).
- Click the "1" in waiting to be brought to the dashboard.
-  NOTE: IF THE NUMBER UNDER WAITING IS NOT CLICKABLE, YOU MUST MAKE THE FOLLOWING CHANGE:
   In edx-platform/lms/envs/devstack.py, add the following line at the end of the file: 
   `FEATURES['ENABLE_XBLOCK_VIEW_ENDPOINT'] = True` 
- No learners should be listed in the tool.
- Switch to this branch and reload the waiting learner tool. Learner 1 should now be listed.
 
**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
