### PR TITLE
fix: remove default=None from ManyToMany serializer fields for DRF 3.17+ compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ compile-requirements: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.tx
 	pip-compile ${COMPILE_OPTS} -o requirements/docs.txt requirements/docs.in
 	# Delete django pin from test requirements to avoid tox version collision
 	sed -i.tmp '/^[d|D]jango==/d' requirements/test.txt
-	sed -i.tmp '/^djangorestframework==/d' requirements/test.txt
 	# Delete extra metadata that causes build to fail
 	sed -i.tmp '/^--index-url/d' requirements/*.txt
 	sed -i.tmp '/^--extra-index-url/d' requirements/*.txt

--- a/openassessment/assessment/serializers/peer.py
+++ b/openassessment/assessment/serializers/peer.py
@@ -25,8 +25,8 @@ class AssessmentFeedbackSerializer(serializers.ModelSerializer):
     """
     Serialize feedback in response to an assessment.
     """
-    assessments = AssessmentSerializer(many=True, default=None, required=False)
-    options = AssessmentFeedbackOptionSerializer(many=True, default=None, required=False)
+    assessments = AssessmentSerializer(many=True, required=False)
+    options = AssessmentFeedbackOptionSerializer(many=True, required=False)
 
     class Meta:
         model = AssessmentFeedback

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,13 +8,13 @@ appdirs==1.4.4
     # via fs
 asgiref==3.11.1
     # via django
-attrs==25.4.0
+attrs==26.1.0
     # via openedx-events
 bleach==6.3.0
     # via -r requirements/base.in
-boto3==1.42.62
+boto3==1.42.86
     # via -r requirements/base.in
-botocore==1.42.62
+botocore==1.42.86
     # via
     #   boto3
     #   s3transfer
@@ -22,17 +22,17 @@ certifi==2026.2.25
     # via requests
 cffi==2.0.0
     # via pynacl
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.3.2
     # via
     #   code-annotations
     #   edx-django-utils
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via edx-toggles
 defusedxml==0.7.1
     # via -r requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -63,7 +63,7 @@ django-waffle==5.0.0
     # via
     #   edx-django-utils
     #   edx-toggles
-djangorestframework==3.16.1
+djangorestframework==3.17.1
     # via
     #   -r requirements/base.in
     #   edx-submissions
@@ -78,17 +78,17 @@ edx-django-utils==8.0.1
     #   -r requirements/base.in
     #   edx-toggles
     #   openedx-events
-edx-i18n-tools==1.9.0
+edx-i18n-tools==2.0.0
     # via -r requirements/base.in
-edx-opaque-keys[django]==3.1.0
+edx-opaque-keys[django]==4.0.0
     # via
     #   -r requirements/base.in
     #   edx-ccx-keys
     #   openedx-events
     #   openedx-filters
-edx-submissions==3.12.2
+edx-submissions==4.0.0
     # via -r requirements/base.in
-edx-toggles==5.4.1
+edx-toggles==6.0.0
     # via -r requirements/base.in
 fastavro==1.12.1
     # via openedx-events
@@ -110,7 +110,7 @@ jsonfield==3.2.0
     #   edx-submissions
 lazy==1.6
     # via -r requirements/base.in
-lxml[html-clean]==6.0.2
+lxml[html-clean]==6.0.3
     # via
     #   -r requirements/base.in
     #   edx-i18n-tools
@@ -125,9 +125,9 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   xblock
-openedx-events==10.5.0
+openedx-events==11.1.1
     # via -r requirements/base.in
-openedx-filters==2.1.0
+openedx-filters==3.1.0
     # via -r requirements/base.in
 path==16.16.0
     # via
@@ -165,7 +165,7 @@ pyyaml==6.0.3
     #   edx-django-release-util
     #   edx-i18n-tools
     #   xblock
-requests==2.32.5
+requests==2.33.1
     # via python-swiftclient
 s3transfer==0.16.0
     # via boto3
@@ -195,7 +195,7 @@ urllib3==2.6.3
     #   requests
 voluptuous==0.16.0
     # via -r requirements/base.in
-web-fragments==3.1.0
+web-fragments==4.0.0
     # via xblock
 webencodings==0.5.1
     # via
@@ -203,11 +203,11 @@ webencodings==0.5.1
     #   html5lib
 webob==1.8.9
     # via xblock
-xblock==5.3.0
+xblock==6.0.0
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==82.0.0
+setuptools==82.0.1
     # via
     #   fs
     #   openedx-events

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,21 +6,21 @@
 #
 annotated-doc==0.0.4
     # via typer
-cachetools==7.0.3
+cachetools==7.0.5
     # via
     #   -r requirements/tox.txt
     #   tox
 certifi==2026.2.25
     # via requests
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.3.2
     # via typer
 colorama==0.4.6
     # via
     #   -r requirements/tox.txt
     #   tox
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via coveralls
 coveralls==4.1.0
     # via -r requirements/ci.in
@@ -28,7 +28,7 @@ distlib==0.4.0
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   -r requirements/tox.txt
     #   python-discovery
@@ -45,7 +45,7 @@ packaging==26.0
     #   -r requirements/tox.txt
     #   pyproject-api
     #   tox
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   -r requirements/tox.txt
     #   python-discovery
@@ -55,17 +55,18 @@ pluggy==1.6.0
     # via
     #   -r requirements/tox.txt
     #   tox
-pygments==2.19.2
+pygments==2.20.0
     # via rich
 pyproject-api==1.10.0
     # via
     #   -r requirements/tox.txt
     #   tox
-python-discovery==1.1.0
+python-discovery==1.2.2
     # via
     #   -r requirements/tox.txt
+    #   tox
     #   virtualenv
-requests==2.32.5
+requests==2.33.1
     # via coveralls
 rich==14.3.3
     # via typer
@@ -75,17 +76,17 @@ tomli-w==1.2.0
     # via
     #   -r requirements/tox.txt
     #   tox
-tox==4.49.0
+tox==4.52.1
     # via -r requirements/tox.txt
 typer==0.24.1
     # via coveralls
 urllib3==2.6.3
     # via requests
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via
     #   -r requirements/tox.txt
     #   tox
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==82.0.0
+setuptools==82.0.1
     # via -r requirements/ci.in

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,7 +8,7 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 alabaster==1.0.0
     # via sphinx
-anyio==4.12.1
+anyio==4.13.0
     # via
     #   starlette
     #   watchfiles
@@ -20,9 +20,9 @@ beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
 certifi==2026.2.25
     # via requests
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.3.2
     # via uvicorn
 colorama==0.4.6
     # via sphinx-autobuild
@@ -45,19 +45,17 @@ jinja2==3.1.6
 markupsafe==3.0.3
     # via jinja2
 packaging==26.0
-    # via
-    #   pydata-sphinx-theme
-    #   sphinx
-pydata-sphinx-theme==0.15.4
+    # via sphinx
+pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   accessible-pygments
     #   pydata-sphinx-theme
     #   sphinx
 pyyaml==6.0.3
     # via sphinxcontrib-mermaid
-requests==2.32.5
+requests==2.33.1
     # via sphinx
 roman-numerals==4.1.0
     # via sphinx
@@ -76,7 +74,7 @@ sphinx==9.1.0
     #   sphinxcontrib-mermaid
 sphinx-autobuild==2025.8.25
     # via -r requirements/docs.in
-sphinx-book-theme==1.1.4
+sphinx-book-theme==1.2.0
     # via -r requirements/docs.in
 sphinx-copybutton==0.5.2
     # via -r requirements/docs.in
@@ -96,7 +94,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-starlette==0.52.1
+starlette==1.0.0
     # via sphinx-autobuild
 typing-extensions==4.15.0
     # via
@@ -106,7 +104,7 @@ typing-extensions==4.15.0
     #   starlette
 urllib3==2.6.3
     # via requests
-uvicorn==0.41.0
+uvicorn==0.44.0
     # via sphinx-autobuild
 watchfiles==1.1.1
     # via sphinx-autobuild

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-build==1.4.0
+build==1.4.2
     # via pip-tools
-click==8.3.1
+click==8.3.2
     # via pip-tools
 packaging==26.0
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,5 +12,5 @@ wheel==0.46.3
 # The following packages are considered to be unsafe in a requirements file:
 pip==26.0.1
     # via -r requirements/pip.in
-setuptools==82.0.0
+setuptools==82.0.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -24,7 +24,7 @@ astroid==3.3.11
     # via
     #   pylint
     #   pylint-celery
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
@@ -32,28 +32,28 @@ billiard==4.2.4
     # via
     #   -r requirements/test.txt
     #   celery
-binaryornot==0.4.4
+binaryornot==0.6.0
     # via
     #   -r requirements/test.txt
     #   cookiecutter
 bleach==6.3.0
     # via -r requirements/test.txt
-boto3==1.42.62
+boto3==1.42.86
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
     #   moto
-botocore==1.42.62
+botocore==1.42.86
     # via
     #   -r requirements/test.txt
     #   boto3
     #   moto
     #   s3transfer
-cachetools==7.0.3
+cachetools==7.0.5
     # via
     #   -r requirements/test.txt
     #   tox
-celery==5.6.2
+celery==5.6.3
     # via -r requirements/test.txt
 certifi==2026.2.25
     # via
@@ -64,15 +64,11 @@ cffi==2.0.0
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-chardet==7.0.1
-    # via
-    #   -r requirements/test.txt
-    #   binaryornot
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.3.1
+click==8.3.2
     # via
     #   -r requirements/test.txt
     #   celery
@@ -98,7 +94,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/test.txt
     #   celery
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -111,11 +107,11 @@ cookiecutter==2.7.1
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==46.0.5
+cryptography==46.0.7
     # via
     #   -r requirements/test.txt
     #   moto
@@ -131,7 +127,7 @@ distlib==0.4.0
     # via
     #   -r requirements/test.txt
     #   virtualenv
-django==5.2.12
+django==5.2.13
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
@@ -165,7 +161,7 @@ django-waffle==5.0.0
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-toggles
-djangorestframework==3.16.1
+djangorestframework==3.17.1
     # via
     #   -r requirements/test.txt
     #   edx-submissions
@@ -186,23 +182,23 @@ edx-django-utils==8.0.1
     #   -r requirements/test.txt
     #   edx-toggles
     #   openedx-events
-edx-i18n-tools==1.9.0
+edx-i18n-tools==2.0.0
     # via -r requirements/test.txt
-edx-lint==5.6.0
+edx-lint==6.0.0
     # via -r requirements/quality.in
-edx-opaque-keys[django]==3.1.0
+edx-opaque-keys[django]==4.0.0
     # via
     #   -r requirements/test.txt
     #   edx-ccx-keys
     #   openedx-events
     #   openedx-filters
-edx-submissions==3.12.2
+edx-submissions==4.0.0
     # via -r requirements/test.txt
-edx-toggles==5.4.1
+edx-toggles==6.0.0
     # via -r requirements/test.txt
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==40.8.0
+faker==40.13.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -210,7 +206,7 @@ fastavro==1.12.1
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   -r requirements/test.txt
     #   python-discovery
@@ -262,7 +258,7 @@ kombu==5.6.2
     #   celery
 lazy==1.6
     # via -r requirements/test.txt
-lxml[html-clean]==6.0.2
+lxml[html-clean]==6.0.3
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
@@ -296,15 +292,15 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.2.0
     # via -r requirements/test.txt
-more-itertools==10.8.0
+more-itertools==11.0.2
     # via -r requirements/test.txt
 moto==4.2.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-openedx-events==10.5.0
+openedx-events==11.1.1
     # via -r requirements/test.txt
-openedx-filters==2.1.0
+openedx-filters==3.1.0
     # via -r requirements/test.txt
 packaging==26.0
     # via
@@ -320,7 +316,7 @@ path==16.16.0
     #   path-py
 path-py==12.5.0
     # via -r requirements/test.txt
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -351,7 +347,7 @@ pycparser==3.0
     # via
     #   -r requirements/test.txt
     #   cffi
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -388,12 +384,12 @@ pyproject-api==1.10.0
     # via
     #   -r requirements/test.txt
     #   tox
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.txt
 pytest-django==4.12.0
     # via -r requirements/test.txt
@@ -406,9 +402,10 @@ python-dateutil==2.9.0.post0
     #   freezegun
     #   moto
     #   xblock
-python-discovery==1.1.0
+python-discovery==1.2.2
     # via
     #   -r requirements/test.txt
+    #   tox
     #   virtualenv
 python-slugify==8.0.4
     # via
@@ -431,7 +428,7 @@ pyyaml==6.0.3
     #   edx-i18n-tools
     #   responses
     #   xblock
-requests==2.32.5
+requests==2.33.1
     # via
     #   -r requirements/test.txt
     #   cookiecutter
@@ -477,7 +474,7 @@ stevedore==5.7.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-testfixtures==10.0.0
+testfixtures==11.0.0
     # via -r requirements/test.txt
 text-unidecode==1.3
     # via
@@ -489,13 +486,13 @@ tomli-w==1.2.0
     #   tox
 tomlkit==0.14.0
     # via pylint
-tox==4.49.0
+tox==4.52.1
     # via -r requirements/test.txt
 typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
-tzdata==2025.3
+tzdata==2026.1
     # via
     #   -r requirements/test.txt
     #   arrow
@@ -516,7 +513,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -526,7 +523,7 @@ wcwidth==0.6.0
     # via
     #   -r requirements/test.txt
     #   prompt-toolkit
-web-fragments==3.1.0
+web-fragments==4.0.0
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -541,15 +538,15 @@ webob==1.8.9
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-werkzeug==3.1.6
+werkzeug==3.1.8
     # via
     #   -r requirements/test.txt
     #   moto
-xblock==5.3.0
+xblock==6.0.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-xblock-sdk==0.13.0
+xblock-sdk==0.14.0
     # via -r requirements/test.txt
 xmltodict==1.0.4
     # via
@@ -557,7 +554,7 @@ xmltodict==1.0.4
     #   moto
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==82.0.0
+setuptools==82.0.1
     # via
     #   fs
     #   openedx-events

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -20,7 +20,7 @@ asgiref==3.11.1
     # via
     #   -r requirements/test.txt
     #   django
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
@@ -28,28 +28,28 @@ billiard==4.2.4
     # via
     #   -r requirements/test.txt
     #   celery
-binaryornot==0.4.4
+binaryornot==0.6.0
     # via
     #   -r requirements/test.txt
     #   cookiecutter
 bleach==6.3.0
     # via -r requirements/test.txt
-boto3==1.42.62
+boto3==1.42.86
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
     #   moto
-botocore==1.42.62
+botocore==1.42.86
     # via
     #   -r requirements/test.txt
     #   boto3
     #   moto
     #   s3transfer
-cachetools==7.0.3
+cachetools==7.0.5
     # via
     #   -r requirements/test.txt
     #   tox
-celery==5.6.2
+celery==5.6.3
     # via -r requirements/test.txt
 certifi==2026.2.25
     # via
@@ -60,15 +60,11 @@ cffi==2.0.0
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-chardet==7.0.1
-    # via
-    #   -r requirements/test.txt
-    #   binaryornot
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.3.1
+click==8.3.2
     # via
     #   -r requirements/test.txt
     #   celery
@@ -90,7 +86,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/test.txt
     #   celery
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via
     #   -r requirements/test.txt
     #   edx-toggles
@@ -102,11 +98,11 @@ cookiecutter==2.7.1
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==46.0.5
+cryptography==46.0.7
     # via
     #   -r requirements/test.txt
     #   moto
@@ -121,7 +117,7 @@ distlib==0.4.0
     # via
     #   -r requirements/test.txt
     #   virtualenv
-django==5.2.12
+django==5.2.13
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
@@ -155,7 +151,7 @@ django-waffle==5.0.0
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-toggles
-djangorestframework==3.16.1
+djangorestframework==3.17.1
     # via
     #   -r requirements/test.txt
     #   edx-submissions
@@ -176,21 +172,21 @@ edx-django-utils==8.0.1
     #   -r requirements/test.txt
     #   edx-toggles
     #   openedx-events
-edx-i18n-tools==1.9.0
+edx-i18n-tools==2.0.0
     # via -r requirements/test.txt
-edx-opaque-keys[django]==3.1.0
+edx-opaque-keys[django]==4.0.0
     # via
     #   -r requirements/test.txt
     #   edx-ccx-keys
     #   openedx-events
     #   openedx-filters
-edx-submissions==3.12.2
+edx-submissions==4.0.0
     # via -r requirements/test.txt
-edx-toggles==5.4.1
+edx-toggles==6.0.0
     # via -r requirements/test.txt
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==40.8.0
+faker==40.13.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -198,7 +194,7 @@ fastavro==1.12.1
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   -r requirements/test.txt
     #   python-discovery
@@ -248,7 +244,7 @@ kombu==5.6.2
     #   celery
 lazy==1.6
     # via -r requirements/test.txt
-lxml[html-clean]==6.0.2
+lxml[html-clean]==6.0.3
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
@@ -280,15 +276,15 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.2.0
     # via -r requirements/test.txt
-more-itertools==10.8.0
+more-itertools==11.0.2
     # via -r requirements/test.txt
 moto==4.2.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-openedx-events==10.5.0
+openedx-events==11.1.1
     # via -r requirements/test.txt
-openedx-filters==2.1.0
+openedx-filters==3.1.0
     # via -r requirements/test.txt
 packaging==26.0
     # via
@@ -304,7 +300,7 @@ path==16.16.0
     #   path-py
 path-py==12.5.0
     # via -r requirements/test.txt
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   -r requirements/test.txt
     #   python-discovery
@@ -332,7 +328,7 @@ pycparser==3.0
     # via
     #   -r requirements/test.txt
     #   cffi
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -355,13 +351,13 @@ pyproject-api==1.10.0
     # via
     #   -r requirements/test.txt
     #   tox
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements/test-acceptance.in
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.txt
 pytest-django==4.12.0
     # via -r requirements/test.txt
@@ -374,9 +370,10 @@ python-dateutil==2.9.0.post0
     #   freezegun
     #   moto
     #   xblock
-python-discovery==1.1.0
+python-discovery==1.2.2
     # via
     #   -r requirements/test.txt
+    #   tox
     #   virtualenv
 python-slugify==8.0.4
     # via
@@ -399,7 +396,7 @@ pyyaml==6.0.3
     #   edx-i18n-tools
     #   responses
     #   xblock
-requests==2.32.5
+requests==2.33.1
     # via
     #   -r requirements/test.txt
     #   cookiecutter
@@ -444,7 +441,7 @@ stevedore==5.7.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-testfixtures==10.0.0
+testfixtures==11.0.0
     # via -r requirements/test.txt
 text-unidecode==1.3
     # via
@@ -454,13 +451,13 @@ tomli-w==1.2.0
     # via
     #   -r requirements/test.txt
     #   tox
-tox==4.49.0
+tox==4.52.1
     # via -r requirements/test.txt
 typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
-tzdata==2025.3
+tzdata==2026.1
     # via
     #   -r requirements/test.txt
     #   arrow
@@ -481,7 +478,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -491,7 +488,7 @@ wcwidth==0.6.0
     # via
     #   -r requirements/test.txt
     #   prompt-toolkit
-web-fragments==3.1.0
+web-fragments==4.0.0
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -506,15 +503,15 @@ webob==1.8.9
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-werkzeug==3.1.6
+werkzeug==3.1.8
     # via
     #   -r requirements/test.txt
     #   moto
-xblock==5.3.0
+xblock==6.0.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-xblock-sdk==0.13.0
+xblock-sdk==0.14.0
     # via -r requirements/test.txt
 xmltodict==1.0.4
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,30 +16,30 @@ asgiref==3.11.1
     # via
     #   -r requirements/base.txt
     #   django
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -r requirements/base.txt
     #   openedx-events
 billiard==4.2.4
     # via celery
-binaryornot==0.4.4
+binaryornot==0.6.0
     # via cookiecutter
 bleach==6.3.0
     # via -r requirements/base.txt
-boto3==1.42.62
+boto3==1.42.86
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
     #   moto
-botocore==1.42.62
+botocore==1.42.86
     # via
     #   -r requirements/base.txt
     #   boto3
     #   moto
     #   s3transfer
-cachetools==7.0.3
+cachetools==7.0.5
     # via tox
-celery==5.6.2
+celery==5.6.3
     # via -r requirements/test.in
 certifi==2026.2.25
     # via
@@ -50,13 +50,11 @@ cffi==2.0.0
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-chardet==7.0.1
-    # via binaryornot
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.3.1
+click==8.3.2
     # via
     #   -r requirements/base.txt
     #   celery
@@ -72,7 +70,7 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via
     #   -r requirements/base.txt
     #   edx-toggles
@@ -80,11 +78,11 @@ colorama==0.4.6
     # via tox
 cookiecutter==2.7.1
     # via xblock-sdk
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==46.0.5
+cryptography==46.0.7
     # via moto
 ddt==1.0.0
     # via
@@ -127,6 +125,7 @@ django-waffle==5.0.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-toggles
+djangorestframework==3.17.1
     # via
     #   -r requirements/base.txt
     #   edx-submissions
@@ -147,27 +146,27 @@ edx-django-utils==8.0.1
     #   -r requirements/base.txt
     #   edx-toggles
     #   openedx-events
-edx-i18n-tools==1.9.0
+edx-i18n-tools==2.0.0
     # via -r requirements/base.txt
-edx-opaque-keys[django]==3.1.0
+edx-opaque-keys[django]==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
     #   openedx-events
     #   openedx-filters
-edx-submissions==3.12.2
+edx-submissions==4.0.0
     # via -r requirements/base.txt
-edx-toggles==5.4.1
+edx-toggles==6.0.0
     # via -r requirements/base.txt
 factory-boy==3.3.3
     # via -r requirements/test.in
-faker==40.8.0
+faker==40.13.0
     # via factory-boy
 fastavro==1.12.1
     # via
     #   -r requirements/base.txt
     #   openedx-events
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   python-discovery
     #   tox
@@ -210,7 +209,7 @@ kombu==5.6.2
     # via celery
 lazy==1.6
     # via -r requirements/base.txt
-lxml[html-clean]==6.0.2
+lxml[html-clean]==6.0.3
     # via
     #   -r requirements/base.txt
     #   edx-i18n-tools
@@ -238,15 +237,15 @@ mdurl==0.1.2
     # via markdown-it-py
 mock==5.2.0
     # via -r requirements/test.in
-more-itertools==10.8.0
+more-itertools==11.0.2
     # via -r requirements/test.in
 moto==4.2.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
-openedx-events==10.5.0
+openedx-events==11.1.1
     # via -r requirements/base.txt
-openedx-filters==2.1.0
+openedx-filters==3.1.0
     # via -r requirements/base.txt
 packaging==26.0
     # via
@@ -261,7 +260,7 @@ path==16.16.0
     #   path-py
 path-py==12.5.0
     # via -r requirements/base.txt
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   tox
@@ -285,7 +284,7 @@ pycparser==3.0
     # via
     #   -r requirements/base.txt
     #   cffi
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   pytest
     #   rich
@@ -301,12 +300,12 @@ pypng==0.20220715.0
     # via xblock-sdk
 pyproject-api==1.10.0
     # via tox
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements/test.in
     #   pytest-cov
     #   pytest-django
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.in
 pytest-django==4.12.0
     # via -r requirements/test.in
@@ -319,8 +318,10 @@ python-dateutil==2.9.0.post0
     #   freezegun
     #   moto
     #   xblock
-python-discovery==1.1.0
-    # via virtualenv
+python-discovery==1.2.2
+    # via
+    #   tox
+    #   virtualenv
 python-slugify==8.0.4
     # via
     #   -r requirements/base.txt
@@ -342,7 +343,7 @@ pyyaml==6.0.3
     #   edx-i18n-tools
     #   responses
     #   xblock
-requests==2.32.5
+requests==2.33.1
     # via
     #   -r requirements/base.txt
     #   cookiecutter
@@ -383,7 +384,7 @@ stevedore==5.7.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-testfixtures==10.0.0
+testfixtures==11.0.0
     # via -r requirements/test.in
 text-unidecode==1.3
     # via
@@ -391,13 +392,13 @@ text-unidecode==1.3
     #   python-slugify
 tomli-w==1.2.0
     # via tox
-tox==4.49.0
+tox==4.52.1
     # via -r requirements/test.in
 typing-extensions==4.15.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
-tzdata==2025.3
+tzdata==2026.1
     # via
     #   arrow
     #   kombu
@@ -414,13 +415,13 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via tox
 voluptuous==0.16.0
     # via -r requirements/base.txt
 wcwidth==0.6.0
     # via prompt-toolkit
-web-fragments==3.1.0
+web-fragments==4.0.0
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -435,13 +436,13 @@ webob==1.8.9
     #   -r requirements/base.txt
     #   xblock
     #   xblock-sdk
-werkzeug==3.1.6
+werkzeug==3.1.8
     # via moto
-xblock==5.3.0
+xblock==6.0.0
     # via
     #   -r requirements/base.txt
     #   xblock-sdk
-xblock-sdk==0.13.0
+xblock-sdk==0.14.0
     # via -r requirements/test.in
 xmltodict==1.0.4
     # via moto

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-cachetools==7.0.3
+cachetools==7.0.5
     # via tox
 colorama==0.4.6
     # via tox
 distlib==0.4.0
     # via virtualenv
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   python-discovery
     #   tox
@@ -19,7 +19,7 @@ packaging==26.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   tox
@@ -28,11 +28,13 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-python-discovery==1.1.0
-    # via virtualenv
+python-discovery==1.2.2
+    # via
+    #   tox
+    #   virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.49.0
+tox==4.52.1
     # via -r requirements/tox.in
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via tox


### PR DESCRIPTION
Django REST Framework 3.17+ introduced stricter validation that explicitly
rejects `default=None` on fields with `many=True`. This is a breaking change
from DRF 3.15.x behavior.

The issue manifests as:
ValueError: The field 'assessments' on serializer 'AssessmentFeedbackSerializer'
is a ManyToMany field and cannot have a default value of None.

This fix removes the redundant `default=None` parameters from the
AssessmentFeedbackSerializer's ManyToMany fields. The behavior remains
unchanged since `required=False` already handles missing data appropriately,
defaulting to empty lists for many=True fields.

Fixes test failure: test_create_feedback_on_an_assessment in Python 3.12
environments with DRF 3.17.1

See: https://github.com/encode/django-rest-framework/issues/8698

---
The second commit fixes the underlying issue that let this failure slip through.  We weren't pinning DRF in the test.txt file and so it was getting the latest valid version for the python version being tested.  This was fine previously but a new version got released that broke the build just after we moved to python 3.12.   When we made the last change to the PR the latest version of DRF didn't have the stricter validation, so tests passed. But by the time we merged it, the latest version had the stricter rule and so tests failed when it landed on master because master was testing with a different DRF version than our PR.
