### PR TITLE
Hide step actions for response if in studio

### DIFF
--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -201,141 +201,142 @@
                                 {% endif %}
                             </li>
                         {% endfor %}
-                        {% if team_name and previous_team_name %}
-                            <div id='team_user_has_previous_submission'>
-                                {% blocktrans %}
-                                    You are currently on Team {{team_name}}. Since you were on Team {{previous_team_name}}
-                                    when they submitted a response to this assignment, you are seeing Team {{previous_team_name}}’s
-                                    response and will receive the same grade for this assignment as your former teammates.
-                                    You will not be part of Team {{team_name}}’s submission for this assignment and will not
-                                    receive a grade for their submission.
-                                {% endblocktrans %}
-                            </div>
-                        {% endif %}
-                        {% if text_response %}
-                        <li class="field">
-                            <div class="response__submission__actions">
-                                <div class="message message--inline message--error message--error-server" tabindex="-1">
-                                    <h5 class="message__title">{% trans "We could not save your progress" %}</h5>
-                                    <div class="message__content"></div>
+
+                        {% if has_real_user %}
+                          {% if team_name and previous_team_name %}
+                              <div id='team_user_has_previous_submission'>
+                                  {% blocktrans %}
+                                      You are currently on Team {{team_name}}. Since you were on Team {{previous_team_name}}
+                                      when they submitted a response to this assignment, you are seeing Team {{previous_team_name}}’s
+                                      response and will receive the same grade for this assignment as your former teammates.
+                                      You will not be part of Team {{team_name}}’s submission for this assignment and will not
+                                      receive a grade for their submission.
+                                  {% endblocktrans %}
+                              </div>
+                          {% endif %}
+                          {% if text_response %}
+                          <li class="field">
+                              <div class="response__submission__actions">
+                                  <div class="message message--inline message--error message--error-server" tabindex="-1">
+                                      <h5 class="message__title">{% trans "We could not save your progress" %}</h5>
+                                      <div class="message__content"></div>
+                                  </div>
+
+                                  <ul class="list list--actions">
+                                      <li class="list--actions__item">
+                                          <button type="submit" class="action action--save submission__save" aria-describedby="response__save_status__{{ xblock_id }}" disabled>
+                                              {% trans "Save your progress" %}
+                                          </button>
+
+                                          <div id="response__save_status__{{ xblock_id }}" class="save__submission__label response__submission__label">
+                                              <span class="sr">{% trans "Your Submission Status" %}:</span>
+                                              {{ save_status }}
+                                          </div>
+                                      </li>
+                                  </ul>
+                              </div>
+                          </li>
+                          {% endif %}
+                          {% if file_upload_type %}
+                            <h5 class="submission__upload__files__title">
+                              {% trans "File Uploads " %}
+                              {% if file_upload_response == "required" %}
+                                {% trans "(Required)" %}
+                              {% elif file_upload_response == "optional" %}
+                                {% trans "(Optional)" %}
+                              {% endif %}
+                            </h5>
+                            {% if team_name %}
+                              {% blocktrans %}
+                                  Upload files and review files uploaded by you and your teammates below. Be sure to add
+                                  descriptions to your files to help your teammates identify them.
+                              {% endblocktrans %}
+                            {% endif %}
+                            <li class="field">
+                                <div class="upload__error">
+                                    <div class="message message--inline message--error message--error-server" tabindex="-1">
+                                        <h5 class="message__title">{% trans "We could not upload files" %}</h5>
+                                        <div class="message__content"></div>
+                                    </div>
+                                </div>
+                                <div class="delete__error">
+                                    <div class="message message--inline message--error message--error-server" tabindex="-1">
+                                        <h5 class="message__title">{% trans "We could not delete files" %}</h5>
+                                        <div class="message__content"></div>
+                                    </div>
                                 </div>
 
-                                <ul class="list list--actions">
-                                    <li class="list--actions__item">
-                                        <button type="submit" class="action action--save submission__save" aria-describedby="response__save_status__{{ xblock_id }}" disabled>
-                                            {% trans "Save your progress" %}
-                                        </button>
-
-                                        <div id="response__save_status__{{ xblock_id }}" class="save__submission__label response__submission__label">
-                                            <span class="sr">{% trans "Your Submission Status" %}:</span>
-                                            {{ save_status }}
-                                        </div>
-                                    </li>
-                                </ul>
-                            </div>
-                        </li>
-                        {% endif %}
-                        {% if file_upload_type %}
-                          <h5 class="submission__upload__files__title">
-                            {% trans "File Uploads " %}
-                            {% if file_upload_response == "required" %}
-                              {% trans "(Required)" %}
-                            {% elif file_upload_response == "optional" %}
-                              {% trans "(Optional)" %}
-                            {% endif %}
-                          </h5>
-                          {% if team_name %}
-                            {% blocktrans %}
-                                Upload files and review files uploaded by you and your teammates below. Be sure to add
-                                descriptions to your files to help your teammates identify them.
-                            {% endblocktrans %}
+                                <label class="sr" for="submission_answer_upload_{{ xblock_id }}">
+                                  {% if allow_multiple_files %}
+                                      {% trans "Select one or more files to upload for this submission." %}
+                                  {% else %}
+                                      {% trans "Select a file to upload for this submission." %}
+                                  {% endif %}
+                                </label>
+                                <input type="file" class="submission__answer__upload file--upload" id="submission_answer_upload_{{ xblock_id }}" {% if allow_multiple_files %}multiple=""{% endif %} accept="{{white_listed_file_types|join:", "}}">
+                                <span>
+                                  {% trans "Supported file types: " %}{{ white_listed_file_types|join:", "}}
+                                </span>
+                                <button type="submit" class="file__upload action action--upload" disabled>
+                                  {% if allow_multiple_files %}
+                                      {% trans "Upload files" %}
+                                  {% else %}
+                                      {% trans "Upload file" %}
+                                  {% endif %}
+                                </button>
+                                <div class="files__descriptions"></div>
+                            </li>
                           {% endif %}
                           <li class="field">
