### PR TITLE
Skip "missing" students in submission ZIP

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -1248,10 +1248,15 @@ class OraDownloadData:
         logger.info("[%s] Loaded student identifiers (len=%d)", course_id, len(student_identifiers_map))
 
         for student, submission, _ in all_submission_information:
-            # If course staff creates a submission from the studio preview, they will create a submission for
-            # a student called `student` with no mapping to a real django User
+            # Submissions created from the studio authoring view will create a submission for
+            # a student called `student` with no mapping to a real django User. Doing so should no longer be allowed,
+            # but this remains for backwards compatibility.
             if student['student_id'] not in student_identifiers_map:
-                logger.info("[%s] Student id %s has no mapping to a user and will be skipped")
+                logger.info(
+                    "[%s] Student id %s has no mapping to a user and will be skipped",
+                    course_id,
+                    student['student_id']
+                )
                 continue
 
             logger.info(

--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -1248,6 +1248,12 @@ class OraDownloadData:
         logger.info("[%s] Loaded student identifiers (len=%d)", course_id, len(student_identifiers_map))
 
         for student, submission, _ in all_submission_information:
+            # If course staff creates a submission from the studio preview, they will create a submission for
+            # a student called `student` with no mapping to a real django User
+            if student['student_id'] not in student_identifiers_map:
+                logger.info("[%s] Student id %s has no mapping to a user and will be skipped")
+                continue
+
             logger.info(
                 "[%s] Collecting files for %s, submission %s ",
                 course_id,

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -1272,20 +1272,13 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
         workflow_api.create_workflow(submission_uuid, steps if steps else STEPS)
         return submission
 
-    @patch(
-        'openassessment.data.OraDownloadData._map_ora_usage_keys_to_path_info',
-        Mock(return_value={ITEM_ID: ITEM_PATH_INFO})
-    )
-    @patch(
-        'openassessment.data.OraDownloadData._map_student_ids_to_path_ids',
-        Mock(return_value=USERNAME_MAPPING)
-    )
-    def test_collect_ora2_submission_files(self):
+    def _override_default_answers(self):
         """
-        Test that `collect_ora2_submission_files` returns correct set of
-        submission texts and attachments for a given course.
+        _create_submission creates lightweight "dummy" submissons,
+        with an answer defined as the constant ANSWER in this file.
+        This method modifies the answer values for tests that actually
+        care about the values of the answers
         """
-
         submission = sub_api._get_submission_model(self.submission['uuid'])  # pylint: disable=protected-access
         submission.answer = self.answer
         submission.save()
@@ -1309,8 +1302,39 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
         scorer_submission.answer = {'parts': []}
         scorer_submission.save()
 
+    @patch(
+        'openassessment.data.OraDownloadData._map_ora_usage_keys_to_path_info',
+        Mock(return_value={ITEM_ID: ITEM_PATH_INFO})
+    )
+    @patch(
+        'openassessment.data.OraDownloadData._map_student_ids_to_path_ids',
+        Mock(return_value=USERNAME_MAPPING)
+    )
+    def test_collect_ora2_submission_files(self):
+        """
+        Test that `collect_ora2_submission_files` returns correct set of
+        submission texts and attachments for a given course.
+        """
+        self._override_default_answers()
         collected_ora_files_data = list(OraDownloadData.collect_ora2_submission_files(COURSE_ID))
         assert collected_ora_files_data == self.submission_files_data
+
+    @patch(
+        'openassessment.data.OraDownloadData._map_ora_usage_keys_to_path_info',
+        Mock(return_value={ITEM_ID: ITEM_PATH_INFO})
+    )
+    def test_collect_ora2_submission_files__no_user(self):
+        """
+        Test for behavior when a user isn't included in the username map
+        """
+        self._override_default_answers()
+        username_mapping_no_default_student = USERNAME_MAPPING.copy()
+        del username_mapping_no_default_student[STUDENT_ID]
+
+        with patch('openassessment.data.OraDownloadData._map_student_ids_to_path_ids') as mock_map_student_ids:
+            mock_map_student_ids.return_value = username_mapping_no_default_student
+            with self.assertRaises(KeyError):
+                list(OraDownloadData.collect_ora2_submission_files(COURSE_ID))
 
     def test_create_zip_with_attachments(self):
         """

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -1333,8 +1333,13 @@ class TestOraDownloadDataIntegration(TransactionCacheResetTest):
 
         with patch('openassessment.data.OraDownloadData._map_student_ids_to_path_ids') as mock_map_student_ids:
             mock_map_student_ids.return_value = username_mapping_no_default_student
-            with self.assertRaises(KeyError):
-                list(OraDownloadData.collect_ora2_submission_files(COURSE_ID))
+            collected_ora_files_data = list(OraDownloadData.collect_ora2_submission_files(COURSE_ID))
+
+        expected_files = [
+            expected_file for expected_file in self.submission_files_data
+            if expected_file.get('student_id') != STUDENT_ID
+        ]
+        assert collected_ora_files_data == expected_files
 
     def test_create_zip_with_attachments(self):
         """

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.6.17",
+  "version": "3.6.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.6.17",
+  "version": "3.6.18",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.6.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='3.6.17',
+    version='3.6.18',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** Skip "missing" students in submission ZIP

JIRA: [AU-74](https://openedx.atlassian.net/browse/AU-74)

**What changed?**

If a student isn't in the student to username map, it means the submission was made referencing a nonexistant User. The only known situation in which this can happen is if a course staff creates a submission from the studio author view.

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

Before fix, first commit:
Create an ora, release it, and make a submission through the studio author view.
Then navigate to the instructor dashboard and generate the submission zip.

Check the lms logs. There should be a report of a keyerror.

After fix, second commit:
Generate the file again. It should generate and show up on the instructor dashboard (although you may not be able to download it dur to devstack-yness

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
