### PR TITLE
fix: change how submission zip looks up block children

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -964,14 +964,15 @@ class OraDownloadData:
         where key is a string representation of ORA's usage key, and value is a dictionary with
         all information needed to build the submission file path.
         """
-
         blocks = _get_course_blocks(course_id)
+        logger.info("[%s] _get_course_blocks returned %d blocks", course_id, len(blocks))
 
         path_info = {}
 
         def children(usage_key, condition=None):
             # pylint: disable=filter-builtin-not-iterating
-            filtered = filter(condition, blocks.get_xblock_field(usage_key, 'children') or [])
+            child_blocks = blocks.get_children(usage_key)
+            filtered = filter(condition, child_blocks)
             for index, child in enumerate(filtered, 1):
                 yield index, blocks.get_xblock_field(child, 'display_name'), child
 
@@ -982,7 +983,7 @@ class OraDownloadData:
             for sub_section_index, sub_section_name, sub_section in children(section):
                 for unit_index, unit_name, unit in children(sub_section):
                     for block_index, block_name, block in children(unit, only_ora_blocks):
-                        path_info[str(block)] = {
+                        ora_block_path_info = {
                             "section_index": section_index,
                             "section_name": section_name,
                             "sub_section_index": sub_section_index,
@@ -992,6 +993,8 @@ class OraDownloadData:
                             "ora_index": block_index,
                             "ora_name": block_name,
                         }
+                        logger.info("[%s] ORA block found: %s", course_id, str(ora_block_path_info))
+                        path_info[str(block)] = ora_block_path_info
 
         return path_info
 


### PR DESCRIPTION
**TL;DR -** change how submission zip looks up block children

JIRA: [AU-374](https://openedx.atlassian.net/browse/AU-374)

**What changed?**

- There was a bug where the way that we look up child blocks in the ZIP download was not working
- It was a questionable approach anyways, so this is a change to the method that definitely works.
- I also added some additional logging. (My previous logging let me identify the issue way faster. Thanks, past me!)

**Testing Instructions**


1.  Install a local ORA. 
2. Go to a course with ORAs and submissions. Go to instructor dashboard -> data download and click "Generate submissions archive"
3.  Wait for the task to complete. You will see a link, but we cannot click it in devstack.
4. To check the file, run the following command: `docker cp edx.devstack.lms:/tmp/edx-s3/grades lms_tmp` This will copy your lms devstack """uploads""" directory to a local folder called lms_tmp. In there will be some folders. You might have to root around a bit but you'll find a zip file with the same name as your submission zip. Unzip it, and look inside.
5. There should be a csv and a folder called "removed from course"
6. Now, switch to this branch and allow the LMS to restart
7. Delete the lms_tmp folder and run steps 2-4 again.
8. This time, the folder should contain folders that somewhat map to course structure. To be honest I don't totally understand how it's laid out but it won't all be "removed from course"

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
