### PR TITLE
fix: typo in reusable rubric copy

### DIFF
--- a/openassessment/templates/openassessmentblock/edit/oa_rubric_reuse.html
+++ b/openassessment/templates/openassessmentblock/edit/oa_rubric_reuse.html
@@ -4,7 +4,7 @@
     <h3>{% trans "Clone Rubric" %}<span id="rubric-reuse-collapse-icon"></span></h3>
     <div>
         {{ rubric_reuse_data|json_script:"openassessment_rubric_reuse_data" }}
-        <div class="openassessment_rubric_clone_block" id="openassessment_rubric_clone_description">{% trans "To clone a rubric from an existing published or unpublished draft, you can search by the Block ID. Note that cloning is one-way, meaning changes made after cloning will only effect the rubric being modified, and will not modify any rubric it was cloned from." %}</div>
+        <div class="openassessment_rubric_clone_block" id="openassessment_rubric_clone_description">{% trans "To clone a rubric from an existing published or unpublished draft, you can search by the Block ID. Note that cloning is one-way, meaning changes made after cloning will only affect the rubric being modified, and will not modify any rubric it was cloned from." %}</div>
         <div class="openassessment_rubric_clone_block" id="openassessment_rubric_clone_block_id">
             <span class="no-select"><b>{% trans "Block ID For this ORA:" %}  </b></span>{{ block_location }}
         </div>


### PR DESCRIPTION
**TL;DR -** 

fix a small typo from `effect` to `affect`

JIRA: [AU-363](https://openedx.atlassian.net/browse/AU-363)

**What changed?**

![image](https://user-images.githubusercontent.com/83240113/137972789-e256e487-d987-49ec-9f18-54c893532a35.png)

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
