### PR TITLE
feat: add points to assessment criteria in submission fetch

### DIFF
--- a/openassessment/staffgrader/serializers/assessments.py
+++ b/openassessment/staffgrader/serializers/assessments.py
@@ -19,10 +19,11 @@ class SubmissionDetailFileSerilaizer(serializers.Serializer):
 class AssessmentPartSerializer(serializers.ModelSerializer):
     name = serializers.CharField(source='criterion.name')
     option = serializers.CharField(source='option.name', default=None)
+    points = serializers.IntegerField(source='option.points', default=None)
 
     class Meta:
         model = AssessmentPart
-        fields = ['name', 'option', 'feedback']
+        fields = ['name', 'option', 'points', 'feedback']
         read_only_fields = fields
 
 

--- a/openassessment/staffgrader/tests/test_get_submission_and_assessment_info.py
+++ b/openassessment/staffgrader/tests/test_get_submission_and_assessment_info.py
@@ -248,11 +248,13 @@ class HandlerTests(GetSubmissionAndAssessmentInfoBase):
                         {
                             'name': "Criterion 1",
                             'option': "Three",
+                            'points': 3,
                             'feedback': "Feedback 1"
                         },
                         {
                             'name': "Criterion 2",
                             'option': "Two",
+                            'points': 2,
                             'feedback': ""
                         }
                     ]
@@ -524,6 +526,7 @@ class GetAssessmentInfoTests(GetSubmissionAndAssessmentInfoBase):
                 OrderedDict({
                     'name': part.criterion.name,
                     'option': part.option.name,
+                    'points': part.option.points,
                     'feedback': f"Feedback for criterion={part.criterion.id}"
                 }) for part in assessment.parts.all()
             ]
@@ -571,11 +574,13 @@ class GetAssessmentInfoTests(GetSubmissionAndAssessmentInfoBase):
                 OrderedDict({
                     'name': 'Criterion 1',
                     'option': 'Three',
+                    'points': 3,
                     'feedback': criterion_feedback['Criterion 1']
                 }),
                 OrderedDict({
                     'name': 'Criterion 2',
                     'option': 'Two',
+                    'points': 2,
                     'feedback': ''
                 }),
             ]
@@ -614,6 +619,7 @@ class GetAssessmentInfoTests(GetSubmissionAndAssessmentInfoBase):
                 OrderedDict({
                     'name': part.criterion.name,
                     'option': None,
+                    'points': None,
                     'feedback': f"Feedback for criterion {part.criterion.id}"
                 }) for part in assessment.parts.all()
             ]


### PR DESCRIPTION
**TL;DR -** add `points` to assessment criteria api data object

JIRA: [AU-410](https://openedx.atlassian.net/browse/AU-410)

**What changed?**
- Add a field `points` to the submission fetch endpoint, within the criteria object within the assessment object
- This field represents the number of points that the chosen option for this criterion is worth (whose name is specified by `option` in the same object)

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

FYI: @edx/masters-devs-gta
