### PR TITLE
fix: stub out loremipsum

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.17.2'
+__version__ = '6.18.0'

--- a/openassessment/management/commands/create_oa_submissions.py
+++ b/openassessment/management/commands/create_oa_submissions.py
@@ -8,11 +8,11 @@ from uuid import uuid4
 
 from django.core.management.base import BaseCommand, CommandError
 
-import loremipsum
 from submissions import api as sub_api
 from openassessment.assessment.api import peer as peer_api
 from openassessment.assessment.api import self as self_api
 from openassessment.workflow import api as workflow_api
+from . import loremipsum
 
 STEPS = ['peer', 'self']
 
@@ -168,7 +168,7 @@ class Command(BaseCommand):
         """
         rubric = {'criteria': []}
         options_selected = {}
-        words = loremipsum.Generator().words
+        words = loremipsum.get_words(10)
 
         for criteria_num in range(self.NUM_CRITERIA):
             criterion = {

--- a/openassessment/management/commands/create_oa_submissions.py
+++ b/openassessment/management/commands/create_oa_submissions.py
@@ -43,6 +43,28 @@ class Command(BaseCommand):
         super().__init__(*args, **kwargs)
         self._student_items = []
 
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            'COURSE_ID',
+            type=str,
+            help='The ID of the course to create submissions for.',
+        )
+        parser.add_argument(
+            'ITEM_ID',
+            type=str,
+            help='The ID of the item in the course to create submissions for.',
+        )
+        parser.add_argument(
+            'NUM_SUBMISSIONS',
+            type=int,
+            help='Number of submissions to create',
+        )
+        parser.add_argument(
+            'PERCENTAGE',
+            type=float,
+            help='Percentage for assessments to be made against submissions',
+        )
+
     def handle(self, *args, **options):
         """
         Execute the command.
