### PR TITLE
build: Remove outdated sphinx-contentui package

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,6 @@ release = "latest"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    "sphinxcontrib.contentui",
     "sphinx_copybutton",
     "sphinx.ext.graphviz",
     "sphinxcontrib.mermaid",

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -6,4 +6,3 @@ sphinx-book-theme
 sphinx-copybutton
 sphinx-autobuild
 sphinxcontrib-mermaid
-sphinxcontrib-contentui

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -70,7 +70,6 @@ sphinx==9.1.0
     #   sphinx-autobuild
     #   sphinx-book-theme
     #   sphinx-copybutton
-    #   sphinxcontrib-contentui
     #   sphinxcontrib-mermaid
 sphinx-autobuild==2025.8.25
     # via -r requirements/docs.in
@@ -80,8 +79,6 @@ sphinx-copybutton==0.5.2
     # via -r requirements/docs.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-contentui==0.2.5
-    # via -r requirements/docs.in
 sphinxcontrib-devhelp==2.0.0
     # via sphinx
 sphinxcontrib-htmlhelp==2.1.0


### PR DESCRIPTION
See openedx/docs.openedx.org#1417

This is an outdated package that was included in the docs cookie cutter. It can cause build errors and doesn't seem to be used.