-                              <div class="upload__error">
-                                  <div class="message message--inline message--error message--error-server" tabindex="-1">
-                                      <h5 class="message__title">{% trans "We could not upload files" %}</h5>
-                                      <div class="message__content"></div>
-                                  </div>
-                              </div>
-                              <div class="delete__error">
-                                  <div class="message message--inline message--error message--error-server" tabindex="-1">
-                                      <h5 class="message__title">{% trans "We could not delete files" %}</h5>
-                                      <div class="message__content"></div>
-                                  </div>
-                              </div>
-
-                              <label class="sr" for="submission_answer_upload_{{ xblock_id }}">
-                                {% if allow_multiple_files %}
-                                    {% trans "Select one or more files to upload for this submission." %}
-                                {% else %}
-                                    {% trans "Select a file to upload for this submission." %}
-                                {% endif %}
-                              </label>
-                              <input type="file" class="submission__answer__upload file--upload" id="submission_answer_upload_{{ xblock_id }}" {% if allow_multiple_files %}multiple=""{% endif %} accept="{{white_listed_file_types|join:", "}}">
-                              <span>
-                                {% trans "Supported file types: " %}{{ white_listed_file_types|join:", "}}
-                              </span>
-                              <button type="submit" class="file__upload action action--upload" disabled>
-                                {% if allow_multiple_files %}
-                                    {% trans "Upload files" %}
-                                {% else %}
-                                    {% trans "Upload file" %}
-                                {% endif %}
-                              </button>
-                              <div class="files__descriptions"></div>
+                          {% include "openassessmentblock/oa_uploaded_file.html" with file_upload_type=file_upload_type file_urls=file_urls class_prefix="submission__answer" including_template="response" xblock_id=xblock_id %}
                           </li>
-                        {% endif %}
-                        <li class="field">
-                        {% include "openassessmentblock/oa_uploaded_file.html" with file_upload_type=file_upload_type file_urls=file_urls class_prefix="submission__answer" including_template="response" xblock_id=xblock_id %}
-                        </li>
-                        <hr/>
-                        <li class="field">
-                        {% include "openassessmentblock/oa_team_uploaded_files.html" with file_upload_type=file_upload_type team_file_urls=team_file_urls class_prefix="submission__team__answer" including_template="response" xblock_id=xblock_id %}
-                        </li>
-                    </ol>
+                          <hr/>
+                          <li class="field">
+                          {% include "openassessmentblock/oa_team_uploaded_files.html" with file_upload_type=file_upload_type team_file_urls=team_file_urls class_prefix="submission__team__answer" including_template="response" xblock_id=xblock_id %}
+                          </li>
+                      </ol>
 
-                    {% if not team_name %}
-                        <span class="tip" id="submission__answer__tip__{{ xblock_id }}">{% trans "You may continue to work on your response until you submit it." %}</span>
-                    {% endif %}
-                </form>
-            </div>
-            {% if team_name %}
-              <div id='team_concurrency_notice'>
-                {% trans "This is a team submission." %}
-                {% if file_upload_type and text_response %}
-                    {% trans "One team member should submit a response with the team’s shared files and a text response on behalf of the entire team." %}
-                {% elif file_upload_type %}
-                    {% trans "One team member should submit a response with the team’s shared files on behalf of the entire team." %}
-                {% elif text_response %}
-                    {% trans "One team member should submit a text response on behalf of the entire team." %}
-                {% else %}
-                    {% trans "One team member should submit on behalf of the entire team."%}
-                {% endif %}
-                {% blocktrans %}
-                Learn more about team assignments here: (<a href="" >link</a>)
-                {% endblocktrans %}
+                      {% if not team_name %}
+                          <span class="tip" id="submission__answer__tip__{{ xblock_id }}">{% trans "You may continue to work on your response until you submit it." %}</span>
+                      {% endif %}
+                  </form>
               </div>
