### PR TITLE
filter users in _map_student_ids_to_path_ids

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -1013,7 +1013,7 @@ class OraDownloadData:
         # pylint: disable=unused-variable
         student_ids = [item[0]["student_id"] for item in all_submission_information]
         if not student_ids:
-            return
+            return {}
         course_id = all_submission_information[0][0]['course_id']
         logger.info("[%s] Getting user model", course_id)
         User = get_user_model()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.6.10",
+  "version": "3.6.11",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.6.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='3.6.10',
+    version='3.6.11',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** Filter out users when we attempt to make the user map for submission zip generation

JIRA: [EDUCATOR-5862](https://openedx.atlassian.net/browse/EDUCATOR-5862)
[AU-24](https://openedx.atlassian.net/browse/AU-24)

**What changed?**

- We aren't filtering users in `_map_student_ids_to_path_ids` so we're attempting to make an annotation over every user in the database and it's making the submission jobs fail. (I am fairly sure)
- A previous PR of adding logging confirmed that this function call `_map_student_ids_to_path_ids` was where execution disappeared.
- This was already something I have identified as an issue, so I went in and fixed it, and added some more logs in case this isn't ultimately the cause 

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

If you don't have many local users, generate some with `generate_test_users`
Install ORA locally, then generate the submission archive for a course with some number of submissions.
Your logs should have the lines
```
[course_id] Getting user model
[course_id] Loading users
[course_id] Loaded <number> users
```

<number> should be the number of users with submissions, and not the number of total users.
To verify the change, comment out line 1024 and try again. You'll see we load all users.
 
**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
