### PR TITLE
feat: add toggle feature for enhanced staff grade

### DIFF
--- a/openassessment/xblock/config_mixin.py
+++ b/openassessment/xblock/config_mixin.py
@@ -15,12 +15,14 @@ ALL_FILES_URLS = 'all_files_urls'
 TEAM_SUBMISSIONS = 'team_submissions'
 USER_STATE_UPLOAD_DATA = 'user_state_upload_data'
 RUBRIC_REUSE = 'rubric_reuse'
+ENHANCED_STAFF_GRADER = 'enhanced_staff_grader'
 
 FEATURE_TOGGLES_BY_FLAG_NAME = {
     ALL_FILES_URLS: 'ENABLE_ORA_ALL_FILE_URLS',
     TEAM_SUBMISSIONS: 'ENABLE_ORA_TEAM_SUBMISSIONS',
     USER_STATE_UPLOAD_DATA: 'ENABLE_ORA_USER_STATE_UPLOAD_DATA',
     RUBRIC_REUSE: 'ENABLE_ORA_RUBRIC_REUSE',
+    ENHANCED_STAFF_GRADER: 'ENABLE_ENHANCED_STAFF_GRADER'
 }
 
 
@@ -167,3 +169,17 @@ class ConfigMixin:
         # .. toggle_creation_date: 2021-05-18
         # .. toggle_tickets:  https://openedx.atlassian.net/browse/EDUCATOR-5751
         return self.is_feature_enabled(RUBRIC_REUSE)
+
+    @cached_property
+    def is_enhanced_staff_grader_enabled(self):
+        """
+        Return a boolean indicating the enhanced staff grader feature is enabled or not.
+        """
+        # .. toggle_name: FEATURES['ENABLE_ENHANCED_STAFF_GRADER']
+        # .. toggle_implementation: WaffleFlag
+        # .. toggle_default: False
+        # .. toggle_description: Set to True to enable the enhanced staff grader feature
+        # .. toggle_use_cases: circuit_breaker
+        # .. toggle_creation_date: 2021-08-29
+        # .. toggle_tickets: https://openedx.atlassian.net/browse/AU-50
+        return self.is_feature_enabled(ENHANCED_STAFF_GRADER)

--- a/openassessment/xblock/test/test_config_mixin.py
+++ b/openassessment/xblock/test/test_config_mixin.py
@@ -14,7 +14,8 @@ from openassessment.xblock.config_mixin import (
     FEATURE_TOGGLES_BY_FLAG_NAME,
     TEAM_SUBMISSIONS,
     USER_STATE_UPLOAD_DATA,
-    RUBRIC_REUSE
+    RUBRIC_REUSE,
+    ENHANCED_STAFF_GRADER,
 )
 
 
@@ -122,6 +123,24 @@ class ConfigMixinTest(TestCase):
             waffle_flag_input,
             settings_input,
             'is_rubric_reuse_enabled',
+        )
+
+    @ddt.data(
+        *list(itertools.product([True, False, None], repeat=3))
+    )
+    @ddt.unpack
+    def test_enhanced_staff_grader_enabled(self, waffle_switch_input, waffle_flag_input, settings_input):
+        """
+        The enhanced staff grader feature is expected to be enabled only if:
+          1) The openresponseassessment.enhanced_staff_grader waffle flag is enabled
+          2) The settings.FEATURES['ENABLE_ENHANCED_STAFF_GRADER'] value is True
+        """
+        self._run_feature_toggle_test(
+            ENHANCED_STAFF_GRADER,
+            waffle_switch_input,
+            waffle_flag_input,
+            settings_input,
+            'is_enhanced_staff_grader_enabled',
         )
 
     def _run_feature_toggle_test(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.6.18",
+  "version": "3.6.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.6.19",
+  "version": "3.6.20",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.6.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='3.6.19',
+    version='3.6.20',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
- Create a django waffle addressable via the admin dashboard 
- Follow examples in code on approach
- Name the waffle `openresponseassessment.enhanced_staff_grader`

JIRA: [AU-50](https://openedx.atlassian.net/browse/AU-50)

**What changed?**

- The `toggle_implementation` was documented as `WaffleFlag`. I made personal judgement based on this [document](https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/implement_the_right_toggle_type.html).

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

1. Create a waffle flag on the admin page - _/admin/waffle/flag/_
2. Name `openresponseassessment.enhanced_staff_grader`
3. Set everyone to `Yes` or `No` to verify the test
4. Put a `breakpoint()` or `print(self.is_enhanced_staff_grader_enabled)` at [this line](https://github.com/edx/edx-ora2/blob/032ab926fcdb90c2ab09c6b265a74dd4e08cb440/openassessment/xblock/openassessmentblock.py#L528) to verify the value is `True/False` respectively to number *3*.
7. The added line should be hit on loading `ORA` to the screen.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
