### PR TITLE
chore: ESG tweaks

### DIFF
--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -28,22 +28,22 @@ log = logging.getLogger(__name__)
 
 def require_submission_uuid(validate=True):
     """
-    Unpacks and passes submission_id from request to handler function.
+    Unpacks and passes submission_uuid from request to handler function.
 
     params:
     - validate: Whether or not to check submissions to see if this is a real submission UUID or not. Default True
 
     Raises:
-    - 400 if the submission_id was not provided or was incorrectly formatted
-    - 404 if the submission_id wasn't found in submissions
+    - 400 if the submission_uuid was not provided or was incorrectly formatted
+    - 404 if the submission_uuid wasn't found in submissions
     - 500 for errors with submissions or general exceptions
     """
     def decorator(handler):
         @wraps(handler)
         def wrapped_handler(self, data, suffix=""):  # pylint: disable=unused-argument
-            submission_uuid = data.get('submission_id', None)
+            submission_uuid = data.get('submission_uuid', None)
             if not submission_uuid:
-                raise JsonHandlerError(400, "Body must contain a submission_id")
+                raise JsonHandlerError(400, "Body must contain a submission_uuid")
             if validate:
                 try:
                     get_submission(submission_uuid)

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -235,6 +235,7 @@ class StaffGraderMixin:
         staff_workflows = StaffWorkflow.objects.filter(
             course_id=student_item_dict['course_id'],
             item_id=student_item_dict['item_id'],
+            cancelled_at=None,
         ).annotate(
             current_lock_user=Subquery(newest_lock.values('owner_id')),
         ).annotate(

--- a/openassessment/staffgrader/tests/test_decorators.py
+++ b/openassessment/staffgrader/tests/test_decorators.py
@@ -12,7 +12,7 @@ from openassessment.staffgrader.staff_grader_mixin import require_submission_uui
 
 
 class RequireSubmissionUUIDTest(TestCase):
-    valid_data = {"submission_id": uuid4()}
+    valid_data = {"submission_uuid": uuid4()}
 
     def setUp(self):
         super().setUp()
@@ -27,14 +27,14 @@ class RequireSubmissionUUIDTest(TestCase):
 
         self.mock_function.assert_not_called()
         self.assertEqual(error_context.exception.status_code, 400)
-        self.assertEqual(error_context.exception.message, 'Body must contain a submission_id')
+        self.assertEqual(error_context.exception.message, 'Body must contain a submission_uuid')
 
     def test_arguments_passed(self):
         self.wrapped_function = require_submission_uuid(validate=False)(self.mock_function)
 
         data = {str(i): str((i * 2) - 1) for i in range(10)}
         submission_uuid = uuid4()
-        data['submission_id'] = submission_uuid
+        data['submission_uuid'] = submission_uuid
 
         result = self.wrapped_function(self.mock_self, data, suffix=self.mock_suffix)
 
@@ -44,7 +44,7 @@ class RequireSubmissionUUIDTest(TestCase):
     @patch('openassessment.staffgrader.staff_grader_mixin.get_submission')
     def test_validate_submission(self, mock_get_submission):  # pylint: disable=unused-argument
         mock_get_submission.return_value = {}
-        submission_uuid = self.valid_data['submission_id']
+        submission_uuid = self.valid_data['submission_uuid']
         result = self.wrapped_function(self.mock_self, self.valid_data, suffix=self.mock_suffix)
 
         self.assertEqual(result, self.mock_function.return_value)
@@ -67,7 +67,7 @@ class RequireSubmissionUUIDTest(TestCase):
         self.assertEqual(error_context.exception.message, 'Submission not found')
 
     @patch('openassessment.staffgrader.staff_grader_mixin.get_submission')
-    def test_validate_bad_submission_id(self, mock_get_submission):
+    def test_validate_bad_submission_uuid(self, mock_get_submission):
         mock_get_submission.side_effect = SubmissionRequestError
 
         with self.assertRaises(JsonHandlerError) as error_context:

--- a/openassessment/staffgrader/tests/test_get_assessment_info.py
+++ b/openassessment/staffgrader/tests/test_get_assessment_info.py
@@ -19,17 +19,17 @@ class GetAssessmentInfoTests(StaffGraderMixinTestBase):
     handler_name = 'get_assessment_info'
 
     @scenario('data/simple_self_staff_scenario.xml', user_id='Bob')
-    def test_no_submission_id(self, xblock):
-        """ How does the endpoint behave when we don't give it a submission_id? """
+    def test_no_submission_uuid(self, xblock):
+        """ How does the endpoint behave when we don't give it a submission_uuid? """
         self.set_staff_user(xblock, 'Bob')
         response = self.request(xblock, {})
-        self.assert_response(response, 400, {"error": "Body must contain a submission_id"})
+        self.assert_response(response, 400, {"error": "Body must contain a submission_uuid"})
 
     @scenario('data/simple_self_staff_scenario.xml', user_id='Bob')
     def test_no_access(self, xblock):
         """ How does the endpoint behave when the requester doesn't have proper permissions? """
         xblock.xmodule_runtime = Mock(user_is_staff=False)
-        response = self.request(xblock, {'submission_id': 'meaningless-value'})
+        response = self.request(xblock, {'submission_uuid': 'meaningless-value'})
         self.assertEqual(response.status_code, 200)
         self.assertIn('You do not have permission to access ORA staff grading.', response.body.decode('UTF-8'))
 
@@ -80,7 +80,7 @@ class GetAssessmentInfoTests(StaffGraderMixinTestBase):
         submission_uuid = str(uuid4())
         with self._mock_get_staff_workflow(side_effect=StaffWorkflow.DoesNotExist):
             with self._mock_get_submission():
-                response = self.request(xblock, {'submission_id': submission_uuid})
+                response = self.request(xblock, {'submission_uuid': submission_uuid})
 
         self.assert_response(
             response,
@@ -97,7 +97,7 @@ class GetAssessmentInfoTests(StaffGraderMixinTestBase):
 
         with self._mock_get_staff_workflow(return_value=mock_staff_workflow):
             with self._mock_get_submission():
-                response = self.request(xblock, {'submission_id': submission_uuid})
+                response = self.request(xblock, {'submission_uuid': submission_uuid})
 
         self.assert_response(response, 200, {})
 
@@ -134,7 +134,7 @@ class GetAssessmentInfoTests(StaffGraderMixinTestBase):
         self._mock_bulk_deep_fetch_assessments(xblock, return_value=bulk_fetch_return_value)
         with self._mock_get_staff_workflow(return_value=mock_staff_workflow):
             with self._mock_get_submission():
-                response = self.request(xblock, {'submission_id': submission_uuid})
+                response = self.request(xblock, {'submission_uuid': submission_uuid})
 
         self.assert_response(response, 500, {'error': 'Error looking up assessments'})
 
@@ -147,7 +147,7 @@ class GetAssessmentInfoTests(StaffGraderMixinTestBase):
         self._mock_bulk_deep_fetch_assessments(xblock, return_value={submission_uuid: assessment})
         with self._mock_get_staff_workflow():
             with self._mock_get_submission():
-                response = self.request(xblock, {'submission_id': submission_uuid})
+                response = self.request(xblock, {'submission_uuid': submission_uuid})
 
         expected_assessment_info = {
             'feedback': "Base Assessment Feedback",
@@ -190,7 +190,7 @@ class GetAssessmentInfoTests(StaffGraderMixinTestBase):
             # 3 - AssessmentPart
             # 4 - Criterion
             # 5 - Option
-            response = self.request(xblock, {'submission_id': submission['uuid']})
+            response = self.request(xblock, {'submission_uuid': submission['uuid']})
 
         expected_assessment_info = {
             'feedback': overall_feedback,
@@ -235,7 +235,7 @@ class GetAssessmentInfoTests(StaffGraderMixinTestBase):
         self._mock_bulk_deep_fetch_assessments(xblock, return_value={submission_uuid: assessment})
         with self._mock_get_staff_workflow():
             with self._mock_get_submission():
-                response = self.request(xblock, {'submission_id': submission_uuid})
+                response = self.request(xblock, {'submission_uuid': submission_uuid})
 
         expected_assessment_info = {
             'feedback': "Base Assessment Feedback",

--- a/openassessment/staffgrader/tests/test_get_submission_info.py
+++ b/openassessment/staffgrader/tests/test_get_submission_info.py
@@ -16,17 +16,17 @@ class GetSubmissionInfoTests(StaffGraderMixinTestBase):
     handler_name = 'get_submission_info'
 
     @scenario('data/simple_self_staff_scenario.xml', user_id='Bob')
-    def test_no_submission_id(self, xblock):
-        """ How does the endpoint behave when we don't give it a submission_id? """
+    def test_no_submission_uuid(self, xblock):
+        """ How does the endpoint behave when we don't give it a submission_uuid? """
         self.set_staff_user(xblock, 'Bob')
         response = self.request(xblock, {})
-        self.assert_response(response, 400, {"error": "Body must contain a submission_id"})
+        self.assert_response(response, 400, {"error": "Body must contain a submission_uuid"})
 
     @scenario('data/simple_self_staff_scenario.xml', user_id='Bob')
     def test_no_access(self, xblock):
         """ How does the endpoint behave when the requester doesn't have proper permissions? """
         xblock.xmodule_runtime = Mock(user_is_staff=False)
-        response = self.request(xblock, {'submission_id': 'meaningless-value'})
+        response = self.request(xblock, {'submission_uuid': 'meaningless-value'})
         self.assertEqual(response.status_code, 200)
         self.assertIn('You do not have permission to access ORA staff grading.', response.body.decode('UTF-8'))
 
@@ -51,7 +51,7 @@ class GetSubmissionInfoTests(StaffGraderMixinTestBase):
 
         self.set_staff_user(xblock, 'Bob')
         with self._mock_get_submission(side_effect=sub_api.SubmissionError(err_msg)):
-            response = self.request(xblock, {'submission_id': submission_uuid})
+            response = self.request(xblock, {'submission_uuid': submission_uuid})
 
         self.assert_response(response, 500, {"error": "Internal error getting submission info"})
 
@@ -64,7 +64,7 @@ class GetSubmissionInfoTests(StaffGraderMixinTestBase):
         self.set_staff_user(xblock, 'Bob')
         with self._mock_get_submission(return_value=mock_submission):
             with self._mock_parse_submission_raw_answer(side_effect=mock_exception):
-                response = self.request(xblock, {'submission_id': submission_uuid})
+                response = self.request(xblock, {'submission_uuid': submission_uuid})
 
         self.assertEqual(response.status_code, 500)
         self.assertIn(str(mock_exception), response.body.decode('UTF-8'))
@@ -90,7 +90,7 @@ class GetSubmissionInfoTests(StaffGraderMixinTestBase):
         with self._mock_get_submission(return_value=mock_submission):
             with self._mock_parse_submission_raw_answer(return_value=mock_answer):
                 self._mock_get_download_urls_from_submission(xblock, return_value=file_responses)
-                response = self.request(xblock, {'submission_id': submission_uuid})
+                response = self.request(xblock, {'submission_uuid': submission_uuid})
 
         self.assert_response(
             response,
@@ -120,7 +120,7 @@ class GetSubmissionInfoTests(StaffGraderMixinTestBase):
 
         self.set_staff_user(xblock, 'Bob')
         with self._mock_get_url_by_file_key(xblock):
-            response = self.request(xblock, {'submission_id': submission['uuid']})
+            response = self.request(xblock, {'submission_uuid': submission['uuid']})
 
         expected_submission_info = {
             'text': [

--- a/openassessment/staffgrader/tests/test_staff_grader_mixin.py
+++ b/openassessment/staffgrader/tests/test_staff_grader_mixin.py
@@ -59,7 +59,7 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
     def test_check_submission_lock_none(self, xblock):
         """ A check for submission lock where there is no lock should return empty dict """
         xblock.xmodule_runtime = Mock(user_is_staff=True)
-        request_data = {'submission_id': self.test_submission_uuid_unlocked}
+        request_data = {'submission_uuid': self.test_submission_uuid_unlocked}
         response = self.request(xblock, 'check_submission_lock', json.dumps(request_data), response_format='json')
 
         self.assertDictEqual(response, {
@@ -70,7 +70,7 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
     def test_check_submission_lock(self, xblock):
         """ A check for submission lock returns the matching submission lock """
         xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=self.staff_user_id)
-        request_data = {'submission_id': self.test_submission_uuid}
+        request_data = {'submission_uuid': self.test_submission_uuid}
         response = self.request(xblock, 'check_submission_lock', json.dumps(request_data), response_format='json')
 
         self.assertDictEqual(response, {
@@ -86,7 +86,7 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         """ A submission lock can be claimed on a submission w/out an active lock """
         xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=self.staff_user_id)
 
-        request_data = {'submission_id': self.test_submission_uuid_unlocked}
+        request_data = {'submission_uuid': self.test_submission_uuid_unlocked}
         response = self.request(xblock, 'claim_submission_lock', json.dumps(request_data), response_format='json')
 
         self.assertDictEqual(response, {
@@ -107,7 +107,7 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         lock.created_at = lock.created_at - timedelta(hours=2)
         lock.save()
 
-        request_data = {'submission_id': self.test_submission_uuid}
+        request_data = {'submission_uuid': self.test_submission_uuid}
         response = self.request(xblock, 'claim_submission_lock', json.dumps(request_data), response_format='json')
 
         self.assertDictEqual(response, {
@@ -123,7 +123,7 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         """ Trying to claim a lock on a submission with an active lock raises an error """
         xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id='other-staff-user-id')
 
-        request_data = {'submission_id': self.test_submission_uuid}
+        request_data = {'submission_uuid': self.test_submission_uuid}
         response = self.request(xblock, 'claim_submission_lock', json.dumps(request_data), response_format='response')
         response_body = json.loads(response.body.decode('utf-8'))
 
@@ -137,7 +137,7 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         """ The lock owner can clear a submission lock if it exists """
         xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=self.staff_user_id)
 
-        request_data = {'submission_id': self.test_submission_uuid}
+        request_data = {'submission_uuid': self.test_submission_uuid}
         response = self.request(xblock, 'delete_submission_lock', json.dumps(request_data), response_format='json')
 
         self.assertDictEqual(response, {
@@ -149,7 +149,7 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         """ Users cannot clear a lock owned by another user """
         xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id='other-staff-user-id')
 
-        request_data = {'submission_id': self.test_submission_uuid}
+        request_data = {'submission_uuid': self.test_submission_uuid}
         response = self.request(xblock, 'delete_submission_lock', json.dumps(request_data), response_format='response')
         response_body = json.loads(response.body.decode('utf-8'))
 


### PR DESCRIPTION
**TL;DR -** minor fixes and tweaks to ESG functionality

JIRA: [AU-444](https://openedx.atlassian.net/browse/AU-444) & [AU-367](https://openedx.atlassian.net/browse/AU-367)

**What changed?**

- Renames `submission_id` param to `submission_uuid` param for submission locking for consistency.
- Filters cancelled submissions from submission return list in ESG.

**Testing Instructions**

- Manually exercise with Postman & updated contracts.
- For an ORA with cancelled submissions, hit `list_staff_workflows` XBlock handler and verify it returns successfully (used to break due to cancelled submissions mapping issues).

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
