### PR TITLE
fix: try calling set_code_owner inside task

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '5.5.6'
+__version__ = '5.5.7'

--- a/openassessment/workflow/tasks.py
+++ b/openassessment/workflow/tasks.py
@@ -4,7 +4,7 @@ Celery task wrappers to execute batch ORA workflow update
 
 from celery import shared_task
 
-from edx_django_utils.monitoring import set_code_owner_attribute
+from edx_django_utils.monitoring import set_code_owner_attribute_from_module
 
 
 @shared_task(bind=True,
@@ -14,11 +14,11 @@ from edx_django_utils.monitoring import set_code_owner_attribute
              retry_backoff=True,
              retry_backoff_max=500,
              retry_jitter=True)
-@set_code_owner_attribute
 def update_workflows_for_all_blocked_submissions_task(self):  # pylint: disable=unused-argument
     """
     Async task wrapper
     """
+    set_code_owner_attribute_from_module(__name__)
     from openassessment.workflow.workflow_batch_update_api import update_workflows_for_all_blocked_submissions
     return update_workflows_for_all_blocked_submissions()
 
@@ -36,6 +36,7 @@ def update_workflows_for_course_task(self, course_id, workflow_update_data_for_c
     """
     Async task wrapper
     """
+    set_code_owner_attribute_from_module(__name__)
     from openassessment.workflow.workflow_batch_update_api import update_workflows_for_course
     return update_workflows_for_course(course_id, workflow_update_data_for_course)
 
@@ -53,6 +54,7 @@ def update_workflows_for_ora_block_task(self, item_id, workflow_update_data_for_
     """
     Async task wrapper
     """
+    set_code_owner_attribute_from_module(__name__)
     from openassessment.workflow.workflow_batch_update_api import update_workflows_for_ora_block
     return update_workflows_for_ora_block(item_id, workflow_update_data_for_ora, course_settings)
 
@@ -70,5 +72,6 @@ def update_workflow_for_submission_task(self, submission_uuid, assessment_requir
     """
     Async task wrapper
     """
+    set_code_owner_attribute_from_module(__name__)
     from openassessment.workflow.workflow_batch_update_api import update_workflow_for_submission
     return update_workflow_for_submission(submission_uuid, assessment_requirements, course_settings)

--- a/openassessment/workflow/tasks.py
+++ b/openassessment/workflow/tasks.py
@@ -30,7 +30,6 @@ def update_workflows_for_all_blocked_submissions_task(self):  # pylint: disable=
              retry_backoff=True,
              retry_backoff_max=500,
              retry_jitter=True)
-@set_code_owner_attribute
 # pylint: disable=unused-argument
 def update_workflows_for_course_task(self, course_id, workflow_update_data_for_course=None):
     """
@@ -48,7 +47,6 @@ def update_workflows_for_course_task(self, course_id, workflow_update_data_for_c
              retry_backoff=True,
              retry_backoff_max=500,
              retry_jitter=True)
-@set_code_owner_attribute
 # pylint: disable=unused-argument
 def update_workflows_for_ora_block_task(self, item_id, workflow_update_data_for_ora=None, course_settings=None):
     """
@@ -66,7 +64,6 @@ def update_workflows_for_ora_block_task(self, item_id, workflow_update_data_for_
              retry_backoff=True,
              retry_backoff_max=300,
              retry_jitter=True)
-@set_code_owner_attribute
 # pylint: disable=unused-argument
 def update_workflow_for_submission_task(self, submission_uuid, assessment_requirements=None, course_settings=None):
     """

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "5.5.6",
+  "version": "5.5.a7",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "5.5.a7",
+  "version": "5.5.7",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",


### PR DESCRIPTION
**TL;DR -** Replaces set_code_owner_attribute decorator with a manual call to set_code_owner_attribute_from_module because the decorator isn't working for some reason


**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
