### PR TITLE
EDUCATOR-5301: teams workflows should be in waiting status

### DIFF
--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -912,8 +912,8 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
             'done': 0, 'cancelled': 0, 'teams': 0
         })
         self.assertEqual(data[team_item_id], {
-            'total': 2, 'training': 0, 'peer': 0, 'self': 0, 'staff': 0, 'waiting': 0,
-            'done': 0, 'cancelled': 0, 'teams': 2
+            'total': 2, 'training': 0, 'peer': 0, 'self': 0, 'staff': 0, 'waiting': 2,
+            'done': 0, 'cancelled': 0, 'teams': 0
         })
 
         data = OraAggregateData.collect_ora2_responses(COURSE_ID, ['staff', 'peer'])

--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -731,9 +731,6 @@ class TeamAssessmentWorkflow(AssessmentWorkflow):
         team_assessment_api = team_staff_step.api()
         team_assessment_api.on_init(team_submission_uuid)
 
-        team_workflow.status = TeamAssessmentWorkflow.STATUS.teams
-        team_workflow.save()
-
         return team_workflow
 
     @property

--- a/openassessment/workflow/test/test_models.py
+++ b/openassessment/workflow/test/test_models.py
@@ -52,7 +52,7 @@ class TeamAssessmentTest(CacheResetTest):
             team_workflow = TeamAssessmentWorkflow.start_workflow(self.team_submission_uuid)
         self.assertEqual(team_workflow.team_submission_uuid, self.team_submission_uuid)
         self.assertIn(team_workflow.submission_uuid, self.submission_uuids)
-        self.assertEqual(team_workflow.status, TeamAssessmentWorkflow.STATUS.teams)
+        self.assertEqual(team_workflow.status, TeamAssessmentWorkflow.STATUS.waiting)
         self.assertEqual(team_workflow.course_id, self.course_id)
         self.assertEqual(team_workflow.item_id, self.item_id)
 

--- a/openassessment/workflow/test/test_team_api.py
+++ b/openassessment/workflow/test/test_team_api.py
@@ -43,7 +43,7 @@ class TestTeamAssessmentWorkflowApi(CacheResetTest):
 
         self.assertEqual(team_workflow.team_submission_uuid, self.team_submission_uuid)
         self.assertIn(team_workflow.submission_uuid, self.submission_uuids)
-        self.assertEqual(team_workflow.status, TeamAssessmentWorkflow.STATUS.teams)
+        self.assertEqual(team_workflow.status, TeamAssessmentWorkflow.STATUS.waiting)
         self.assertEqual(team_workflow.course_id, self.course_id)
         self.assertEqual(team_workflow.item_id, self.item_id)
 

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -759,7 +759,7 @@ class TestCourseStaff(XBlockHandlerTestCase):
         status_counts, total_submissions = xblock.get_team_workflow_status_counts()
         self.assertEqual(total_submissions, 1)
         status_counts = self._parse_workflow_status_counts(status_counts)
-        self.assertEqual(status_counts['teams'], 1)
+        self.assertEqual(status_counts['waiting'], 1)
 
         # The staff area student context should not include a workflow cancellation
         _, context = xblock.get_student_info_path_and_context(MOCK_TEAM_MEMBER_STUDENT_IDS[0])
@@ -991,7 +991,7 @@ class TestCourseStaff(XBlockHandlerTestCase):
         status_counts, total_submissions = xblock.get_team_workflow_status_counts()
         self.assertEqual(total_submissions, 1)
         status_counts = self._parse_workflow_status_counts(status_counts)
-        self.assertEqual(status_counts['teams'], 1)
+        self.assertEqual(status_counts['waiting'], 1)
 
         # When I clear the team's state
         xblock.clear_student_state(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.6.7",
+  "version": "3.6.9",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.6.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='3.6.8',
+    version='3.6.9',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** When a teams workflow is created, the status should be WAITING

JIRA: [EDUCATOR-5301](https://openedx.atlassian.net/browse/EDUCATOR-5301)

**What changed?**

- Leave the workflow alone, don't set the value to TEAMS after creation.
- Update tests.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

- Create a two team ORAs in a course with multiple learners. I'll call the ORAs A and B.
- On master, create one or more submissions for ORA A. After you submit, the Staff Grade section should be Not Available, and the message at the top of the screen should be .... my devstack is kinda fighting with me right now, but it should be kinda confusing, and the message in the "my grade" section should kinda imply that you have more work you have to do.
- Check out this branch, wait for things to reload, and then create one or more submissions for ORA B. THe staff grade section should show up, and both the messages should be something more helpful (update when devstack comes back on)
- Load the instructor dashboard openassessment page. ORA A should have zero listed responses. ORA B should have some number of "total responses" and an equal number under the "Staff" column. If you have `FEATURES['ENABLE_XBLOCK_VIEW_ENDPOINT'] = True` in your devstack.py, you should be able to click the "staff" number and verify that the numbers you see match.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