@@ -53,19 +75,19 @@ class Command(BaseCommand):
             num_submissions (int): Number of submissions to create.
             percentage (int or float): Percentage for assessments to be made against submissions.
         """
-        if len(args) < 4:
+        if len(options) < 4:
             raise CommandError('Usage: create_oa_submissions <COURSE_ID> <ITEM_ID> <NUM_SUBMISSIONS> <PERCENTAGE>')
 
-        course_id = str(args[0])
-        item_id = str(args[1])
+        course_id = str(options['COURSE_ID'])
+        item_id = str(options['ITEM_ID'])
 
         try:
-            num_submissions = int(args[2])
+            num_submissions = int(options['NUM_SUBMISSIONS'])
         except ValueError as ex:
             raise CommandError('Number of submissions must be an integer') from ex
 
         try:
-            percentage = float(args[3])
+            percentage = float(options['PERCENTAGE'])
             assessments_to_create = (percentage / 100) * num_submissions
         except ValueError as ex:
             raise CommandError('Percentage for completed submissions must be an integer or float') from ex

--- a/openassessment/management/commands/create_oa_submissions_from_file.py
+++ b/openassessment/management/commands/create_oa_submissions_from_file.py
@@ -11,13 +11,13 @@ from django.core.management import call_command
 
 from opaque_keys.edx.keys import CourseKey
 
-import loremipsum
 from submissions import api as sub_api
 from openassessment.assessment.api import staff as staff_api
 from openassessment.runtime_imports.functions import anonymous_id_for_user, modulestore
 from openassessment.workflow import api as workflow_api
 from openassessment.xblock.utils.data_conversion import create_rubric_dict
 from openassessment.staffgrader.models import SubmissionGradingLock
+from . import loremipsum
 
 log = logging.getLogger('create_oa_submissions_from_file')
 

--- a/openassessment/management/commands/loremipsum.py
+++ b/openassessment/management/commands/loremipsum.py
@@ -1,0 +1,79 @@
+"""
+Stub for the old, unmaintained loremipsum package.
+"""
+
+
+def get_sentences(num: int) -> list[str]:
+    """
+    Returns up to 5 sentences.
+    """
+    sentences = [
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+        "Donec commodo at dui dictum rutrum.",
+        "Sed quis sodales nisl.",
+        "Aenean at ultricies tortor. Nunc nec dictum diam.",
+        "Integer suscipit, mi quis accumsan cursus, magna augue aliquam dui, in laoreet metus odio vitae nisl.",
+    ]
+    return sentences[:num]
+
+
+def get_paragraphs(num: int) -> list[str]:
+    """
+    Returns up to 5 paragraphs.
+    """
+    paragraphs = [
+        (
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec commodo at dui dictum rutrum. Sed quis"
+            "sodales nisl. Aenean at ultricies tortor. Nunc nec dictum diam. Integer suscipit, mi quis accumsan"
+            "cursus, magna augue aliquam dui, in laoreet metus odio vitae nisl. Mauris eget sem ut magna egestas"
+            "laoreet vitae quis purus. Aenean sodales tincidunt mi, vitae consequat quam eleifend sed. Suspendisse"
+            "dictum dolor velit, id auctor turpis molestie eu. Suspendisse porta luctus dolor non tincidunt. In hac"
+            "habitasse platea dictumst. Aenean semper lorem quis nisi blandit luctus. Nullam sed consequat tellus,"
+            "et dapibus nisi. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus"
+            "mus. Mauris aliquet mattis nulla non congue."
+        ),
+        (
+            "Fusce laoreet sapien in pretium dictum. Aenean vel feugiat massa, at cursus nisi. Donec convallis"
+            "consequat diam blandit tristique. Pellentesque egestas gravida gravida. Suspendisse ac volutpat nulla."
+            "Duis at porta augue. Proin quis eleifend nisi."
+        ),
+        (
+            "Vivamus volutpat, est id pretium commodo, ex risus condimentum nunc, et sodales dui nisi tempor enim."
+            "Curabitur efficitur nec ipsum a commodo. Vivamus a dolor libero. Maecenas ipsum lorem, condimentum non"
+            "gravida id, finibus vel orci. Interdum et malesuada fames ac ante ipsum primis in faucibus. Etiam"
+            "dictum rhoncus accumsan. Mauris vel magna elit. Sed nec dui a felis dapibus faucibus. Fusce tincidunt"
+            "est in leo semper, ac interdum dolor venenatis. Fusce in ultricies quam, in egestas nisi. Phasellus"
+            "nec tellus magna. Curabitur eu orci ante. Proin non scelerisque lacus. Phasellus nec lobortis orci."
+        ),
+        (
+            "Donec id quam ut arcu sodales imperdiet. Sed ullamcorper tellus dolor, quis sagittis mi hendrerit nec."
+            "Nunc condimentum porta tellus vitae ornare. Fusce sit amet diam eros. Integer pretium sapien sit amet"
+            "sodales congue. Vivamus mattis dui ac consectetur viverra. Duis blandit eu metus et accumsan. In in"
+            "sem sed mauris varius sagittis a ac lectus."
+        ),
+        (
+            "Vivamus tempor augue ut augue efficitur, nec fringilla sem bibendum. Aliquam rhoncus consequat metus"
+            "nec gravida. Duis a suscipit turpis. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices"
+            "posuere cubilia curae; Nunc convallis dui eget arcu sodales, a pretium nisl molestie. Pellentesque"
+            "rhoncus eros ac tellus vestibulum faucibus ut ut neque. Vivamus eu fringilla velit. Suspendisse sed"
+            "auctor felis. Suspendisse at orci lorem. Mauris lacinia ex egestas diam condimentum efficitur vel a"
+            "est.  Quisque sed sem placerat, finibus libero in, iaculis nisl. Integer nulla urna, pulvinar sit amet"
+            "malesuada in, vulputate sed quam."
+        ),
+    ]
+    return paragraphs[:num]
+
+
+def get_words(num: int) -> list[str]:
+    """
+    Returns up to 10 words.
+    """
+    words = get_sentence().split()
+    return words[:num]
+
+
+def get_sentence() -> str:
+    """
+    Returns a single sentence string.
+    """
+    return get_sentences(1)[0]

--- a/openassessment/management/tests/test_create_oa_submissions.py
+++ b/openassessment/management/tests/test_create_oa_submissions.py
@@ -17,7 +17,12 @@ class CreateSubmissionsTest(TestCase):
         """ Tests create submission process. """
         # Create some submissions
         cmd = create_oa_submissions.Command(**{'self_assessment_required': True})
-        cmd.handle("test_course", "test_item", "5", 100)
+        cmd.handle(
+            COURSE_ID="test_course",
+            ITEM_ID="test_item",
+            NUM_SUBMISSIONS=5,
+            PERCENTAGE=100,
+        )
         self.assertEqual(len(cmd.student_items), 5)
         for student_item in cmd.student_items:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.17.0",
+  "version": "6.18.0",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,25 +6,25 @@
 #
 appdirs==1.4.4
     # via fs
-asgiref==3.9.1
+asgiref==3.11.1
     # via django
-attrs==25.3.0
+attrs==25.4.0
     # via openedx-events
-bleach==6.2.0
+bleach==6.3.0
     # via -r requirements/base.in
-boto3==1.40.11
+boto3==1.42.46
     # via -r requirements/base.in
-botocore==1.40.11
+botocore==1.42.46
     # via
     #   boto3
     #   s3transfer
-certifi==2025.8.3
+certifi==2026.1.4
     # via requests
-cffi==1.17.1
+cffi==2.0.0
     # via pynacl
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via requests
-click==8.2.1
+click==8.3.1
     # via
     #   code-annotations
     #   edx-django-utils
@@ -32,13 +32,13 @@ code-annotations==2.3.0
     # via edx-toggles
 defusedxml==0.7.1
     # via -r requirements/base.in
-django==4.2.23
+django==4.2.28
     # via
     #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-crum
     #   django-model-utils
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   edx-django-release-util
@@ -57,10 +57,8 @@ django-model-utils==5.0.0
     # via
     #   -r requirements/base.in
     #   edx-submissions
-django-simple-history==3.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+django-simple-history==3.11.0
+    # via -r requirements/base.in
 django-waffle==5.0.0
     # via
     #   edx-django-utils
@@ -69,13 +67,13 @@ djangorestframework==3.16.1
     # via
     #   -r requirements/base.in
     #   edx-submissions
-dnspython==2.7.0
+dnspython==2.8.0
     # via pymongo
 edx-ccx-keys==2.0.2
     # via openedx-events
 edx-django-release-util==1.5.0
     # via edx-submissions
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   -r requirements/base.in
     #   edx-toggles
@@ -88,25 +86,21 @@ edx-opaque-keys[django]==3.0.0
     #   edx-ccx-keys
     #   openedx-events
     #   openedx-filters
-edx-submissions==3.11.1
+edx-submissions==3.12.2
     # via -r requirements/base.in
 edx-toggles==5.4.1
     # via -r requirements/base.in
-fastavro==1.12.0
+fastavro==1.12.1
     # via openedx-events
-fs==2.0.18
-    # via
-    #   -c requirements/constraints.txt
-    #   xblock
+fs==2.4.16
+    # via xblock
 html5lib==1.1
     # via -r requirements/base.in
-idna==2.8
-    # via
-    #   -c requirements/constraints.txt
-    #   requests
+idna==3.11
+    # via requests
 jinja2==3.1.6
     # via code-annotations
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   boto3
     #   botocore
@@ -116,43 +110,40 @@ jsonfield==3.2.0
     #   edx-submissions
 lazy==1.6
     # via -r requirements/base.in
-lxml[html-clean]==6.0.0
+lxml[html-clean]==6.0.2
     # via
     #   -r requirements/base.in
     #   edx-i18n-tools
     #   lxml-html-clean
     #   xblock
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.3
     # via lxml
 mako==1.3.10
     # via xblock
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   jinja2
     #   mako
     #   xblock
-openedx-events==10.4.0
+openedx-events==10.5.0
     # via -r requirements/base.in
 openedx-filters==2.1.0
     # via -r requirements/base.in
-path==13.1.0
+path==16.16.0
     # via
-    #   -c requirements/constraints.txt
     #   edx-i18n-tools
     #   path-py
 path-py==12.5.0
     # via -r requirements/base.in
-pbr==7.0.0
-    # via stevedore
 polib==1.2.0
     # via edx-i18n-tools
-psutil==7.0.0
+psutil==7.2.2
     # via edx-django-utils
-pycparser==2.22
+pycparser==3.0
     # via cffi
-pymongo==4.14.0
+pymongo==4.16.0
     # via edx-opaque-keys
-pynacl==1.5.0
+pynacl==1.6.2
     # via edx-django-utils
 python-dateutil==2.9.0.post0
     # via
@@ -161,27 +152,24 @@ python-dateutil==2.9.0.post0
     #   xblock
 python-slugify==8.0.4
     # via code-annotations
-python-swiftclient==3.13.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+python-swiftclient==4.9.0
+    # via -r requirements/base.in
 pytz==2025.2
     # via
     #   -r requirements/base.in
     #   edx-submissions
-    #   fs
     #   xblock
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   code-annotations
     #   edx-django-release-util
     #   edx-i18n-tools
     #   xblock
-requests==2.32.4
+requests==2.32.5
     # via python-swiftclient
-s3transfer==0.13.1
+s3transfer==0.16.0
     # via boto3
-simplejson==3.20.1
+simplejson==3.20.2
     # via xblock
 six==1.17.0
     # via
@@ -190,26 +178,23 @@ six==1.17.0
     #   fs
     #   html5lib
     #   python-dateutil
-    #   python-swiftclient
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via django
-stevedore==5.4.1
+stevedore==5.6.0
     # via
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via edx-opaque-keys
-urllib3==2.5.0
+urllib3==2.6.3
     # via
     #   botocore
     #   requests
-voluptuous==0.15.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+voluptuous==0.16.0
+    # via -r requirements/base.in
 web-fragments==3.1.0
     # via xblock
 webencodings==0.5.1
@@ -218,13 +203,12 @@ webencodings==0.5.1
     #   html5lib
 webob==1.8.9
     # via xblock
-xblock==5.2.0
+xblock==5.3.0
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==80.9.0
+setuptools==82.0.0
     # via
     #   fs
     #   openedx-events
     #   openedx-filters
-    #   pbr

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,25 +4,25 @@
 #
 #    make upgrade
 #
-cachetools==6.1.0
+cachetools==7.0.1
     # via
     #   -r requirements/tox.txt
     #   tox
-certifi==2025.8.3
+certifi==2026.1.4
     # via requests
 chardet==5.2.0
     # via
     #   -r requirements/tox.txt
     #   tox
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via requests
 colorama==0.4.6
     # via
     #   -r requirements/tox.txt
     #   tox
-coverage[toml]==7.10.4
+coverage[toml]==7.13.4
     # via coveralls
-coveralls==4.0.1
+coveralls==4.0.2
     # via -r requirements/ci.in
 distlib==0.4.0
     # via
@@ -30,21 +30,19 @@ distlib==0.4.0
     #   virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.19.1
+filelock==3.20.3
     # via
     #   -r requirements/tox.txt
     #   tox
     #   virtualenv
-idna==2.8
-    # via
-    #   -c requirements/constraints.txt
-    #   requests
-packaging==25.0
+idna==3.11
+    # via requests
+packaging==26.0
     # via
     #   -r requirements/tox.txt
     #   pyproject-api
     #   tox
-platformdirs==4.3.8
+platformdirs==4.5.1
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -53,21 +51,21 @@ pluggy==1.6.0
     # via
     #   -r requirements/tox.txt
     #   tox
-pyproject-api==1.9.1
+pyproject-api==1.10.0
     # via
     #   -r requirements/tox.txt
     #   tox
-requests==2.32.4
+requests==2.32.5
     # via coveralls
-tox==4.28.4
+tox==4.34.1
     # via -r requirements/tox.txt
-urllib3==2.5.0
+urllib3==2.6.3
     # via requests
-virtualenv==20.34.0
+virtualenv==20.36.1
     # via
     #   -r requirements/tox.txt
     #   tox
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==80.9.0
+setuptools==82.0.0
     # via -r requirements/ci.in

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -20,6 +20,8 @@ Django<5.0
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
 
-# Cause: https://github.com/openedx/edx-lint/issues/458
-# This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
-pip<24.3
+# pip 26 is incompatible with pip-tools hence causing failures during the build process
+# Make upgrade command and all requirements upgrade jobs are broken due to this.
+# The constraint can be removed once a release (pip-tools > 7.5.2) is available with support for pip 26
+# Issue to track this dependency and unpin later on: https://github.com/jazzband/pip-tools/issues/2319
+pip<26.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -5,7 +5,6 @@
 # Base dependencies
 Django<4.3                         # Stay on the latest LTS release of Django
 fs<=2.0.18                         # Constrained by edx-platform
-loremipsum<2.0.0
 
 python-swiftclient<4.0.0
 voluptuous<1.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -2,28 +2,12 @@
 
 -c common_constraints.txt
 
-# Base dependencies
-Django<4.3                         # Stay on the latest LTS release of Django
-fs<=2.0.18                         # Constrained by edx-platform
-
-python-swiftclient<4.0.0
-voluptuous<1.0.0
-
 # Test dependencies
 ddt==1.0.0                          # Test failures at versions > 1.0.0
-idna<2.9.0                          # moto version moto==1.3.14 requires idna<2.9.0
-fs-s3fs==0.1.8                      # Constrained by edx-platform
-wrapt==1.11.*                       # Constrained by astroid
 freezegun<=0.3.14                   # Test failures on 0.3.15
-# Networkx 2.5 drops support for python 3.5
-networkx<2.5
+pylint-django<2.6.0                 # Quality fails with infinite recursion errors
 # Moto latest version has breaking changes. Needs the tests to be fixed.
 moto<5.0
-# path 13.2.0 drops support for Python 3.5
-path<13.2.0
-
-# incremental upgrade plan.
-django-simple-history<=3.1.1
 
 # backports.zoneinfo is only needed for Python < 3.9
 backports.zoneinfo; python_version<'3.9'

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,42 +8,43 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 alabaster==1.0.0
     # via sphinx
-anyio==4.10.0
+anyio==4.12.1
     # via
     #   starlette
     #   watchfiles
-babel==2.17.0
+babel==2.18.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.13.4
+beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
-certifi==2025.8.3
+certifi==2026.1.4
     # via requests
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via requests
-click==8.2.1
+click==8.3.1
     # via uvicorn
 colorama==0.4.6
     # via sphinx-autobuild
-docutils==0.21.2
+docutils==0.22.4
     # via
     #   pydata-sphinx-theme
     #   sphinx
 h11==0.16.0
     # via uvicorn
-idna==2.8
+idna==3.11
     # via
-    #   -c requirements/constraints.txt
     #   anyio
     #   requests
 imagesize==1.4.1
     # via sphinx
 jinja2==3.1.6
-    # via sphinx
-markupsafe==3.0.2
+    # via
+    #   sphinx
+    #   sphinxcontrib-mermaid
+markupsafe==3.0.3
     # via jinja2
-packaging==25.0
+packaging==26.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
@@ -54,19 +55,17 @@ pygments==2.19.2
     #   accessible-pygments
     #   pydata-sphinx-theme
     #   sphinx
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via sphinxcontrib-mermaid
-requests==2.32.4
+requests==2.32.5
     # via sphinx
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
     # via sphinx
-sniffio==1.3.1
-    # via anyio
 snowballstemmer==3.0.1
     # via sphinx
-soupsieve==2.7
+soupsieve==2.8.3
     # via beautifulsoup4
-sphinx==8.2.3
+sphinx==9.0.4
     # via
     #   -r requirements/docs.in
     #   pydata-sphinx-theme
@@ -75,7 +74,7 @@ sphinx==8.2.3
     #   sphinx-copybutton
     #   sphinxcontrib-contentui
     #   sphinxcontrib-mermaid
-sphinx-autobuild==2024.10.3
+sphinx-autobuild==2025.8.25
     # via -r requirements/docs.in
 sphinx-book-theme==1.1.4
     # via -r requirements/docs.in
@@ -91,25 +90,25 @@ sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-mermaid==1.0.0
+sphinxcontrib-mermaid==2.0.0
     # via -r requirements/docs.in
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-starlette==0.47.2
+starlette==0.52.1
     # via sphinx-autobuild
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   anyio
     #   beautifulsoup4
     #   pydata-sphinx-theme
     #   starlette
-urllib3==2.5.0
+urllib3==2.6.3
     # via requests
-uvicorn==0.35.0
+uvicorn==0.40.0
     # via sphinx-autobuild
-watchfiles==1.1.0
+watchfiles==1.1.1
     # via sphinx-autobuild
-websockets==15.0.1
+websockets==16.0
     # via sphinx-autobuild

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,19 +4,21 @@
 #
 #    make upgrade
 #
-build==1.3.0
+build==1.4.0
     # via pip-tools
-click==8.2.1
+click==8.3.1
     # via pip-tools
-packaging==25.0
-    # via build
-pip-tools==7.5.0
+packaging==26.0
+    # via
+    #   build
+    #   wheel
+pip-tools==7.5.2
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.45.1
+wheel==0.46.3
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,13 +4,15 @@
 #
 #    make upgrade
 #
-wheel==0.45.1
+packaging==26.0
+    # via wheel
+wheel==0.46.3
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2
+pip==25.3
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==80.9.0
+setuptools==82.0.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -267,10 +267,6 @@ kombu==5.5.4
     #   celery
 lazy==1.6
     # via -r requirements/test.txt
-loremipsum==1.0.5
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
 lxml[html-clean]==6.0.0
     # via
     #   -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,11 +12,11 @@ appdirs==1.4.4
     # via
     #   -r requirements/test.txt
     #   fs
-arrow==1.3.0
+arrow==1.4.0
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-asgiref==3.9.1
+asgiref==3.11.1
     # via
     #   -r requirements/test.txt
     #   django
@@ -24,11 +24,11 @@ astroid==3.3.11
     # via
     #   pylint
     #   pylint-celery
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
-billiard==4.2.1
+billiard==4.2.4
     # via
     #   -r requirements/test.txt
     #   celery
@@ -36,30 +36,30 @@ binaryornot==0.4.4
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-bleach==6.2.0
+bleach==6.3.0
     # via -r requirements/test.txt
-boto3==1.40.11
+boto3==1.42.46
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
     #   moto
-botocore==1.40.11
+botocore==1.42.46
     # via
     #   -r requirements/test.txt
     #   boto3
     #   moto
     #   s3transfer
-cachetools==6.1.0
+cachetools==7.0.1
     # via
     #   -r requirements/test.txt
     #   tox
-celery==5.5.3
+celery==5.6.2
     # via -r requirements/test.txt
-certifi==2025.8.3
+certifi==2026.1.4
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   -r requirements/test.txt
     #   cryptography
@@ -69,11 +69,11 @@ chardet==5.2.0
     #   -r requirements/test.txt
     #   binaryornot
     #   tox
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.2.1
+click==8.3.1
     # via
     #   -r requirements/test.txt
     #   celery
@@ -112,11 +112,11 @@ cookiecutter==2.6.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.10.4
+coverage[toml]==7.13.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==45.0.6
+cryptography==46.0.5
     # via
     #   -r requirements/test.txt
     #   moto
@@ -126,19 +126,19 @@ ddt==1.0.0
     #   -r requirements/test.txt
 defusedxml==0.7.1
     # via -r requirements/test.txt
-dill==0.4.0
+dill==0.4.1
     # via pylint
 distlib==0.4.0
     # via
     #   -r requirements/test.txt
     #   virtualenv
-django==4.2.23
+django==4.2.28
     # via
     #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   django-crum
     #   django-model-utils
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   edx-django-release-util
@@ -159,10 +159,8 @@ django-model-utils==5.0.0
     # via
     #   -r requirements/test.txt
     #   edx-submissions
-django-simple-history==3.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
+django-simple-history==3.11.0
+    # via -r requirements/test.txt
 django-waffle==5.0.0
     # via
     #   -r requirements/test.txt
@@ -172,7 +170,7 @@ djangorestframework==3.16.1
     # via
     #   -r requirements/test.txt
     #   edx-submissions
-dnspython==2.7.0
+dnspython==2.8.0
     # via
     #   -r requirements/test.txt
     #   pymongo
@@ -184,7 +182,7 @@ edx-django-release-util==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-submissions
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   -r requirements/test.txt
     #   edx-toggles
@@ -199,21 +197,21 @@ edx-opaque-keys[django]==3.0.0
     #   edx-ccx-keys
     #   openedx-events
     #   openedx-filters
-edx-submissions==3.11.1
+edx-submissions==3.12.2
     # via -r requirements/test.txt
 edx-toggles==5.4.1
     # via -r requirements/test.txt
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==37.5.3
+faker==40.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-fastavro==1.12.0
+fastavro==1.12.1
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.19.1
+filelock==3.20.3
     # via
     #   -r requirements/test.txt
     #   tox
@@ -222,29 +220,26 @@ freezegun==0.3.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-fs==2.0.18
+fs==2.4.16
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   fs-s3fs
     #   xblock
-fs-s3fs==0.1.8
+fs-s3fs==1.1.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   xblock-sdk
 html5lib==1.1
     # via -r requirements/test.txt
-idna==2.8
+idna==3.11
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   requests
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==6.0.1
+isort==6.1.0
     # via pylint
 jinja2==3.1.6
     # via
@@ -252,7 +247,7 @@ jinja2==3.1.6
     #   code-annotations
     #   cookiecutter
     #   moto
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -261,20 +256,20 @@ jsonfield==3.2.0
     # via
     #   -r requirements/test.txt
     #   edx-submissions
-kombu==5.5.4
+kombu==5.6.2
     # via
     #   -r requirements/test.txt
     #   celery
 lazy==1.6
     # via -r requirements/test.txt
-lxml[html-clean]==6.0.0
+lxml[html-clean]==6.0.2
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
     #   lxml-html-clean
     #   xblock
     #   xblock-sdk
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.3
     # via
     #   -r requirements/test.txt
     #   lxml
@@ -286,7 +281,7 @@ markdown-it-py==4.0.0
     # via
     #   -r requirements/test.txt
     #   rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -301,36 +296,31 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.2.0
     # via -r requirements/test.txt
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via -r requirements/test.txt
 moto==4.2.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-openedx-events==10.4.0
+openedx-events==10.5.0
     # via -r requirements/test.txt
 openedx-filters==2.1.0
     # via -r requirements/test.txt
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/test.txt
     #   kombu
     #   pyproject-api
     #   pytest
     #   tox
-path==13.1.0
+path==16.16.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-i18n-tools
     #   path-py
 path-py==12.5.0
     # via -r requirements/test.txt
-pbr==7.0.0
-    # via
-    #   -r requirements/test.txt
-    #   stevedore
-platformdirs==4.3.8
+platformdirs==4.5.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -346,17 +336,17 @@ polib==1.2.0
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.52
     # via
     #   -r requirements/test.txt
     #   click-repl
-psutil==7.0.0
+psutil==7.2.2
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
 pycodestyle==2.14.0
     # via -r requirements/quality.in
-pycparser==2.22
+pycparser==3.0
     # via
     #   -r requirements/test.txt
     #   cffi
@@ -365,7 +355,7 @@ pygments==2.19.2
     #   -r requirements/test.txt
     #   pytest
     #   rich
-pylint==3.3.8
+pylint==3.3.9
     # via
     #   edx-lint
     #   pylint-celery
@@ -373,17 +363,19 @@ pylint==3.3.8
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.6.1
-    # via edx-lint
+pylint-django==2.5.5
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-lint
 pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.14.0
+pymongo==4.16.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -391,16 +383,16 @@ pypng==0.20220715.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-pyproject-api==1.9.1
+pyproject-api==1.10.0
     # via
     #   -r requirements/test.txt
     #   tox
-pytest==8.4.1
+pytest==9.0.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.1
+pytest-cov==7.0.0
     # via -r requirements/test.txt
 pytest-django==4.11.1
     # via -r requirements/test.txt
@@ -418,17 +410,14 @@ python-slugify==8.0.4
     #   -r requirements/test.txt
     #   code-annotations
     #   cookiecutter
-python-swiftclient==3.13.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
+python-swiftclient==4.9.0
+    # via -r requirements/test.txt
 pytz==2025.2
     # via
     #   -r requirements/test.txt
     #   edx-submissions
-    #   fs
     #   xblock
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -437,7 +426,7 @@ pyyaml==6.0.2
     #   edx-i18n-tools
     #   responses
     #   xblock
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/test.txt
     #   cookiecutter
@@ -449,15 +438,15 @@ responses==0.25.8
     # via
     #   -r requirements/test.txt
     #   moto
-rich==14.1.0
+rich==14.3.2
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-s3transfer==0.13.1
+s3transfer==0.16.0
     # via
     #   -r requirements/test.txt
     #   boto3
-simplejson==3.20.1
+simplejson==3.20.2
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -473,41 +462,40 @@ six==1.17.0
     #   fs-s3fs
     #   html5lib
     #   python-dateutil
-    #   python-swiftclient
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.4.1
+stevedore==5.6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-testfixtures==9.1.0
+testfixtures==10.0.0
     # via -r requirements/test.txt
 text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.3
+tomlkit==0.14.0
     # via pylint
-tox==4.28.4
+tox==4.34.1
     # via -r requirements/test.txt
-types-python-dateutil==2.9.0.20250809
-    # via
-    #   -r requirements/test.txt
-    #   arrow
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
-tzdata==2025.2
+tzdata==2025.3
     # via
     #   -r requirements/test.txt
-    #   faker
+    #   arrow
     #   kombu
-urllib3==2.5.0
+tzlocal==5.3.1
+    # via
+    #   -r requirements/test.txt
+    #   celery
+urllib3==2.6.3
     # via
     #   -r requirements/test.txt
     #   botocore
@@ -519,15 +507,13 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.34.0
+virtualenv==20.36.1
     # via
     #   -r requirements/test.txt
     #   tox
-voluptuous==0.15.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-wcwidth==0.2.13
+voluptuous==0.16.0
+    # via -r requirements/test.txt
+wcwidth==0.6.0
     # via
     #   -r requirements/test.txt
     #   prompt-toolkit
@@ -546,25 +532,24 @@ webob==1.8.9
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-werkzeug==3.1.3
+werkzeug==3.1.5
     # via
     #   -r requirements/test.txt
     #   moto
-xblock==5.2.0
+xblock==5.3.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
 xblock-sdk==0.13.0
     # via -r requirements/test.txt
-xmltodict==0.14.2
+xmltodict==1.0.2
     # via
     #   -r requirements/test.txt
     #   moto
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==80.9.0
+setuptools==82.0.0
     # via
     #   fs
     #   openedx-events
     #   openedx-filters
-    #   pbr

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -253,10 +253,6 @@ kombu==5.5.4
     #   celery
 lazy==1.6
     # via -r requirements/test.txt
-loremipsum==1.0.5
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
 lxml[html-clean]==6.0.0
     # via
     #   -r requirements/test.txt

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -12,19 +12,19 @@ appdirs==1.4.4
     # via
     #   -r requirements/test.txt
     #   fs
-arrow==1.3.0
+arrow==1.4.0
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-asgiref==3.9.1
+asgiref==3.11.1
     # via
     #   -r requirements/test.txt
     #   django
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
-billiard==4.2.1
+billiard==4.2.4
     # via
     #   -r requirements/test.txt
     #   celery
@@ -32,30 +32,30 @@ binaryornot==0.4.4
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-bleach==6.2.0
+bleach==6.3.0
     # via -r requirements/test.txt
-boto3==1.40.11
+boto3==1.42.46
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
     #   moto
-botocore==1.40.11
+botocore==1.42.46
     # via
     #   -r requirements/test.txt
     #   boto3
     #   moto
     #   s3transfer
-cachetools==6.1.0
+cachetools==7.0.1
     # via
     #   -r requirements/test.txt
     #   tox
-celery==5.5.3
+celery==5.6.2
     # via -r requirements/test.txt
-certifi==2025.8.3
+certifi==2026.1.4
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   -r requirements/test.txt
     #   cryptography
@@ -65,11 +65,11 @@ chardet==5.2.0
     #   -r requirements/test.txt
     #   binaryornot
     #   tox
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.2.1
+click==8.3.1
     # via
     #   -r requirements/test.txt
     #   celery
@@ -103,11 +103,11 @@ cookiecutter==2.6.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.10.4
+coverage[toml]==7.13.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==45.0.6
+cryptography==46.0.5
     # via
     #   -r requirements/test.txt
     #   moto
@@ -122,13 +122,13 @@ distlib==0.4.0
     # via
     #   -r requirements/test.txt
     #   virtualenv
-django==4.2.23
+django==4.2.28
     # via
     #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   django-crum
     #   django-model-utils
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   edx-django-release-util
@@ -149,10 +149,8 @@ django-model-utils==5.0.0
     # via
     #   -r requirements/test.txt
     #   edx-submissions
-django-simple-history==3.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
+django-simple-history==3.11.0
+    # via -r requirements/test.txt
 django-waffle==5.0.0
     # via
     #   -r requirements/test.txt
@@ -162,7 +160,7 @@ djangorestframework==3.16.1
     # via
     #   -r requirements/test.txt
     #   edx-submissions
-dnspython==2.7.0
+dnspython==2.8.0
     # via
     #   -r requirements/test.txt
     #   pymongo
@@ -174,7 +172,7 @@ edx-django-release-util==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-submissions
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   -r requirements/test.txt
     #   edx-toggles
@@ -187,21 +185,21 @@ edx-opaque-keys[django]==3.0.0
     #   edx-ccx-keys
     #   openedx-events
     #   openedx-filters
-edx-submissions==3.11.1
+edx-submissions==3.12.2
     # via -r requirements/test.txt
 edx-toggles==5.4.1
     # via -r requirements/test.txt
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==37.5.3
+faker==40.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-fastavro==1.12.0
+fastavro==1.12.1
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.19.1
+filelock==3.20.3
     # via
     #   -r requirements/test.txt
     #   tox
@@ -210,25 +208,22 @@ freezegun==0.3.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-fs==2.0.18
+fs==2.4.16
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   fs-s3fs
     #   xblock
-fs-s3fs==0.1.8
+fs-s3fs==1.1.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   xblock-sdk
 html5lib==1.1
     # via -r requirements/test.txt
-idna==2.8
+idna==3.11
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   requests
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -238,7 +233,7 @@ jinja2==3.1.6
     #   code-annotations
     #   cookiecutter
     #   moto
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -247,20 +242,20 @@ jsonfield==3.2.0
     # via
     #   -r requirements/test.txt
     #   edx-submissions
-kombu==5.5.4
+kombu==5.6.2
     # via
     #   -r requirements/test.txt
     #   celery
 lazy==1.6
     # via -r requirements/test.txt
-lxml[html-clean]==6.0.0
+lxml[html-clean]==6.0.2
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
     #   lxml-html-clean
     #   xblock
     #   xblock-sdk
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.3
     # via
     #   -r requirements/test.txt
     #   lxml
@@ -272,7 +267,7 @@ markdown-it-py==4.0.0
     # via
     #   -r requirements/test.txt
     #   rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -285,36 +280,31 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.2.0
     # via -r requirements/test.txt
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via -r requirements/test.txt
 moto==4.2.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-openedx-events==10.4.0
+openedx-events==10.5.0
     # via -r requirements/test.txt
 openedx-filters==2.1.0
     # via -r requirements/test.txt
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/test.txt
     #   kombu
     #   pyproject-api
     #   pytest
     #   tox
-path==13.1.0
+path==16.16.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-i18n-tools
     #   path-py
 path-py==12.5.0
     # via -r requirements/test.txt
-pbr==7.0.0
-    # via
-    #   -r requirements/test.txt
-    #   stevedore
-platformdirs==4.3.8
+platformdirs==4.5.1
     # via
     #   -r requirements/test.txt
     #   tox
@@ -329,15 +319,15 @@ polib==1.2.0
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.52
     # via
     #   -r requirements/test.txt
     #   click-repl
-psutil==7.0.0
+psutil==7.2.2
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pycparser==2.22
+pycparser==3.0
     # via
     #   -r requirements/test.txt
     #   cffi
@@ -346,13 +336,13 @@ pygments==2.19.2
     #   -r requirements/test.txt
     #   pytest
     #   rich
-pyinstrument==5.1.1
+pyinstrument==5.1.2
     # via -r requirements/test-acceptance.in
-pymongo==4.14.0
+pymongo==4.16.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -360,17 +350,17 @@ pypng==0.20220715.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-pyproject-api==1.9.1
+pyproject-api==1.10.0
     # via
     #   -r requirements/test.txt
     #   tox
-pytest==8.4.1
+pytest==9.0.2
     # via
     #   -r requirements/test-acceptance.in
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.1
+pytest-cov==7.0.0
     # via -r requirements/test.txt
 pytest-django==4.11.1
     # via -r requirements/test.txt
@@ -388,17 +378,14 @@ python-slugify==8.0.4
     #   -r requirements/test.txt
     #   code-annotations
     #   cookiecutter
-python-swiftclient==3.13.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
+python-swiftclient==4.9.0
+    # via -r requirements/test.txt
 pytz==2025.2
     # via
     #   -r requirements/test.txt
     #   edx-submissions
-    #   fs
     #   xblock
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -407,7 +394,7 @@ pyyaml==6.0.2
     #   edx-i18n-tools
     #   responses
     #   xblock
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/test.txt
     #   cookiecutter
@@ -419,15 +406,15 @@ responses==0.25.8
     # via
     #   -r requirements/test.txt
     #   moto
-rich==14.1.0
+rich==14.3.2
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-s3transfer==0.13.1
+s3transfer==0.16.0
     # via
     #   -r requirements/test.txt
     #   boto3
-simplejson==3.20.1
+simplejson==3.20.2
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -442,39 +429,38 @@ six==1.17.0
     #   fs-s3fs
     #   html5lib
     #   python-dateutil
-    #   python-swiftclient
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.4.1
+stevedore==5.6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-testfixtures==9.1.0
+testfixtures==10.0.0
     # via -r requirements/test.txt
 text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tox==4.28.4
+tox==4.34.1
     # via -r requirements/test.txt
-types-python-dateutil==2.9.0.20250809
-    # via
-    #   -r requirements/test.txt
-    #   arrow
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
-tzdata==2025.2
+tzdata==2025.3
     # via
     #   -r requirements/test.txt
-    #   faker
+    #   arrow
     #   kombu
-urllib3==2.5.0
+tzlocal==5.3.1
+    # via
+    #   -r requirements/test.txt
+    #   celery
+urllib3==2.6.3
     # via
     #   -r requirements/test.txt
     #   botocore
@@ -486,15 +472,13 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.34.0
+virtualenv==20.36.1
     # via
     #   -r requirements/test.txt
     #   tox
-voluptuous==0.15.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-wcwidth==0.2.13
+voluptuous==0.16.0
+    # via -r requirements/test.txt
+wcwidth==0.6.0
     # via
     #   -r requirements/test.txt
     #   prompt-toolkit
@@ -513,17 +497,17 @@ webob==1.8.9
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-werkzeug==3.1.3
+werkzeug==3.1.5
     # via
     #   -r requirements/test.txt
     #   moto
-xblock==5.2.0
+xblock==5.3.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
 xblock-sdk==0.13.0
     # via -r requirements/test.txt
-xmltodict==0.14.2
+xmltodict==1.0.2
     # via
     #   -r requirements/test.txt
     #   moto

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -17,7 +17,3 @@ tox
 more-itertools
 xblock-sdk
 celery                              # Celery task queue framework
-
-# NOTE: This package is super old and unmaintained. It no longer works with the latest
-# version of setuptools (v82). It should be replaced ASAP in order to keep ora2 CI working.
-loremipsum

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -217,10 +217,6 @@ kombu==5.5.4
     # via celery
 lazy==1.6
     # via -r requirements/base.txt
-loremipsum==1.0.5
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
 lxml[html-clean]==6.0.0
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,42 +10,42 @@ appdirs==1.4.4
     # via
     #   -r requirements/base.txt
     #   fs
-arrow==1.3.0
+arrow==1.4.0
     # via cookiecutter
-asgiref==3.9.1
+asgiref==3.11.1
     # via
     #   -r requirements/base.txt
     #   django
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   -r requirements/base.txt
     #   openedx-events
-billiard==4.2.1
+billiard==4.2.4
     # via celery
 binaryornot==0.4.4
     # via cookiecutter
-bleach==6.2.0
+bleach==6.3.0
     # via -r requirements/base.txt
-boto3==1.40.11
+boto3==1.42.46
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
     #   moto
-botocore==1.40.11
+botocore==1.42.46
     # via
     #   -r requirements/base.txt
     #   boto3
     #   moto
     #   s3transfer
-cachetools==6.1.0
+cachetools==7.0.1
     # via tox
-celery==5.5.3
+celery==5.6.2
     # via -r requirements/test.in
-certifi==2025.8.3
+certifi==2026.1.4
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -54,11 +54,11 @@ chardet==5.2.0
     # via
     #   binaryornot
     #   tox
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.2.1
+click==8.3.1
     # via
     #   -r requirements/base.txt
     #   celery
@@ -82,11 +82,11 @@ colorama==0.4.6
     # via tox
 cookiecutter==2.6.0
     # via xblock-sdk
-coverage[toml]==7.10.4
+coverage[toml]==7.13.4
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==45.0.6
+cryptography==46.0.5
     # via moto
 ddt==1.0.0
     # via
@@ -98,10 +98,10 @@ distlib==0.4.0
     # via virtualenv
     # via
     #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-crum
     #   django-model-utils
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   edx-django-release-util
@@ -122,10 +122,8 @@ django-model-utils==5.0.0
     # via
     #   -r requirements/base.txt
     #   edx-submissions
-django-simple-history==3.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+django-simple-history==3.11.0
+    # via -r requirements/base.txt
 django-waffle==5.0.0
     # via
     #   -r requirements/base.txt
@@ -134,7 +132,7 @@ django-waffle==5.0.0
     # via
     #   -r requirements/base.txt
     #   edx-submissions
-dnspython==2.7.0
+dnspython==2.8.0
     # via
     #   -r requirements/base.txt
     #   pymongo
@@ -146,7 +144,7 @@ edx-django-release-util==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-submissions
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   -r requirements/base.txt
     #   edx-toggles
@@ -159,19 +157,19 @@ edx-opaque-keys[django]==3.0.0
     #   edx-ccx-keys
     #   openedx-events
     #   openedx-filters
-edx-submissions==3.11.1
+edx-submissions==3.12.2
     # via -r requirements/base.txt
 edx-toggles==5.4.1
     # via -r requirements/base.txt
 factory-boy==3.3.3
     # via -r requirements/test.in
-faker==37.5.3
+faker==40.4.0
     # via factory-boy
-fastavro==1.12.0
+fastavro==1.12.1
     # via
     #   -r requirements/base.txt
     #   openedx-events
-filelock==3.19.1
+filelock==3.20.3
     # via
     #   tox
     #   virtualenv
@@ -179,24 +177,20 @@ freezegun==0.3.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
-fs==2.0.18
+fs==2.4.16
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   fs-s3fs
     #   xblock
-fs-s3fs==0.1.8
-    # via
-    #   -c requirements/constraints.txt
-    #   xblock-sdk
+fs-s3fs==1.1.1
+    # via xblock-sdk
 html5lib==1.1
     # via -r requirements/base.txt
-idna==2.8
+idna==3.11
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   requests
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via pytest
 jinja2==3.1.6
     # via
@@ -204,7 +198,7 @@ jinja2==3.1.6
     #   code-annotations
     #   cookiecutter
     #   moto
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -213,18 +207,18 @@ jsonfield==3.2.0
     # via
     #   -r requirements/base.txt
     #   edx-submissions
-kombu==5.5.4
+kombu==5.6.2
     # via celery
 lazy==1.6
     # via -r requirements/base.txt
-lxml[html-clean]==6.0.0
+lxml[html-clean]==6.0.2
     # via
     #   -r requirements/base.txt
     #   edx-i18n-tools
     #   lxml-html-clean
     #   xblock
     #   xblock-sdk
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.3
     # via
     #   -r requirements/base.txt
     #   lxml
@@ -234,7 +228,7 @@ mako==1.3.10
     #   xblock
 markdown-it-py==4.0.0
     # via rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -245,35 +239,30 @@ mdurl==0.1.2
     # via markdown-it-py
 mock==5.2.0
     # via -r requirements/test.in
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via -r requirements/test.in
 moto==4.2.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
-openedx-events==10.4.0
+openedx-events==10.5.0
     # via -r requirements/base.txt
 openedx-filters==2.1.0
     # via -r requirements/base.txt
-packaging==25.0
+packaging==26.0
     # via
     #   kombu
     #   pyproject-api
     #   pytest
     #   tox
-path==13.1.0
+path==16.16.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-i18n-tools
     #   path-py
 path-py==12.5.0
     # via -r requirements/base.txt
-pbr==7.0.0
-    # via
-    #   -r requirements/base.txt
-    #   stevedore
-platformdirs==4.3.8
+platformdirs==4.5.1
     # via
     #   tox
     #   virtualenv
@@ -286,13 +275,13 @@ polib==1.2.0
     # via
     #   -r requirements/base.txt
     #   edx-i18n-tools
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.52
     # via click-repl
-psutil==7.0.0
+psutil==7.2.2
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycparser==2.22
+pycparser==3.0
     # via
     #   -r requirements/base.txt
     #   cffi
@@ -300,24 +289,24 @@ pygments==2.19.2
     # via
     #   pytest
     #   rich
-pymongo==4.14.0
+pymongo==4.16.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
 pypng==0.20220715.0
     # via xblock-sdk
-pyproject-api==1.9.1
+pyproject-api==1.10.0
     # via tox
-pytest==8.4.1
+pytest==9.0.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.1
+pytest-cov==7.0.0
     # via -r requirements/test.in
 pytest-django==4.11.1
     # via -r requirements/test.in
@@ -335,17 +324,14 @@ python-slugify==8.0.4
     #   -r requirements/base.txt
     #   code-annotations
     #   cookiecutter
-python-swiftclient==3.13.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+python-swiftclient==4.9.0
+    # via -r requirements/base.txt
 pytz==2025.2
     # via
     #   -r requirements/base.txt
     #   edx-submissions
-    #   fs
     #   xblock
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -354,7 +340,7 @@ pyyaml==6.0.2
     #   edx-i18n-tools
     #   responses
     #   xblock
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   cookiecutter
@@ -364,13 +350,13 @@ requests==2.32.4
     #   xblock-sdk
 responses==0.25.8
     # via moto
-rich==14.1.0
+rich==14.3.2
     # via cookiecutter
-s3transfer==0.13.1
+s3transfer==0.16.0
     # via
     #   -r requirements/base.txt
     #   boto3
-simplejson==3.20.1
+simplejson==3.20.2
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -385,36 +371,35 @@ six==1.17.0
     #   fs-s3fs
     #   html5lib
     #   python-dateutil
-    #   python-swiftclient
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.4.1
+stevedore==5.6.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-testfixtures==9.1.0
+testfixtures==10.0.0
     # via -r requirements/test.in
 text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-tox==4.28.4
+tox==4.34.1
     # via -r requirements/test.in
-types-python-dateutil==2.9.0.20250809
-    # via arrow
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
-tzdata==2025.2
+tzdata==2025.3
     # via
-    #   faker
+    #   arrow
     #   kombu
-urllib3==2.5.0
+tzlocal==5.3.1
+    # via celery
+urllib3==2.6.3
     # via
     #   -r requirements/base.txt
     #   botocore
@@ -425,13 +410,11 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.34.0
+virtualenv==20.36.1
     # via tox
-voluptuous==0.15.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
-wcwidth==0.2.13
+voluptuous==0.16.0
+    # via -r requirements/base.txt
+wcwidth==0.6.0
     # via prompt-toolkit
 web-fragments==3.1.0
     # via
@@ -448,15 +431,15 @@ webob==1.8.9
     #   -r requirements/base.txt
     #   xblock
     #   xblock-sdk
-werkzeug==3.1.3
+werkzeug==3.1.5
     # via moto
-xblock==5.2.0
+xblock==5.3.0
     # via
     #   -r requirements/base.txt
     #   xblock-sdk
 xblock-sdk==0.13.0
     # via -r requirements/test.in
-xmltodict==0.14.2
+xmltodict==1.0.2
     # via moto
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==6.1.0
+cachetools==7.0.1
     # via tox
 chardet==5.2.0
     # via tox
@@ -12,23 +12,23 @@ colorama==0.4.6
     # via tox
 distlib==0.4.0
     # via virtualenv
-filelock==3.19.1
+filelock==3.20.3
     # via
     #   tox
     #   virtualenv
-packaging==25.0
+packaging==26.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.3.8
+platformdirs==4.5.1
     # via
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via tox
-pyproject-api==1.9.1
+pyproject-api==1.10.0
     # via tox
-tox==4.28.4
+tox==4.34.1
     # via -r requirements/tox.in
-virtualenv==20.34.0
+virtualenv==20.36.1
     # via tox


### PR DESCRIPTION
**TL;DR -** Replaces the old, unmaintained loremipsum package with a stub.

**What changed?**

* Removes loremipsum package and constraints from requirements
* Adds a new stub module to replace it in the management command (create_oa_submissions_from_file) and tests.
* Removes unneeded test requirement constraints, and upgrades requirements to get tests passing again.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

Passing build should be sufficient for validation.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality
