### PR TITLE
refactor: return lock info with lock contest errors

### DIFF
--- a/openassessment/staffgrader/errors/__init__.py
+++ b/openassessment/staffgrader/errors/__init__.py
@@ -1,0 +1,1 @@
+""" Error classes, codes, etc. for Enhanced Staff Grader (ESG) """

--- a/openassessment/staffgrader/errors/submission_lock.py
+++ b/openassessment/staffgrader/errors/submission_lock.py
@@ -11,3 +11,6 @@ class SubmissionLockContestedError(Exception):
 
     def get_error_code(self):
         return self.error_code
+
+    def __init__(self, current_lock):
+        self.current_lock = current_lock

--- a/openassessment/staffgrader/errors/submission_lock.py
+++ b/openassessment/staffgrader/errors/submission_lock.py
@@ -13,4 +13,5 @@ class SubmissionLockContestedError(Exception):
         return self.error_code
 
     def __init__(self, current_lock):
+        super().__init__()
         self.current_lock = current_lock

--- a/openassessment/staffgrader/models/submission_lock.py
+++ b/openassessment/staffgrader/models/submission_lock.py
@@ -62,7 +62,7 @@ class SubmissionGradingLock(models.Model):
         # If there's already an active lock, raise an error
         # Unless the lock owner is trying to reacquire a lock, which is allowed
         if current_lock and current_lock.is_active and current_lock.owner_id != user_id:
-            raise SubmissionLockContestedError
+            raise SubmissionLockContestedError(current_lock)
 
         # Otherwise, delete the lock. This is needed so we don't violate the unique submission_uuid constraint
         if current_lock:
@@ -90,6 +90,6 @@ class SubmissionGradingLock(models.Model):
 
         # Only the owner can clear the lock
         if current_lock.owner_id != user_id:
-            raise SubmissionLockContestedError
+            raise SubmissionLockContestedError(current_lock)
 
         current_lock.delete()

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -100,7 +100,8 @@ class StaffGraderMixin:
             submission_lock = SubmissionGradingLock.claim_submission_lock(submission_uuid, anonymous_user_id)
             return SubmissionLockSerializer(submission_lock, context=context).data
         except SubmissionLockContestedError as err:
-            raise JsonHandlerError(403, err.get_error_code()) from err
+            # Lock is contested - return lock info
+            raise JsonHandlerError(403, SubmissionLockSerializer(err.current_lock).data) from err
 
     @XBlock.json_handler
     @require_course_staff("STUDENT_GRADE")
@@ -122,7 +123,8 @@ class StaffGraderMixin:
             SubmissionGradingLock.clear_submission_lock(submission_uuid, anonymous_user_id)
             return SubmissionLockSerializer({}, context=context).data
         except SubmissionLockContestedError as err:
-            raise JsonHandlerError(403, err.get_error_code()) from err
+            # Lock is contested - return lock info
+            raise JsonHandlerError(403, SubmissionLockSerializer(err.current_lock).data) from err
 
     @XBlock.json_handler
     @require_course_staff("STUDENT_GRADE")

--- a/openassessment/staffgrader/tests/test_staff_grader_mixin.py
+++ b/openassessment/staffgrader/tests/test_staff_grader_mixin.py
@@ -127,9 +127,15 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         response = self.request(xblock, 'claim_submission_lock', json.dumps(request_data), response_format='response')
         response_body = json.loads(response.body.decode('utf-8'))
 
+        # Lock contest returns a 403 and lock info for reference
         self.assertEqual(response.status_code, 403)
         self.assertDictEqual(response_body, {
-            "error": "ERR_LOCK_CONTESTED"
+            "error": {
+                "submission_uuid": self.test_submission_uuid,
+                "owner_id": self.staff_user_id,
+                "created_at": self.test_timestamp,
+                "lock_status": "locked",
+            }
         })
 
     @scenario('data/basic_scenario.xml', user_id="staff")
@@ -153,7 +159,13 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         response = self.request(xblock, 'delete_submission_lock', json.dumps(request_data), response_format='response')
         response_body = json.loads(response.body.decode('utf-8'))
 
+        # Lock contest returns a 403 and lock info for reference
         self.assertEqual(response.status_code, 403)
         self.assertDictEqual(response_body, {
-            "error": "ERR_LOCK_CONTESTED"
+            "error": {
+                "submission_uuid": self.test_submission_uuid,
+                "owner_id": self.staff_user_id,
+                "created_at": self.test_timestamp,
+                "lock_status": "locked",
+            }
         })


### PR DESCRIPTION
**TL;DR -** change lock contest error shape to return lock info

Paired with PR TBD in `edx-platform` to ingest new error data.

JIRA: [AU-445](https://openedx.atlassian.net/browse/AU-445) 

**What changed?**

- Lock contestation error used to return static error code `403 { "error": "ERR_LOCK_CONTESTED" }`
- Now returns `403 { "error": { (lock_info) }` so that we can update frontend with lock status on error

Low risk in confusion since there is really only one error type we expect to see (outside of network/server issues) which is lock contestation, so the error code doesn't really disambiguate anything.

**Testing Instructions**

1. Create a lock with one user using `claim_submission_lock`
2. Attempt to `delete_submission_lock` or `claim_submission_lock` as another user
3. Verify error information matches the pattern below:

```
{ 
    "error": {
        "submission_uuid": <submission_uuid>,
        "owner_id": <owner_anon_user_id>,
        "created_at": <timestamp>,
        "lock_status": "locked",
    }
}
```

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
