### PR TITLE
Leangseu edx/fix-au-69

### DIFF
--- a/openassessment/xblock/load_static.py
+++ b/openassessment/xblock/load_static.py
@@ -10,6 +10,17 @@ from django.conf import settings
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
+def urljoin(*args):
+    """
+    Joining multiple url continuously. The default behavior from os.path.join
+    would completely reset the path if the second path start with '/'.
+    """
+    begining_slash = '/' if args[0].startswith('/') else ''
+    trailing_slash = '/' if args[-1].endswith('/') else ''
+    joined_path = '/'.join(map(lambda x: str(x).strip('/'), args))
+    return begining_slash + joined_path + trailing_slash
+
+
 class LoadStatic:
     """
     Helper class for loading generated file from webpack.
@@ -37,7 +48,7 @@ class LoadStatic:
         except IOError:
             logger.error('Cannot find static/dist/manifest.json')
         finally:
-            LoadStatic._base_url = root_url + base_url
+            LoadStatic._base_url = urljoin(root_url, base_url)
 
     @staticmethod
     def get_url(key):
@@ -46,5 +57,5 @@ class LoadStatic:
         """
         if not LoadStatic._is_loaded:
             LoadStatic.reload_manifest()
-        url = LoadStatic._manifest[key] if LoadStatic._is_loaded else key
-        return LoadStatic._base_url + url
+        url = LoadStatic._manifest[key] if key in LoadStatic._manifest else key
+        return urljoin(LoadStatic._base_url, url)

--- a/openassessment/xblock/test/test_load_static.py
+++ b/openassessment/xblock/test/test_load_static.py
@@ -1,0 +1,87 @@
+"""
+Test load static class
+"""
+
+from unittest.mock import patch
+from django.test import TestCase, override_settings
+from openassessment.xblock.load_static import LoadStatic, urljoin
+
+
+class TestLoadStatic(TestCase):
+    """Test load static class"""
+    default_base_url = '/static/dist/'
+
+    def setUp(self):
+        LoadStatic._manifest = dict()   # pylint: disable=protected-access
+        LoadStatic._is_loaded = False   # pylint: disable=protected-access
+        LoadStatic._base_url = ''   # pylint: disable=protected-access
+        return super().setUp()
+
+    def test_urljoin(self):
+        expected_result_1 = 'path_1/path_2'
+        expected_result_2 = 'path_1/path_2/'
+        expected_result_3 = '/path_1/path_2'
+        expected_result_4 = '/path_1/path_2/'
+
+        self.assertEqual(expected_result_1, urljoin('path_1', 'path_2'))
+        self.assertEqual(expected_result_1, urljoin('path_1/', 'path_2'))
+        self.assertEqual(expected_result_1, urljoin('path_1', '/path_2'))
+        self.assertEqual(expected_result_1, urljoin('path_1/', '/path_2'))
+
+        self.assertEqual(expected_result_2, urljoin('path_1', 'path_2/'))
+        self.assertEqual(expected_result_2, urljoin('path_1/', 'path_2/'))
+        self.assertEqual(expected_result_2, urljoin('path_1', '/path_2/'))
+        self.assertEqual(expected_result_2, urljoin('path_1/', '/path_2/'))
+
+        self.assertEqual(expected_result_3, urljoin('/path_1', 'path_2'))
+        self.assertEqual(expected_result_3, urljoin('/path_1/', 'path_2'))
+        self.assertEqual(expected_result_3, urljoin('/path_1', '/path_2'))
+        self.assertEqual(expected_result_3, urljoin('/path_1/', '/path_2'))
+
+        self.assertEqual(expected_result_4, urljoin('/path_1', 'path_2/'))
+        self.assertEqual(expected_result_4, urljoin('/path_1/', 'path_2/'))
+        self.assertEqual(expected_result_4, urljoin('/path_1', '/path_2/'))
+        self.assertEqual(expected_result_4, urljoin('/path_1/', '/path_2/'))
+
+    def test_get_url_default(self):
+        key_url = 'some_url.js'
+        self.assertEqual(LoadStatic.get_url(key_url),
+                         urljoin(self.default_base_url, key_url))
+
+    @patch('pkg_resources.resource_string')
+    def test_get_url_file_not_found(self, resource_string):
+        key_url = 'some_url.js'
+        resource_string.side_effect = IOError()
+        self.assertEqual(LoadStatic.get_url(key_url), urljoin(
+            self.default_base_url, 'some_url.js'))
+
+    @override_settings(LMS_ROOT_URL='localhost/')
+    @patch('pkg_resources.resource_string')
+    def test_get_url_file_not_found_with_root_url(self, resource_string):
+        key_url = 'some_url.js'
+        resource_string.side_effect = IOError()
+        self.assertEqual(LoadStatic.get_url(key_url), urljoin(
+            'localhost/', self.default_base_url, 'some_url.js'))
+
+    @patch('pkg_resources.resource_string')
+    def test_get_url_with_manifest(self, resource_string):
+        resource_string.return_value = None
+        key_url = 'some_url.js'
+        with patch('json.loads') as jsondata:
+            jsondata.return_value = {
+                'some_url.js': 'some_url.hashchunk.js'
+            }
+            self.assertEqual(LoadStatic.get_url(key_url), urljoin(
+                self.default_base_url, 'some_url.hashchunk.js'))
+
+    @override_settings(LMS_ROOT_URL='localhost/')
+    @patch('pkg_resources.resource_string')
+    def test_get_url_with_manifest_and_root_url(self, resource_string):
+        resource_string.return_value = None
+        key_url = 'some_url.js'
+        with patch('json.loads') as jsondata:
+            jsondata.return_value = {
+                'some_url.js': 'some_url.hashchunk.js'
+            }
+            self.assertEqual(LoadStatic.get_url(key_url), urljoin(
+                'localhost/', self.default_base_url, 'some_url.hashchunk.js'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.6.13",
+  "version": "3.6.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.6.13",
+  "version": "3.6.14",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.6.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='3.6.13',
+    version='3.6.14',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
This is an improvement for [this pr](https://github.com/edx/edx-ora2/pull/1664). It includes fail safe.

- [x] Tested on `sandbox`

**TL;DR -**

Improvement to developing javascript using webpack build:
- [x] include source map
- [x] has distinct name on production build
- [x] `npm run build` to build production
- [x] `npm run dev` to build development
- [x] `npm run start` to start development server
- [x] `make static` should generate javascript for `dev/prod` build

Bonus:
- [x] Hot reload in dev build. **CMS** does not hot reload yet.

JIRA: [educator 5480](https://openedx.atlassian.net/browse/EDUCATOR-5480)

**What changed?**

- `make static` should generate generate javascript for `dev/prod` build
- breakpoint, sourceMap, debugger should work on `npm run build` or `npm run start`
- `npm run start` should start dev server

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

** Hot Reload **
- from local directory (not in lms shell)
- `npm run start`
- from devstack directory (not in lms shell)
- `make lms-restart studio-restart` This is only require when you `load_static.py` to reload its static method.
  - **NOTE**: cms does not support hot reload at the moment
- modify `javascript` or add `debugger` within lms page that has `xblock-ora`. It should hot reload the `xblock`.
  - **NOTE**: lms use iframe while cms is not. One of the reason hot reload not working properly.

**Reviewer Checklist**
- [x] `make static`
- [x] `npm run dev`
- [x] `npm run start`

NOTE:
- Each command require `make lms-restart studio-restart`
- Source map should be working
- `Debugger` should only work on development build

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
