### PR TITLE
fix: typo in whitelisted file types

### DIFF
--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -50,7 +50,7 @@ class SubmissionMixin:
     """
 
     ALLOWED_IMAGE_MIME_TYPES = ['image/gif', 'image/jpeg', 'image/pjpeg', 'image/png']  # pragma: no cover
-    ALLOWED_IMAGE_EXTENSIONS = ['gif', 'jpg', 'jpgeg', 'jfif', 'pjpeg', 'pjp', 'png']  # pragma: no cover
+    ALLOWED_IMAGE_EXTENSIONS = ['gif', 'jpg', 'jpeg', 'jfif', 'pjpeg', 'pjp', 'png']  # pragma: no cover
 
     ALLOWED_FILE_MIME_TYPES = ['application/pdf'] + ALLOWED_IMAGE_MIME_TYPES  # pragma: no cover
     ALLOWED_FILE_EXTENSIONS = ['pdf'] + ALLOWED_IMAGE_EXTENSIONS  # pragma: no cover

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -1131,7 +1131,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'text_response_editor': 'text',
                 'user_language': None,
                 'user_timezone': None,
-                'white_listed_file_types': ['.pdf', '.gif', '.jpg', '.jpgeg', '.jfif', '.pjpeg', '.pjp', '.png']
+                'white_listed_file_types': ['.pdf', '.gif', '.jpg', '.jpeg', '.jfif', '.pjpeg', '.pjp', '.png']
             }
         )
 
@@ -1790,7 +1790,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
                 'text_response_editor': 'text',
                 'user_timezone': None,
                 'user_language': None,
-                'white_listed_file_types': ['.pdf', '.gif', '.jpg', '.jpgeg', '.jfif', '.pjpeg', '.pjp', '.png'],
+                'white_listed_file_types': ['.pdf', '.gif', '.jpg', '.jpeg', '.jfif', '.pjpeg', '.pjp', '.png'],
             }
         )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^5.6.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='3.7.4',
+    version='3.7.5',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
Fix typo in whitelisted file types:

![image (3)](https://user-images.githubusercontent.com/47273130/143440157-5bf8e51f-b10d-435a-ad92-a6302ecb438c.png)


JIRA: No Jira ticket

**What changed?**

- Just fixed a typo:
<img width="1150" alt="Screenshot 2021-11-25 at 14 02 06" src="https://user-images.githubusercontent.com/47273130/143440931-e0b565de-9a30-4c35-bf09-691cafb0177e.png">
<img width="1090" alt="Screenshot 2021-11-25 at 14 03 39" src="https://user-images.githubusercontent.com/47273130/143440943-34549034-f95d-4b76-9ec1-0bf897cd55b2.png">


**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [x] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
