### PR TITLE
chore: remove 2u-aurora as repo maintainer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,5 +24,3 @@ Collectively, these should be completed by reviewers of this PR:
 
 - [ ] I've done a visual code review
 - [ ] I've tested the new functionality
-
-FYI: @openedx/content-aurora

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -18,7 +18,7 @@ jobs:
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
       # team_reviewers: ""
-      email_address: "aurora-requirements-update@2u-internal.opsgenie.net"
+      # email_address: ""
       send_success_notification: true
     secrets:
       requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,6 +13,6 @@ metadata:
   annotations:
     openedx.org/arch-interest-groups: ""
 spec:
-  owner: group:2u-aurora
+  owner: group:openedx-unmaintained
   type: 'xblock'
   lifecycle: 'production'


### PR DESCRIPTION
[2u-aurora](https://github.com/orgs/openedx/teams/2u-aurora) is no longer able to maintain this repo. Despite [a search](https://discuss.openedx.org/t/edx-ora2-is-seeking-a-new-maintainer/17552), no new maintainer was found so ownership is being transferred to [openedx-unmaintained](https://github.com/orgs/openedx/teams/openedx-unmaintained).

Removes all references to existing team:
- `catalog-info.yml`
- `.github/workflows/upgrade-python-requirements.yml`
- `.github/pull_request_template.md`