-            {% endif %}
+              {% if team_name %}
+                <div id='team_concurrency_notice'>
+                  {% trans "This is a team submission." %}
+                  {% if file_upload_type and text_response %}
+                      {% trans "One team member should submit a response with the team’s shared files and a text response on behalf of the entire team." %}
+                  {% elif file_upload_type %}
+                      {% trans "One team member should submit a response with the team’s shared files on behalf of the entire team." %}
+                  {% elif text_response %}
+                      {% trans "One team member should submit a text response on behalf of the entire team." %}
+                  {% else %}
+                      {% trans "One team member should submit on behalf of the entire team."%}
+                  {% endif %}
+                  {% blocktrans %}
+                  Learn more about team assignments here: (<a href="" >link</a>)
+                  {% endblocktrans %}
+                </div>
+              {% endif %}
 
-            {% if has_real_user %}
               <div class="step__actions">
-                  <div class="message message--inline message--error message--error-server" tabindex="-1">
-                      <h5 class="message__title">{% trans "We could not submit your response" %}</h5>
-                      <div class="message__content"></div>
-                  </div>
+                <div class="message message--inline message--error message--error-server" tabindex="-1">
+                    <h5 class="message__title">{% trans "We could not submit your response" %}</h5>
+                    <div class="message__content"></div>
+                </div>
 
-                  <ul class="list list--actions">
-                      <li class="list--actions__item">
-                          <button type="submit" class="action action--submit step--response__submit"
-                                  text_response="{{text_response}}"
-                                  file_upload_response="{{file_upload_response}}"
-                                  {{submit_enabled|yesno:",disabled" }}>
-                              {% trans "Submit your response and move to the next step" %}
-                          </button>
-                      </li>
-                  </ul>
-              </div>
-            {% endif %}
+                <ul class="list list--actions">
+                    <li class="list--actions__item">
+                        <button type="submit" class="action action--submit step--response__submit"
+                                text_response="{{text_response}}"
+                                file_upload_response="{{file_upload_response}}"
+                                {{submit_enabled|yesno:",disabled" }}>
+                            {% trans "Submit your response and move to the next step" %}
+                        </button>
+                    </li>
+                </ul>
+            </div>
+          {% endif %}
         </div>
     </div>
     {% endblock %}

--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -317,23 +317,25 @@
               </div>
             {% endif %}
 
-            <div class="step__actions">
-                <div class="message message--inline message--error message--error-server" tabindex="-1">
-                    <h5 class="message__title">{% trans "We could not submit your response" %}</h5>
-                    <div class="message__content"></div>
-                </div>
+            {% if has_real_user %}
+              <div class="step__actions">
+                  <div class="message message--inline message--error message--error-server" tabindex="-1">
+                      <h5 class="message__title">{% trans "We could not submit your response" %}</h5>
+                      <div class="message__content"></div>
+                  </div>
 
-                <ul class="list list--actions">
-                    <li class="list--actions__item">
-                        <button type="submit" class="action action--submit step--response__submit"
-                                text_response="{{text_response}}"
-                                file_upload_response="{{file_upload_response}}"
-                                {{submit_enabled|yesno:",disabled" }}>
-                            {% trans "Submit your response and move to the next step" %}
-                        </button>
-                    </li>
-                </ul>
-            </div>
+                  <ul class="list list--actions">
+                      <li class="list--actions__item">
+                          <button type="submit" class="action action--submit step--response__submit"
+                                  text_response="{{text_response}}"
+                                  file_upload_response="{{file_upload_response}}"
+                                  {{submit_enabled|yesno:",disabled" }}>
+                              {% trans "Submit your response and move to the next step" %}
+                          </button>
+                      </li>
+                  </ul>
+              </div>
+            {% endif %}
         </div>
     </div>
     {% endblock %}

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -751,6 +751,18 @@ class OpenAssessmentBlock(MessageMixin,
         # student ID, so we can't rely on that)
         return self.scope_ids.user_id is None
 
+    @property
+    def in_studio(self):
+        """
+        Checks whether we are in Studio view
+
+        Returns:
+            bool
+        """
+        if hasattr(self, 'xmodule_runtime'):
+            return self.xmodule_runtime.get_real_user is None  # pylint: disable=no-member
+        return False
+
     def _create_ui_models(self):
         """Combine UI attributes and XBlock configuration into a UI model.
 

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -752,15 +752,15 @@ class OpenAssessmentBlock(MessageMixin,
         return self.scope_ids.user_id is None
 
     @property
-    def in_studio(self):
+    def has_real_user(self):
         """
-        Checks whether we are in Studio view
+        Checks whether the runtime is tied to a real user
 
         Returns:
             bool
         """
         if hasattr(self, 'xmodule_runtime'):
-            return self.xmodule_runtime.get_real_user is None  # pylint: disable=no-member
+            return self.xmodule_runtime.get_real_user is not None  # pylint: disable=no-member
         return False
 
     def _create_ui_models(self):

--- a/openassessment/xblock/static/js/fixtures/templates.json
+++ b/openassessment/xblock/static/js/fixtures/templates.json
@@ -89,6 +89,7 @@
             "text_response": "required",
             "file_upload_response": "optional",
             "file_upload_type": "pdf-and-image",
+            "has_real_user": true,
             "saved_response": {
                 "answer": {
                     "parts": [

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -865,6 +865,7 @@ class SubmissionMixin:
             "prompts_type": self.prompts_type,
             "enable_delete_files": False,
             "show_rubric_during_response": self.show_rubric_during_response,
+            "in_studio": self.in_studio,
         }
 
         if self.show_rubric_during_response:

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -856,16 +856,16 @@ class SubmissionMixin:
 
         path = 'openassessmentblock/response/oa_response.html'
         context = {
-            'user_timezone': user_preferences['user_timezone'],
+            'enable_delete_files': False,
+            'file_upload_response': self.file_upload_response,
+            'has_real_user': self.has_real_user,
+            'prompts_type': self.prompts_type,
+            'show_rubric_during_response': self.show_rubric_during_response,
+            'text_response': self.text_response,
+            'text_response_editor': self.text_response_editor,
             'user_language': user_preferences['user_language'],
-            "xblock_id": self.get_xblock_id(),
-            "text_response": self.text_response,
-            "text_response_editor": self.text_response_editor,
-            "file_upload_response": self.file_upload_response,
-            "prompts_type": self.prompts_type,
-            "enable_delete_files": False,
-            "show_rubric_during_response": self.show_rubric_during_response,
-            "in_studio": self.in_studio,
+            'user_timezone': user_preferences['user_timezone'],
+            'xblock_id': self.get_xblock_id(),
         }
 
         if self.show_rubric_during_response:

--- a/openassessment/xblock/test/test_save_files_descriptions.py
+++ b/openassessment/xblock/test/test_save_files_descriptions.py
@@ -9,7 +9,6 @@ from unittest import mock
 
 from .base import XBlockHandlerTestCase, scenario
 
-
 class SaveFilesDescriptionsTest(XBlockHandlerTestCase):
     """
     Group of tests to check ability to save files descriptions
@@ -32,6 +31,13 @@ class SaveFilesDescriptionsTest(XBlockHandlerTestCase):
         """
         # We're not worried about looking up shared uploads in this test
         xblock.has_team = mock.Mock(return_value=False)
+
+        xblock.xmodule_runtime = mock.Mock(
+            user_is_staff=False,
+            user_is_beta_tester=False,
+            course_id='test_course',
+            anonymous_student_id='Pmn'
+        )
 
         # Save the response
         descriptions = [{'description': "Ѕраѓтаиѕ! ГоиіБЂт, Щэ ↁіиэ іи Нэll!", 'fileName': 'fname1', 'fileSize': 1000},
@@ -58,6 +64,13 @@ class SaveFilesDescriptionsTest(XBlockHandlerTestCase):
         """
         # We're not worried about looking up shared uploads in this test
         xblock.has_team = mock.Mock(return_value=False)
+
+        xblock.xmodule_runtime = mock.Mock(
+            user_is_staff=False,
+            user_is_beta_tester=False,
+            course_id='test_course',
+            anonymous_student_id='Pmn'
+        )
 
         descriptions1 = [
             {'description': "Ѕраѓтаиѕ! ГоиіБЂт, Щэ ↁіиэ іи Нэll!", 'fileName': 'fname1', 'fileSize': 1000},

--- a/openassessment/xblock/test/test_save_files_descriptions.py
+++ b/openassessment/xblock/test/test_save_files_descriptions.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 from .base import XBlockHandlerTestCase, scenario
 
+
 class SaveFilesDescriptionsTest(XBlockHandlerTestCase):
     """
     Group of tests to check ability to save files descriptions

--- a/openassessment/xblock/test/test_save_response.py
+++ b/openassessment/xblock/test/test_save_response.py
@@ -18,6 +18,14 @@ class SaveResponseTest(XBlockHandlerTestCase):
     @scenario('data/save_scenario.xml', user_id="Daniels")
     def test_default_saved_response_blank(self, xblock):
         xblock.get_team_info = mock.Mock(return_value={})
+
+        xblock.xmodule_runtime = mock.Mock(
+            user_is_staff=False,
+            user_is_beta_tester=False,
+            course_id='test_course',
+            anonymous_student_id='Pmn'
+        )
+
         resp = self.request(xblock, 'render_submission', json.dumps({}))
         self.assertIn('response has not been saved', resp.decode('utf-8'))
 
@@ -25,6 +33,13 @@ class SaveResponseTest(XBlockHandlerTestCase):
     @scenario('data/save_scenario.xml', user_id="Perleman")
     def test_save_response(self, xblock, data):
         xblock.get_team_info = mock.Mock(return_value={})
+
+        xblock.xmodule_runtime = mock.Mock(
+            user_is_staff=False,
+            user_is_beta_tester=False,
+            course_id='test_course',
+            anonymous_student_id='Pmn'
+        )
 
         # Save the response
         submission = ["  ".join(data[0]), "  ".join(data[1])]

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -1015,6 +1015,13 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
 
         xblock.file_manager.append_uploads(*file_uploads)
 
+        xblock.xmodule_runtime = Mock(
+            user_is_staff=False,
+            user_is_beta_tester=False,
+            course_id='test_course',
+            anonymous_student_id='Pmn'
+        )
+
         # delete file-2
         with patch('openassessment.fileupload.api.remove_file'):
             xblock.file_manager.delete_upload(1)
@@ -1202,6 +1209,13 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         ])
 
         mock_get_download_url.side_effect = ['file-1-url', 'file-5-url']
+
+        xblock.xmodule_runtime = Mock(
+            user_is_staff=False,
+            user_is_beta_tester=False,
+            course_id='test_course',
+            anonymous_student_id='Pmn'
+        )
 
         # assert that there's an entry with the correct index in the rendered HTML
         # we should have an index for all files ever uploaded, even the deleted one

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -693,18 +693,19 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response_unavailable.html',
             {
-                'text_response': 'required',
-                'text_response_editor': 'text',
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'submission_start': dt.datetime(4999, 4, 1).replace(tzinfo=pytz.utc),
-                'allow_multiple_files': True,
-                'show_rubric_during_response': False,
-                'allow_latex': False,
-                'user_timezone': None,
-                'user_language': None,
+                'in_studio': False,
                 'prompts_type': 'text',
-                'enable_delete_files': False,
+                'show_rubric_during_response': False,
+                'submission_start': dt.datetime(4999, 4, 1).replace(tzinfo=pytz.utc),
+                'text_response': 'required',
+                'text_response_editor': 'text',
+                'user_language': None,
+                'user_timezone': None,
             }
         )
 
@@ -722,20 +723,21 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response_submitted.html',
             {
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': False,
+                'file_upload_response': None,
+                'file_upload_type': None,
+                'in_studio': False,
+                'peer_incomplete': True,
+                'prompts_type': 'text',
+                'self_incomplete': True,
+                'show_rubric_during_response': False,
                 'student_submission': create_submission_dict(submission, xblock.prompts),
                 'text_response': 'required',
                 'text_response_editor': 'text',
-                'file_upload_response': None,
-                'file_upload_type': None,
-                'peer_incomplete': True,
-                'self_incomplete': True,
-                'show_rubric_during_response': False,
-                'allow_multiple_files': True,
-                'allow_latex': False,
-                'user_timezone': None,
                 'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': False,
+                'user_timezone': None,
             }
         )
 
@@ -744,25 +746,26 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response.html',
             {
-                'text_response': 'required',
-                'text_response_editor': 'text',
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': True,
                 'file_upload_response': None,
                 'file_upload_type': None,
+                'in_studio': False,
+                'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
                         ("", "")
                     )
                 }, xblock.prompts),
                 'save_status': 'This response has not been saved.',
-                'submit_enabled': False,
-                'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
-                'allow_multiple_files': True,
                 'show_rubric_during_response': False,
-                'allow_latex': False,
+                'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
+                'submit_enabled': False,
+                'text_response': 'required',
+                'text_response_editor': 'text',
                 'user_timezone': None,
                 'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': True,
             }
         )
 
@@ -782,30 +785,31 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response.html',
             {
-                'text_response': 'required',
-                'text_response_editor': 'text',
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': True,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'allow_multiple_files': True,
-                'show_rubric_during_response': False,
+                'in_studio': False,
+                'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
                         ("", "")
                     )
                 }, xblock.prompts),
                 'save_status': 'This response has not been saved.',
+                'show_rubric_during_response': False,
                 'submit_enabled': False,
                 'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
                 'team_id': mock_team['team_id'],
+                'team_members_with_external_submissions': '',
                 'team_name': mock_team['team_name'],
                 'team_url': mock_team['team_url'],
                 'team_usernames': mock_team['team_usernames'],
-                'team_members_with_external_submissions': '',
-                'allow_latex': False,
-                'user_timezone': None,
+                'text_response': 'required',
+                'text_response_editor': 'text',
                 'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': True,
+                'user_timezone': None,
             }
         )
 
@@ -905,24 +909,25 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response.html',
             {
-                'text_response': 'required',
-                'text_response_editor': 'text',
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': True,
                 'file_upload_response': None,
                 'file_upload_type': None,
+                'in_studio': False,
+                'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
                         ("", "")
                     )
                 }, xblock.prompts),
                 'save_status': 'This response has not been saved.',
-                'submit_enabled': False,
-                'allow_multiple_files': True,
                 'show_rubric_during_response': False,
-                'allow_latex': False,
+                'submit_enabled': False,
+                'text_response': 'required',
+                'text_response_editor': 'text',
                 'user_timezone': None,
                 'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': True,
             }
         )
 
@@ -943,25 +948,26 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response.html',
             {
-                'text_response': 'required',
-                'text_response_editor': 'text',
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': True,
                 'file_upload_response': None,
                 'file_upload_type': None,
+                'in_studio': False,
+                'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
                         ('A man must have a code', 'A man must have an umbrella too.')
                     )
                 }, xblock.prompts),
                 'save_status': 'This response has been saved but not submitted.',
-                'submit_enabled': True,
-                'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
-                'allow_multiple_files': True,
                 'show_rubric_during_response': False,
-                'allow_latex': False,
-                'user_timezone': None,
+                'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
+                'submit_enabled': True,
+                'text_response': 'required',
+                'text_response_editor': 'text',
                 'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': True,
+                'user_timezone': None,
             }
         )
 
@@ -1094,29 +1100,30 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response.html',
             {
-                'text_response': None,
-                'text_response_editor': 'text',
+                'allow_latex': False,
                 'allow_multiple_files': True,
-                'show_rubric_during_response': False,
+                'enable_delete_files': True,
                 'file_upload_response': 'optional',
                 'file_upload_type': 'pdf-and-image',
                 'file_urls': [
                     {'download_url': '', 'description': 'file-1', 'name': None, 'show_delete_button': True},
                     {'download_url': '', 'description': 'file-2', 'name': None, 'show_delete_button': True}
                 ],
-                'team_file_urls': [],
+                'in_studio': False,
+                'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
                         ('A man must have a code', 'A man must have an umbrella too.')
                     )
                 }, xblock.prompts),
                 'save_status': 'This response has been saved but not submitted.',
+                'show_rubric_during_response': False,
                 'submit_enabled': True,
-                'allow_latex': False,
-                'user_timezone': None,
+                'team_file_urls': [],
+                'text_response': None,
+                'text_response_editor': 'text',
                 'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': True,
+                'user_timezone': None,
                 'white_listed_file_types': ['.pdf', '.gif', '.jpg', '.jpgeg', '.jfif', '.pjpeg', '.pjp', '.png']
             }
         )
@@ -1225,25 +1232,26 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response.html',
             {
-                'text_response': 'required',
-                'text_response_editor': 'text',
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': True,
                 'file_upload_response': None,
                 'file_upload_type': None,
+                'in_studio': False,
+                'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
                         ('An old format response.',)
                     )
                 }, xblock.prompts),
                 'save_status': 'This response has been saved but not submitted.',
-                'submit_enabled': True,
-                'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
-                'allow_multiple_files': True,
                 'show_rubric_during_response': False,
-                'allow_latex': False,
-                'user_timezone': None,
+                'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
+                'submit_enabled': True,
+                'text_response': 'required',
+                'text_response_editor': 'text',
                 'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': True,
+                'user_timezone': None,
             }
         )
 
@@ -1274,21 +1282,22 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response_submitted.html',
             {
-                'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
-                'student_submission': create_submission_dict(submission, xblock.prompts),
-                'text_response': 'required',
-                'text_response_editor': 'text',
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
+                'in_studio': False,
                 'peer_incomplete': True,
+                'prompts_type': 'text',
                 'self_incomplete': True,
                 'show_rubric_during_response': False,
-                'allow_multiple_files': True,
-                'allow_latex': False,
-                'user_timezone': None,
+                'student_submission': create_submission_dict(submission, xblock.prompts),
+                'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
+                'text_response': 'required',
+                'text_response_editor': 'text',
                 'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': False,
+                'user_timezone': None,
             }
         )
 
@@ -1310,15 +1319,20 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response_cancelled.html',
             {
-                'text_response': 'required',
-                'text_response_editor': 'text',
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'allow_multiple_files': True,
+                'in_studio': False,
+                'prompts_type': 'text',
                 'show_rubric_during_response': False,
-                'allow_latex': False,
-                'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
                 'student_submission': submission,
+                'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
+                'text_response': 'required',
+                'text_response_editor': 'text',
+                'user_language': None,
+                'user_timezone': None,
                 'workflow_cancellation': {
                     'comments': 'Inappropriate language',
                     'cancelled_at': xblock.get_workflow_cancellation_info(
@@ -1326,10 +1340,6 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                     'cancelled_by_id': 'Bob',
                     'cancelled_by': mock_staff
                 },
-                'user_timezone': None,
-                'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': False,
             }
         )
 
@@ -1367,16 +1377,21 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response_cancelled.html',
             {
-                'text_response': 'required',
-                'text_response_editor': 'text',
-                'file_upload_response': None,
-                'allow_multiple_files': True,
-                'show_rubric_during_response': False,
-                'file_upload_type': None,
                 'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': False,
+                'file_upload_response': None,
+                'file_upload_type': None,
+                'in_studio': False,
+                'prompts_type': 'text',
+                'show_rubric_during_response': False,
+                'student_submission': student_submission,
                 # date listed in xml scenario.
                 'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
-                'student_submission': student_submission,
+                'text_response': 'required',
+                'text_response_editor': 'text',
+                'user_language': None,
+                'user_timezone': None,
                 'workflow_cancellation': {
                     'comments': comments,
                     'cancelled_at': xblock.get_team_workflow_cancellation_info(
@@ -1384,10 +1399,6 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                     'cancelled_by_id': staff_id,
                     'cancelled_by': mock_staff
                 },
-                'user_timezone': None,
-                'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': False,
             }
         )
 
@@ -1405,23 +1416,24 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response_submitted.html',
             {
-                'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': False,
+                'file_upload_response': None,
+                'file_upload_type': None,
+                'in_studio': False,
+                'peer_incomplete': True,
+                'prompts_type': 'text',
+                'self_incomplete': True,
+                'show_rubric_during_response': False,
                 'student_submission': {"answer": {"parts": [
                     {"prompt": {'description': 'One prompt.'}, "text": "An old format response."}
                 ]}},
+                'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
                 'text_response': 'required',
                 'text_response_editor': 'text',
-                'file_upload_response': None,
-                'file_upload_type': None,
-                'peer_incomplete': True,
-                'self_incomplete': True,
-                'show_rubric_during_response': False,
-                'allow_multiple_files': True,
-                'allow_latex': False,
-                'user_timezone': None,
                 'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': False,
+                'user_timezone': None,
             }
         )
 
@@ -1430,18 +1442,19 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response_closed.html',
             {
-                'text_response': 'required',
-                'text_response_editor': 'text',
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'submission_due': dt.datetime(2014, 4, 5).replace(tzinfo=pytz.utc),
-                'allow_multiple_files': True,
-                'show_rubric_during_response': False,
-                'allow_latex': False,
-                'user_timezone': None,
-                'user_language': None,
+                'in_studio': False,
                 'prompts_type': 'text',
-                'enable_delete_files': False,
+                'show_rubric_during_response': False,
+                'submission_due': dt.datetime(2014, 4, 5).replace(tzinfo=pytz.utc),
+                'text_response': 'required',
+                'text_response_editor': 'text',
+                'user_language': None,
+                'user_timezone': None,
             }
         )
 
@@ -1454,21 +1467,22 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response_submitted.html',
             {
-                'submission_due': dt.datetime(2014, 4, 5).replace(tzinfo=pytz.utc),
-                'student_submission': create_submission_dict(submission, xblock.prompts),
-                'text_response': 'required',
-                'text_response_editor': 'text',
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
+                'in_studio': False,
                 'peer_incomplete': False,
+                'prompts_type': 'text',
                 'self_incomplete': True,
                 'show_rubric_during_response': False,
-                'allow_multiple_files': True,
-                'allow_latex': False,
-                'user_timezone': None,
+                'student_submission': create_submission_dict(submission, xblock.prompts),
+                'submission_due': dt.datetime(2014, 4, 5).replace(tzinfo=pytz.utc),
+                'text_response': 'required',
+                'text_response_editor': 'text',
                 'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': False,
+                'user_timezone': None,
             }
         )
 
@@ -1489,19 +1503,20 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response_graded.html',
             {
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': False,
+                'file_upload_response': None,
+                'file_upload_type': None,
+                'in_studio': False,
+                'prompts_type': 'text',
+                'show_rubric_during_response': False,
                 'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
                 'student_submission': create_submission_dict(submission, xblock.prompts),
                 'text_response': 'required',
                 'text_response_editor': 'text',
-                'file_upload_response': None,
-                'file_upload_type': None,
-                'show_rubric_during_response': False,
-                'allow_multiple_files': True,
-                'allow_latex': False,
-                'user_timezone': None,
                 'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': False,
+                'user_timezone': None,
             }
         )
 
@@ -1522,19 +1537,20 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response_graded.html',
             {
-                'submission_due': dt.datetime(2014, 4, 5).replace(tzinfo=pytz.utc),
-                'student_submission': create_submission_dict(submission, xblock.prompts),
-                'text_response': 'required',
-                'text_response_editor': 'text',
+                'allow_latex': False,
+                'allow_multiple_files': True,
+                'enable_delete_files': False,
+                'in_studio': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'show_rubric_during_response': False,
-                'allow_multiple_files': True,
-                'allow_latex': False,
-                'user_timezone': None,
-                'user_language': None,
                 'prompts_type': 'text',
-                'enable_delete_files': False,
+                'show_rubric_during_response': False,
+                'student_submission': create_submission_dict(submission, xblock.prompts),
+                'submission_due': dt.datetime(2014, 4, 5).replace(tzinfo=pytz.utc),
+                'text_response': 'required',
+                'text_response_editor': 'text',
+                'user_language': None,
+                'user_timezone': None,
             }
         )
 
@@ -1708,24 +1724,25 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                     )
                 }, xblock.prompts),
                 'allow_latex': False,
-                'team_id': MOCK_TEAM_ID,
-                'user_timezone': None,
-                'team_usernames': ['Red Leader', 'Red Two', 'Red Five'],
-                'file_upload_response': None,
                 'allow_multiple_files': True,
+                'enable_delete_files': True,
+                'in_studio': False,
+                'file_upload_response': None,
+                'file_upload_type': None,
+                'prompts_type': 'text',
+                'save_status': 'This response has not been saved.',
                 'show_rubric_during_response': False,
                 'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
-                'file_upload_type': None,
                 'submit_enabled': False,
-                'prompts_type': 'text',
-                'user_language': None,
-                'enable_delete_files': True,
-                'team_url': 'rebel_alliance.org',
-                'save_status': 'This response has not been saved.',
+                'team_id': MOCK_TEAM_ID,
                 'team_name': 'Red Squadron',
+                'team_members_with_external_submissions': '',
+                'team_url': 'rebel_alliance.org',
+                'team_usernames': ['Red Leader', 'Red Two', 'Red Five'],
                 'text_response': 'required',
                 'text_response_editor': 'text',
-                'team_members_with_external_submissions': ''
+                'user_language': None,
+                'user_timezone': None,
             }
         )
 
@@ -1738,27 +1755,28 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         self._assert_path_and_context(
             xblock, 'openassessmentblock/response/oa_response.html',
             {
-                'text_response': 'required',
-                'text_response_editor': 'text',
-                'file_upload_response': 'optional',
+                'allow_latex': False,
                 'allow_multiple_files': True,
-                'show_rubric_during_response': False,
+                'enable_delete_files': True,
+                'file_upload_response': 'optional',
                 'file_upload_type': 'pdf-and-image',
                 'file_urls': [],
-                'team_file_urls': [],
-                'white_listed_file_types': ['.pdf', '.gif', '.jpg', '.jpgeg', '.jfif', '.pjpeg', '.pjp', '.png'],
+                'in_studio': False,
+                'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
                         ("", "")
                     )
                 }, xblock.prompts),
                 'save_status': 'This response has not been saved.',
+                'show_rubric_during_response': False,
                 'submit_enabled': False,
-                'allow_latex': False,
+                'team_file_urls': [],
+                'text_response': 'required',
+                'text_response_editor': 'text',
                 'user_timezone': None,
                 'user_language': None,
-                'prompts_type': 'text',
-                'enable_delete_files': True,
+                'white_listed_file_types': ['.pdf', '.gif', '.jpg', '.jpgeg', '.jfif', '.pjpeg', '.pjp', '.png'],
             }
         )
 

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -698,7 +698,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': False,
                 'prompts_type': 'text',
                 'show_rubric_during_response': False,
                 'submission_start': dt.datetime(4999, 4, 1).replace(tzinfo=pytz.utc),
@@ -728,7 +728,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': False,
                 'peer_incomplete': True,
                 'prompts_type': 'text',
                 'self_incomplete': True,
@@ -751,7 +751,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': True,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': False,
                 'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
@@ -790,7 +790,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': True,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': True,
                 'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
@@ -914,7 +914,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': True,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': False,
                 'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
@@ -953,7 +953,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': True,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': False,
                 'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
@@ -1109,7 +1109,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                     {'download_url': '', 'description': 'file-1', 'name': None, 'show_delete_button': True},
                     {'download_url': '', 'description': 'file-2', 'name': None, 'show_delete_button': True}
                 ],
-                'in_studio': False,
+                'has_real_user': False,
                 'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
@@ -1237,7 +1237,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': True,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': False,
                 'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(
@@ -1287,7 +1287,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': False,
                 'peer_incomplete': True,
                 'prompts_type': 'text',
                 'self_incomplete': True,
@@ -1324,7 +1324,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': False,
                 'prompts_type': 'text',
                 'show_rubric_during_response': False,
                 'student_submission': submission,
@@ -1382,7 +1382,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': True,
                 'prompts_type': 'text',
                 'show_rubric_during_response': False,
                 'student_submission': student_submission,
@@ -1421,7 +1421,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': False,
                 'peer_incomplete': True,
                 'prompts_type': 'text',
                 'self_incomplete': True,
@@ -1447,7 +1447,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': False,
                 'prompts_type': 'text',
                 'show_rubric_during_response': False,
                 'submission_due': dt.datetime(2014, 4, 5).replace(tzinfo=pytz.utc),
@@ -1472,7 +1472,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': False,
                 'peer_incomplete': False,
                 'prompts_type': 'text',
                 'self_incomplete': True,
@@ -1508,7 +1508,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'enable_delete_files': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
-                'in_studio': False,
+                'has_real_user': False,
                 'prompts_type': 'text',
                 'show_rubric_during_response': False,
                 'submission_due': dt.datetime(2999, 5, 6).replace(tzinfo=pytz.utc),
@@ -1540,7 +1540,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'allow_latex': False,
                 'allow_multiple_files': True,
                 'enable_delete_files': False,
-                'in_studio': False,
+                'has_real_user': False,
                 'file_upload_response': None,
                 'file_upload_type': None,
                 'prompts_type': 'text',
@@ -1726,7 +1726,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'allow_latex': False,
                 'allow_multiple_files': True,
                 'enable_delete_files': True,
-                'in_studio': False,
+                'has_real_user': True,
                 'file_upload_response': None,
                 'file_upload_type': None,
                 'prompts_type': 'text',
@@ -1761,7 +1761,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'file_upload_response': 'optional',
                 'file_upload_type': 'pdf-and-image',
                 'file_urls': [],
-                'in_studio': False,
+                'has_real_user': False,
                 'prompts_type': 'text',
                 'saved_response': create_submission_dict({
                     'answer': prepare_submission_for_serialization(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.6.18",
+  "version": "3.6.19",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.6.0",


### PR DESCRIPTION
**TL;DR -** 
Added a has_real_user prop based on whether the runtime is bound to a real user.

This is now linked such that nothing below the response shows up if it is true.

JIRA: [AU-58](https://openedx.atlassian.net/browse/AU-58)

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

View an ORA in studio and verify the Save, file upload, and actions (submit button) don't show up
Verify that they do for the LMS view.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [x] I've tested the new functionality

FYI: @edx/masters-devs-gta
